### PR TITLE
Ensure platform support in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   spm-15:
     name: Build and Test on Xcode 15
-    runs-on: macos-13-arm64
+    runs-on: macos-latest-xlarge
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -25,7 +25,7 @@ jobs:
 
   xcodebuild-15:
     name: Build with xcodebuild on Xcode 15
-    runs-on: macOS-13-arm64
+    runs-on: macos-latest-xlarge
     strategy:
       matrix:
         platforms: [
@@ -45,7 +45,7 @@ jobs:
 
   spm-package-integration-15:
     name: Build Package Integration on Xcode 15
-    runs-on: macos-13-arm64
+    runs-on: macos-latest-xlarge
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
 
   spm-project-integration-15:
     name: Build Project Integration on Xcode 15
-    runs-on: macos-13-arm64
+    runs-on: macos-latest-xlarge
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
       - name: Build Framework
-        run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -configuration release -scheme SafeDI-Package -destination ${{ matrix.platforms }}
+        run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination ${{ matrix.platforms }}
 
   spm-package-integration-15:
     name: Build Package Integration on Xcode 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   spm-15:
     name: Build and Test on Xcode 15
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -25,12 +25,12 @@ jobs:
 
   xcodebuild-15:
     name: Build with xcodebuild on Xcode 15
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
     strategy:
       matrix:
         platforms: [
           'generic/platform=ios',
-          'platform=macos,arch=arm64',
+          'platform=macos',
           'generic/platform=tvos',
           'generic/platform=watchos',
         ]
@@ -45,7 +45,7 @@ jobs:
 
   spm-package-integration-15:
     name: Build Package Integration on Xcode 15
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
 
   spm-project-integration-15:
     name: Build Project Integration on Xcode 15
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,22 +7,6 @@ on:
   pull_request:
 
 jobs:
-  spm-15:
-    name: Build and Test on Xcode 15
-    runs-on: macos-13
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-      - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
-      - name: Build and Test Framework
-        run: xcrun swift test -c release --enable-code-coverage -Xswiftc -enable-testing
-      - name: Prepare Coverage Reports
-        run: ./Scripts/prepare-coverage-reports.sh
-      - name: Upload Coverage Reports
-        if: success()
-        uses: codecov/codecov-action@v3
-
   xcodebuild-15:
     name: Build with xcodebuild on Xcode 15
     runs-on: macos-13
@@ -65,8 +49,24 @@ jobs:
       - name: Build Project Integration
         run: pushd Examples/ExampleProjectIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExampleProjectIntegration; popd
 
+  spm-15:
+    name: Build and Test on Xcode 15
+    runs-on: macos-13
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Select Xcode Version
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
+      - name: Build and Test Framework
+        run: xcrun swift test -c release --enable-code-coverage -Xswiftc -enable-testing
+      - name: Prepare Coverage Reports
+        run: ./Scripts/prepare-coverage-reports.sh
+      - name: Upload Coverage Reports
+        if: success()
+        uses: codecov/codecov-action@v3
+
   linux:
-    name: "Build and Test on Linux"
+    name: Build and Test on Linux
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
       - name: Build Framework
-        run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -c release -scheme SafeDI-Package -destination ${{ matrix.platforms }}
+        run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -configuration release -scheme SafeDI-Package -destination ${{ matrix.platforms }}
 
   spm-package-integration-15:
     name: Build Package Integration on Xcode 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   spm-15:
     name: Build and Test on Xcode 15
-    runs-on: macos-latest-xlarge
+    runs-on: macos-13-xlarge
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -25,7 +25,7 @@ jobs:
 
   xcodebuild-15:
     name: Build with xcodebuild on Xcode 15
-    runs-on: macos-latest-xlarge
+    runs-on: macos-13-xlarge
     strategy:
       matrix:
         platforms: [
@@ -45,7 +45,7 @@ jobs:
 
   spm-package-integration-15:
     name: Build Package Integration on Xcode 15
-    runs-on: macos-latest-xlarge
+    runs-on: macos-13-xlarge
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
 
   spm-project-integration-15:
     name: Build Project Integration on Xcode 15
-    runs-on: macos-latest-xlarge
+    runs-on: macos-13-xlarge
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
       - name: Build Framework
-        run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination ${{ matrix.platforms }}
+        run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -c release -scheme SafeDI-Package -destination ${{ matrix.platforms }}
 
   spm-package-integration-15:
     name: Build Package Integration on Xcode 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   spm-15:
     name: Build and Test on Xcode 15
-    runs-on: macos-13
+    runs-on: macos-13-arm64
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
 
   spm-package-integration-15:
     name: Build Package Integration on Xcode 15
-    runs-on: macos-13
+    runs-on: macos-13-arm64
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
 
   spm-project-integration-15:
     name: Build Project Integration on Xcode 15
-    runs-on: macos-13
+    runs-on: macos-13-arm64
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,26 @@ jobs:
         if: success()
         uses: codecov/codecov-action@v3
 
+  xcodebuild-15:
+    name: Build with xcodebuild on Xcode 15
+    runs-on: macOS-13-arm64
+    strategy:
+      matrix:
+        platforms: [
+          'generic/platform=ios',
+          'platform=macos,arch=arm64',
+          'generic/platform=tvos',
+          'generic/platform=watchos',
+        ]
+      fail-fast: false
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Select Xcode Version
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
+      - name: Build Framework
+        run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination ${{ matrix.platforms }}
+
   spm-package-integration-15:
     name: Build Package Integration on Xcode 15
     runs-on: macos-13

--- a/Tests/SafeDIToolTests/SafeDIToolTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolTests.swift
@@ -3086,18 +3086,18 @@ final class SafeDIToolTests: XCTestCase {
                 return location
             }
         try swiftFiles
-            .map { $0.filePath }
+            .map { $0.relativePath }
             .joined(separator: ",")
             .write(to: swiftFileCSV, atomically: true, encoding: .utf8)
 
         let moduleInfoOutput = URL.temporaryFile
         let dependencyTreeOutput = URL.temporaryFile
         var tool = SafeDITool()
-        tool.swiftSourcesFilePath = swiftFileCSV.filePath
+        tool.swiftSourcesFilePath = swiftFileCSV.relativePath
         tool.additionalImportedModules = []
-        tool.moduleInfoOutput = moduleInfoOutput.filePath
+        tool.moduleInfoOutput = moduleInfoOutput.relativePath
         tool.moduleInfoPaths = dependentModuleOutputPaths
-        tool.dependencyTreeOutput = buildDependencyTreeOutput ? dependencyTreeOutput.filePath : nil
+        tool.dependencyTreeOutput = buildDependencyTreeOutput ? dependencyTreeOutput.relativePath : nil
         try await tool.run()
         
         filesToDelete.append(swiftFileCSV)
@@ -3109,9 +3109,9 @@ final class SafeDIToolTests: XCTestCase {
 
         return TestOutput(
             moduleInfo: try JSONDecoder().decode(SafeDITool.ModuleInfo.self, from: Data(contentsOf: moduleInfoOutput)),
-            moduleInfoOutputPath: moduleInfoOutput.filePath,
+            moduleInfoOutputPath: moduleInfoOutput.relativePath,
             dependencyTree: buildDependencyTreeOutput ? String(data: try Data(contentsOf: dependencyTreeOutput), encoding: .utf8) : nil,
-            dependencyTreeOutputPath: buildDependencyTreeOutput ? dependencyTreeOutput.filePath : nil
+            dependencyTreeOutputPath: buildDependencyTreeOutput ? dependencyTreeOutput.relativePath : nil
         )
     }
 
@@ -3131,14 +3131,6 @@ extension URL {
         FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
 #else
         URL.temporaryDirectory.appending(path: UUID().uuidString)
-#endif
-    }
-
-    fileprivate var filePath: String {
-#if os(Linux)
-        path
-#else
-        path()
 #endif
     }
 }

--- a/Tests/SafeDIToolTests/SafeDIToolTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolTests.swift
@@ -3130,7 +3130,11 @@ extension URL {
 #if os(Linux)
         FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
 #else
-        URL.temporaryDirectory.appending(path: UUID().uuidString)
+        if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+            URL.temporaryDirectory.appending(path: UUID().uuidString)
+        } else {
+            FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        }
 #endif
     }
 }


### PR DESCRIPTION
`path()`, `URL.temporaryDirectory`, and `appending(path:)` have limited OS availability, and our CI only tests against latest operating systems (due to limitations with GitHub Actions). Swift package index's test suite was able to catch an issue with our use of `path()` ([iOS](https://swiftpackageindex.com/builds/F78DED19-7319-48DE-988C-858A00241AC9), [watchOS](https://swiftpackageindex.com/builds/E84BC0F8-0D4B-48C2-83B1-1B6B9812DD29), and [tvOS](https://swiftpackageindex.com/builds/A333E309-D9AA-4562-ADEE-C7D5DF8A2C60)), and we copy their build config here.

Thankfully these availability issues only occurred in the test suite rather than the production suite, so `0.2.1` has the same version support as `0.2.0` despite the Swift Package Index build failures linked above.

I also moved to utilizing `relativePath` instead of `path()` and `path` since `relativePath` does not have availability issues.