### PR TITLE
Improve test coverage

### DIFF
--- a/Sources/SafeDICore/Extensions/PatternBindingSyntaxExtensions.swift
+++ b/Sources/SafeDICore/Extensions/PatternBindingSyntaxExtensions.swift
@@ -21,10 +21,7 @@
 import SwiftSyntax
 
 extension PatternBindingSyntax {
-    var isOptionalAndUninitialized: Bool {
-        guard let typeAnnotation else {
-            return initializer == nil
-        }
-        return typeAnnotation.type.typeDescription.isOptional
+    var isOptionalOrInitialized: Bool {
+        typeAnnotation?.type.typeDescription.isOptional ?? (initializer != nil)
     }
 }

--- a/Sources/SafeDICore/Generators/DependencyTreeGenerator.swift
+++ b/Sources/SafeDICore/Generators/DependencyTreeGenerator.swift
@@ -63,7 +63,7 @@ public final class DependencyTreeGenerator {
         // Any modifications made to this file will be overwritten on subsequent builds.
         // Please refrain from editing this file directly.
         \(importsWhitespace)\(imports)\(importsWhitespace)
-        \(dependencyTree.isEmpty ? "// No root @\(InstantiableVisitor.macroName)-decorated types found." : dependencyTree)
+        \(dependencyTree.isEmpty ? "// No root @\(InstantiableVisitor.macroName)-decorated types found, or root types already had a `public init()` method." : dependencyTree)
         """
     }
 

--- a/Sources/SafeDICore/Models/TypeDescription.swift
+++ b/Sources/SafeDICore/Models/TypeDescription.swift
@@ -109,7 +109,7 @@ public enum TypeDescription: Codable, Hashable, Comparable, Sendable {
                 // Reference manual: https://docs.swift.org/swift-book/ReferenceManual/Types.html#grammar_type
                 return "\(specifier) \(attributesFromList(attributes)) \(type.asSource)"
             case (.none, .none):
-                // This case represents an error that has previously caused an assertion.
+                // This case represents an error.
                 return type.asSource
             }
         case let .array(element):
@@ -258,13 +258,7 @@ extension TypeSyntax {
 
         } else if let typeIdentifier = AttributedTypeSyntax(self) {
             let attributes: [String] = typeIdentifier.attributes.compactMap {
-                guard
-                    let attributeName = AttributeSyntax($0)?.attributeName,
-                    let attributeIdentifier = IdentifierTypeSyntax(attributeName)
-                else {
-                    return nil
-                }
-                return attributeIdentifier.name.text
+                AttributeSyntax($0)?.attributeName.as(IdentifierTypeSyntax.self)?.name.text
             }
             return .attributed(
                 typeIdentifier.baseType.typeDescription,
@@ -448,9 +442,7 @@ public struct UnorderedComparingCollection<Element: Codable & Hashable & Sendabl
 
     // MARK: Collection
 
-    public func makeIterator() -> IndexingIterator<Array<Element>> {
-        array.makeIterator()
-    }
+    public func makeIterator() -> IndexingIterator<Array<Element>> { array.makeIterator() }
     public var startIndex: Int { array.startIndex }
     public var endIndex: Int { array.endIndex }
     public func index(after i: Int) -> Int {

--- a/Sources/SafeDICore/Visitors/InstantiableVisitor.swift
+++ b/Sources/SafeDICore/Visitors/InstantiableVisitor.swift
@@ -57,9 +57,8 @@ public final class InstantiableVisitor: SyntaxVisitor {
             let patterns = node
                 .bindings
                 .filter {
-                    $0.initializer == nil
-                    && $0.accessorBlock == nil
-                    && !$0.isOptionalAndUninitialized
+                    $0.accessorBlock == nil
+                    && !$0.isOptionalOrInitialized
                 }
                 .map(\.pattern)
             uninitializedNonOptionalPropertyNames += patterns

--- a/Sources/SafeDITool/SafeDITool.swift
+++ b/Sources/SafeDITool/SafeDITool.swift
@@ -55,17 +55,14 @@ struct SafeDITool: AsyncParsableCommand {
             parsedModule(loadSwiftFiles())
         )
 
-        async let generatedCode: String? = if dependencyTreeOutput != nil {
-            DependencyTreeGenerator(
-                importStatements: dependentModuleInfo.flatMap(\.imports) + additionalImportedModules.map { ImportStatement(moduleName: $0) } + module.imports,
-                typeDescriptionToFulfillingInstantiableMap: try resolveSafeDIFulfilledTypes(
-                    instantiables: dependentModuleInfo.flatMap(\.instantiables) + module.instantiables
-                )
+        async let generatedCode: String? = dependencyTreeOutput != nil
+        ? DependencyTreeGenerator(
+            importStatements: dependentModuleInfo.flatMap(\.imports) + additionalImportedModules.map { ImportStatement(moduleName: $0) } + module.imports,
+            typeDescriptionToFulfillingInstantiableMap: try resolveSafeDIFulfilledTypes(
+                instantiables: dependentModuleInfo.flatMap(\.instantiables) + module.instantiables
             )
-            .generate()
-        } else {
-            nil
-        }
+        ).generate()
+        : nil
 
         if !module.nestedInstantiableDecoratedTypeDescriptions.isEmpty {
             throw CollectInstantiablesError

--- a/Tests/SafeDICoreTests/TypeDescriptionTests.swift
+++ b/Tests/SafeDICoreTests/TypeDescriptionTests.swift
@@ -573,6 +573,21 @@ final class TypeDescriptionTests: XCTestCase {
         )
     }
 
+    func test_UnorderedComparingCollection_makeIterator_iteratesInOrder() {
+        for (index, value) in UnorderedComparingCollection([1, 2, 3]).enumerated() {
+            switch index {
+            case 0:
+                XCTAssertEqual(value, 1)
+            case 1:
+                XCTAssertEqual(value, 2)
+            case 2:
+                XCTAssertEqual(value, 3)
+            case _:
+                XCTFail("Unexpected index \(index)")
+            }
+        }
+    }
+
     // MARK: - Visitors
 
     private final class TypeIdentifierSyntaxVisitor: SyntaxVisitor {

--- a/Tests/SafeDICoreTests/TypeDescriptionTests.swift
+++ b/Tests/SafeDICoreTests/TypeDescriptionTests.swift
@@ -542,9 +542,9 @@ final class TypeDescriptionTests: XCTestCase {
         XCTAssertEqual(typeDescription.asSource, "() async throws -> ()")
     }
 
-    func test_asSource_whenDescribingAnUnknownCase_returnsTheProvidedStringWithWhitespaceStripped() {
-        let typeDescription = TypeSyntax(stringLiteral: " SomeTypeThatIsFormattedOddly    ").typeDescription
-        XCTAssertEqual(typeDescription.asSource, "SomeTypeThatIsFormattedOddly")
+    func test_asSource_whenDescribingAnUnknownCase_returnsTheProvidedStringWithTrailingWhitespaceStripped() {
+        let typeDescription = TypeSyntax(stringLiteral: "<[]>    ").typeDescription
+        XCTAssertEqual(typeDescription.asSource, "<[]>")
     }
 
     func test_equality_isTrueWhenComparingLexigraphicallyEquivalentCompositions() {

--- a/Tests/SafeDIToolTests/SafeDIToolTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolTests.swift
@@ -3078,10 +3078,10 @@ final class SafeDIToolTests: XCTestCase {
         dependentModuleOutputPaths: [String] = [],
         buildDependencyTreeOutput: Bool
     ) async throws -> TestOutput {
-        let swiftFileCSV = makeTempFile()
+        let swiftFileCSV = URL.temporaryFile
         let swiftFiles = try swiftFileContent
             .map {
-                let location = makeTempFile()
+                let location = URL.temporaryFile
                 try $0.write(to: location, atomically: true, encoding: .utf8)
                 return location
             }
@@ -3090,8 +3090,8 @@ final class SafeDIToolTests: XCTestCase {
             .joined(separator: ",")
             .write(to: swiftFileCSV, atomically: true, encoding: .utf8)
 
-        let moduleInfoOutput = makeTempFile()
-        let dependencyTreeOutput = makeTempFile()
+        let moduleInfoOutput = URL.temporaryFile
+        let dependencyTreeOutput = URL.temporaryFile
         var tool = SafeDITool()
         tool.swiftSourcesFilePath = swiftFileCSV.filePath
         tool.additionalImportedModules = []
@@ -3123,17 +3123,17 @@ final class SafeDIToolTests: XCTestCase {
     }
 
     private var filesToDelete = [URL]()
+}
 
-    private func makeTempFile() -> URL {
+extension URL {
+    fileprivate static var temporaryFile: URL {
 #if os(Linux)
         FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
 #else
         URL.temporaryDirectory.appending(path: UUID().uuidString)
 #endif
     }
-}
 
-extension URL {
     fileprivate var filePath: String {
 #if os(Linux)
         path

--- a/Tests/SafeDIToolTests/SafeDIToolTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolTests.swift
@@ -3078,10 +3078,10 @@ final class SafeDIToolTests: XCTestCase {
         dependentModuleOutputPaths: [String] = [],
         buildDependencyTreeOutput: Bool
     ) async throws -> TestOutput {
-        let swiftFileCSV = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let swiftFileCSV = makeTempFile()
         let swiftFiles = try swiftFileContent
             .map {
-                let location = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+                let location = makeTempFile()
                 try $0.write(to: location, atomically: true, encoding: .utf8)
                 return location
             }
@@ -3090,8 +3090,8 @@ final class SafeDIToolTests: XCTestCase {
             .joined(separator: ",")
             .write(to: swiftFileCSV, atomically: true, encoding: .utf8)
 
-        let moduleInfoOutput = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
-        let dependencyTreeOutput = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let moduleInfoOutput = makeTempFile()
+        let dependencyTreeOutput = makeTempFile()
         var tool = SafeDITool()
         tool.swiftSourcesFilePath = swiftFileCSV.path()
         tool.additionalImportedModules = []
@@ -3123,4 +3123,12 @@ final class SafeDIToolTests: XCTestCase {
     }
 
     private var filesToDelete = [URL]()
+
+    private func makeTempFile() -> URL {
+#if os(Linux)
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+#else
+        URL.temporaryDirectory.appending(path: UUID().uuidString)
+#endif
+    }
 }

--- a/Tests/SafeDIToolTests/SafeDIToolTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolTests.swift
@@ -3078,10 +3078,10 @@ final class SafeDIToolTests: XCTestCase {
         dependentModuleOutputPaths: [String] = [],
         buildDependencyTreeOutput: Bool
     ) async throws -> TestOutput {
-        let swiftFileCSV = URL.temporaryDirectory.appending(path: UUID().uuidString)
+        let swiftFileCSV = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
         let swiftFiles = try swiftFileContent
             .map {
-                let location = URL.temporaryDirectory.appending(path: UUID().uuidString)
+                let location = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
                 try $0.write(to: location, atomically: true, encoding: .utf8)
                 return location
             }
@@ -3090,8 +3090,8 @@ final class SafeDIToolTests: XCTestCase {
             .joined(separator: ",")
             .write(to: swiftFileCSV, atomically: true, encoding: .utf8)
 
-        let moduleInfoOutput = URL.temporaryDirectory.appending(path: UUID().uuidString)
-        let dependencyTreeOutput = URL.temporaryDirectory.appending(path: UUID().uuidString)
+        let moduleInfoOutput = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        let dependencyTreeOutput = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
         var tool = SafeDITool()
         tool.swiftSourcesFilePath = swiftFileCSV.path()
         tool.additionalImportedModules = []

--- a/Tests/SafeDIToolTests/SafeDIToolTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolTests.swift
@@ -21,7 +21,6 @@
 import SafeDICore
 import XCTest
 
-@testable import ArgumentParser
 @testable import SafeDITool
 
 final class SafeDIToolTests: XCTestCase {

--- a/Tests/SafeDIToolTests/SafeDIToolTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolTests.swift
@@ -3086,18 +3086,18 @@ final class SafeDIToolTests: XCTestCase {
                 return location
             }
         try swiftFiles
-            .map { $0.path() }
+            .map { $0.filePath }
             .joined(separator: ",")
             .write(to: swiftFileCSV, atomically: true, encoding: .utf8)
 
         let moduleInfoOutput = makeTempFile()
         let dependencyTreeOutput = makeTempFile()
         var tool = SafeDITool()
-        tool.swiftSourcesFilePath = swiftFileCSV.path()
+        tool.swiftSourcesFilePath = swiftFileCSV.filePath
         tool.additionalImportedModules = []
-        tool.moduleInfoOutput = moduleInfoOutput.path()
+        tool.moduleInfoOutput = moduleInfoOutput.filePath
         tool.moduleInfoPaths = dependentModuleOutputPaths
-        tool.dependencyTreeOutput = buildDependencyTreeOutput ? dependencyTreeOutput.path() : nil
+        tool.dependencyTreeOutput = buildDependencyTreeOutput ? dependencyTreeOutput.filePath : nil
         try await tool.run()
         
         filesToDelete.append(swiftFileCSV)
@@ -3109,9 +3109,9 @@ final class SafeDIToolTests: XCTestCase {
 
         return TestOutput(
             moduleInfo: try JSONDecoder().decode(SafeDITool.ModuleInfo.self, from: Data(contentsOf: moduleInfoOutput)),
-            moduleInfoOutputPath: moduleInfoOutput.path(),
+            moduleInfoOutputPath: moduleInfoOutput.filePath,
             dependencyTree: buildDependencyTreeOutput ? String(data: try Data(contentsOf: dependencyTreeOutput), encoding: .utf8) : nil,
-            dependencyTreeOutputPath: buildDependencyTreeOutput ? dependencyTreeOutput.path() : nil
+            dependencyTreeOutputPath: buildDependencyTreeOutput ? dependencyTreeOutput.filePath : nil
         )
     }
 
@@ -3129,6 +3129,16 @@ final class SafeDIToolTests: XCTestCase {
         FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
 #else
         URL.temporaryDirectory.appending(path: UUID().uuidString)
+#endif
+    }
+}
+
+extension URL {
+    fileprivate var filePath: String {
+#if os(Linux)
+        path
+#else
+        path()
 #endif
     }
 }


### PR DESCRIPTION
Exercises more of the SafeDI library via tests, and discovers/fixes an issue where an source empty file list in the CSV would cause an error.

There's also a little code cleanup along the way here.