### PR TITLE
Refactor property validation and simplify generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,13 +68,10 @@ jobs:
   linux:
     name: Build and Test on Linux
     runs-on: ubuntu-latest
+    container: swift:5.9
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Setup Swift Environment
-        uses: swift-actions/setup-swift@v1
-        with:
-          swift-version: 5.9
       - name: Build and Test Framework
         run: swift test -c release --enable-code-coverage -Xswiftc -enable-testing
       - name: Prepare Coverage Reports

--- a/Sources/SafeDICore/Errors/FixableInstantiableError.swift
+++ b/Sources/SafeDICore/Errors/FixableInstantiableError.swift
@@ -35,7 +35,7 @@ public enum FixableInstantiableError: DiagnosticError {
     public var description: String {
         switch self {
         case .dependencyHasTooManyAttributes:
-            "Dependency can have at most one of @\(Dependency.Source.instantiated), @\(Dependency.Source.received), or @\(Dependency.Source.forwarded) attached macro"
+            "Dependency can have at most one of @\(Dependency.Source.instantiatedRawValue), @\(Dependency.Source.receivedRawValue), or @\(Dependency.Source.forwardedRawValue) attached macro"
         case .dependencyHasInitializer:
             "Dependency must not have hand-written initializer"
         case .missingPublicOrOpenAttribute:

--- a/Sources/SafeDICore/Extensions/AttributeListSyntaxElementExtensions.swift
+++ b/Sources/SafeDICore/Extensions/AttributeListSyntaxElementExtensions.swift
@@ -1,0 +1,49 @@
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftSyntax
+
+extension AttributeListSyntax.Element {
+
+    var instantiableMacro: AttributeSyntax? {
+        attributeIfNameEquals(InstantiableVisitor.macroName)
+    }
+
+    var instantiatedMacro: AttributeSyntax? {
+        attributeIfNameEquals(Dependency.Source.instantiatedRawValue)
+    }
+
+    var receivedMacro: AttributeSyntax? {
+        attributeIfNameEquals(Dependency.Source.receivedRawValue)
+    }
+
+    var forwardedMacro: AttributeSyntax? {
+        attributeIfNameEquals(Dependency.Source.forwardedRawValue)
+    }
+
+    private func attributeIfNameEquals(_ expectedName: String) -> AttributeSyntax? {
+        switch self {
+        case let .attribute(attribute):
+            IdentifierTypeSyntax(attribute.attributeName)?.name.text == expectedName ? attribute : nil
+        case .ifConfigDecl:
+            nil
+        }
+    }
+}

--- a/Sources/SafeDICore/Extensions/AttributeListSyntaxExtensions.swift
+++ b/Sources/SafeDICore/Extensions/AttributeListSyntaxExtensions.swift
@@ -24,12 +24,7 @@ extension AttributeListSyntax {
 
     public var instantiableMacro: AttributeSyntax? {
         guard let attribute = first(where: { element in
-            switch element {
-            case let .attribute(attribute):
-                return IdentifierTypeSyntax(attribute.attributeName)?.name.text == InstantiableVisitor.macroName
-            case .ifConfigDecl:
-                return false
-            }
+            element.instantiableMacro != nil
         }) else {
             return nil
         }
@@ -38,12 +33,7 @@ extension AttributeListSyntax {
 
     public var instantiatedMacro: AttributeSyntax? {
         guard let attribute = first(where: { element in
-            switch element {
-            case let .attribute(attribute):
-                return IdentifierTypeSyntax(attribute.attributeName)?.name.text == Dependency.Source.instantiated.rawValue
-            case .ifConfigDecl:
-                return false
-            }
+            element.instantiatedMacro != nil
         }) else {
             return nil
         }
@@ -52,38 +42,24 @@ extension AttributeListSyntax {
 
     public var receivedMacro: AttributeSyntax? {
         guard let attribute = first(where: { element in
-            switch element {
-            case let .attribute(attribute):
-                return IdentifierTypeSyntax(attribute.attributeName)?.name.text == Dependency.Source.received.rawValue
-            case .ifConfigDecl:
-                return false
-            }
+            element.receivedMacro != nil
         }) else {
             return nil
         }
         return AttributeSyntax(attribute)
     }
 
-    public var attributedNodes: [(attribute: String, node: AttributeListSyntax.Element)] {
-        compactMap { element in
-            switch element {
-            case let .attribute(attribute):
-                guard let identifierText = IdentifierTypeSyntax(attribute.attributeName)?.name.text else {
+    public var dependencySources: [(source: Dependency.Source, node: AttributeListSyntax.Element)] {
+        compactMap {
+            switch $0 {
+            case .attribute:
+                guard let source = Dependency.Source(node: $0) else {
                     return nil
                 }
-                return (attribute: identifierText, node: element)
+                return (source: source, node: $0)
             case .ifConfigDecl:
                 return nil
             }
-        }
-    }
-
-    public var dependencySources: [(source: Dependency.Source, node: AttributeListSyntax.Element)] {
-        attributedNodes.compactMap {
-            guard let source = Dependency.Source.init(rawValue: $0.attribute) else {
-                return nil
-            }
-            return (source: source, node: $0.node)
         }
     }
 }

--- a/Sources/SafeDICore/Generators/DependencyTreeGenerator.swift
+++ b/Sources/SafeDICore/Generators/DependencyTreeGenerator.swift
@@ -214,8 +214,8 @@ public final class DependencyTreeGenerator {
             })
 
         // Populate the propertiesToInstantiate on each scope.
-        for scope in typeDescriptionToScopeMap.values {
-            var additionalPropertiesToInstantiate = [Scope.PropertyToInstantiate]()
+        for scope in Set(typeDescriptionToScopeMap.values) {
+            var propertiesToInstantiate = [Scope.PropertyToInstantiate]()
             for instantiatedDependency in scope.instantiable.dependencies {
                 switch instantiatedDependency.source {
                 case .instantiated:
@@ -238,12 +238,12 @@ public final class DependencyTreeGenerator {
                     case .constant, .instantiator:
                         break
                     }
-                    additionalPropertiesToInstantiate.append(.instantiated(
+                    propertiesToInstantiate.append(.instantiated(
                         instantiatedDependency.property,
                         instantiatedScope
                     ))
                 case let .aliased(fulfillingProperty):
-                    additionalPropertiesToInstantiate.append(.aliased(
+                    propertiesToInstantiate.append(.aliased(
                         instantiatedDependency.property,
                         fulfilledBy: fulfillingProperty
                     ))
@@ -251,7 +251,7 @@ public final class DependencyTreeGenerator {
                     continue
                 }
             }
-            scope.propertiesToInstantiate.append(contentsOf: additionalPropertiesToInstantiate)
+            scope.propertiesToInstantiate.append(contentsOf: propertiesToInstantiate)
         }
         return typeDescriptionToScopeMap
     }

--- a/Sources/SafeDICore/Generators/DependencyTreeGenerator.swift
+++ b/Sources/SafeDICore/Generators/DependencyTreeGenerator.swift
@@ -78,7 +78,7 @@ public final class DependencyTreeGenerator {
         var description: String {
             switch self {
             case let .noInstantiableFound(typeDescription):
-                "No `@\(InstantiableVisitor.macroName)`-decorated type or extension found to fulfill `@\(Dependency.Source.instantiated.rawValue)`-decorated property with type `\(typeDescription.asSource)`"
+                "No `@\(InstantiableVisitor.macroName)`-decorated type or extension found to fulfill `@\(Dependency.Source.instantiatedRawValue)`-decorated property with type `\(typeDescription.asSource)`"
             case let .unfulfillableProperties(unfulfillableProperties):
                 """
                 The following @Received properties were never @Instantiated or @Forwarded:
@@ -216,33 +216,40 @@ public final class DependencyTreeGenerator {
         // Populate the propertiesToInstantiate on each scope.
         for scope in typeDescriptionToScopeMap.values {
             var additionalPropertiesToInstantiate = [Scope.PropertyToInstantiate]()
-            for instantiatedDependency in scope.instantiable.instantiatedDependencies {
-                let instantiatedType = instantiatedDependency.asInstantiatedType
-                guard
-                    let instantiable = typeDescriptionToFulfillingInstantiableMap[instantiatedType],
-                    let instantiatedScope = typeDescriptionToScopeMap[instantiatedType]
-                else {
-                    assertionFailure("Invalid state. Could not look up info for \(instantiatedType)")
+            for instantiatedDependency in scope.instantiable.dependencies {
+                switch instantiatedDependency.source {
+                case .instantiated:
+                    let instantiatedType = instantiatedDependency.asInstantiatedType
+                    guard
+                        let instantiable = typeDescriptionToFulfillingInstantiableMap[instantiatedType],
+                        let instantiatedScope = typeDescriptionToScopeMap[instantiatedType]
+                    else {
+                        assertionFailure("Invalid state. Could not look up info for \(instantiatedType)")
+                        continue
+                    }
+                    let type = instantiatedDependency.property.propertyType
+                    switch type {
+                    case .forwardingInstantiator:
+                        guard !instantiable.dependencies.filter(\.isForwarded).isEmpty else {
+                            throw DependencyTreeGeneratorError.forwardingInstantiatorInstntiableHasNoForwardedProperty(
+                                property: instantiatedDependency.property,
+                                instantiableWithoutForwardedProperty: instantiable)
+                        }
+                    case .constant, .instantiator:
+                        break
+                    }
+                    additionalPropertiesToInstantiate.append(.instantiated(
+                        instantiatedDependency.property,
+                        instantiatedScope
+                    ))
+                case let .aliased(fulfillingProperty):
+                    additionalPropertiesToInstantiate.append(.aliased(
+                        instantiatedDependency.property,
+                        fulfilledBy: fulfillingProperty
+                    ))
+                case .forwarded, .received:
                     continue
                 }
-                let type = instantiatedDependency.property.propertyType
-                switch type {
-                case .forwardingInstantiator:
-                    guard !instantiable.dependencies.filter(\.isForwarded).isEmpty else {
-                        throw DependencyTreeGeneratorError.forwardingInstantiatorInstntiableHasNoForwardedProperty(
-                            property: instantiatedDependency.property,
-                            instantiableWithoutForwardedProperty: instantiable)
-                    }
-
-                case .constant, .instantiator:
-                    break
-                }
-                additionalPropertiesToInstantiate.append(Scope.PropertyToInstantiate(
-                    property: instantiatedDependency.property,
-                    instantiable: instantiable,
-                    scope: instantiatedScope,
-                    type: type
-                ))
             }
             scope.propertiesToInstantiate.append(contentsOf: additionalPropertiesToInstantiate)
         }
@@ -267,7 +274,7 @@ public final class DependencyTreeGenerator {
                 }
             }
 
-            for childScope in scope.propertiesToInstantiate.map(\.scope) {
+            for childScope in scope.propertiesToInstantiate.compactMap(\.scope) {
                 guard !instantiables.contains(childScope.instantiable) else {
                     // We've previously visited this child scope.
                     // There is a cycle in our scope tree. Do not re-enter it.
@@ -314,7 +321,7 @@ extension Dependency {
         switch source {
         case .instantiated:
             return true
-        case .forwarded, .received:
+        case .aliased, .forwarded, .received:
             return false
         }
     }
@@ -322,7 +329,7 @@ extension Dependency {
         switch source {
         case .forwarded:
             return true
-        case .instantiated, .received:
+        case .aliased, .instantiated, .received:
             return false
         }
     }

--- a/Sources/SafeDICore/Models/Initializer.swift
+++ b/Sources/SafeDICore/Models/Initializer.swift
@@ -141,23 +141,18 @@ public struct Initializer: Codable, Hashable {
             ),
             bodyBuilder: {
                 for dependency in dependencies {
-                    switch dependency.source {
-                    case .instantiated,
-                            .received,
-                            .forwarded:
-                        CodeBlockItemSyntax(
-                            item: .expr(ExprSyntax(InfixOperatorExprSyntax(
-                                leadingTrivia: .newline,
-                                leftOperand: MemberAccessExprSyntax(
-                                    base: DeclReferenceExprSyntax(baseName: TokenSyntax.keyword(.`self`)),
-                                    name: TokenSyntax.identifier(dependency.property.label)),
-                                operator: AssignmentExprSyntax(
-                                    leadingTrivia: .space,
-                                    trailingTrivia: .space),
-                                rightOperand: DeclReferenceExprSyntax(baseName: TokenSyntax.identifier(dependency.property.label))
-                            )))
-                        )
-                    }
+                    CodeBlockItemSyntax(
+                        item: .expr(ExprSyntax(InfixOperatorExprSyntax(
+                            leadingTrivia: .newline,
+                            leftOperand: MemberAccessExprSyntax(
+                                base: DeclReferenceExprSyntax(baseName: TokenSyntax.keyword(.`self`)),
+                                name: TokenSyntax.identifier(dependency.property.label)),
+                            operator: AssignmentExprSyntax(
+                                leadingTrivia: .space,
+                                trailingTrivia: .space),
+                            rightOperand: DeclReferenceExprSyntax(baseName: TokenSyntax.identifier(dependency.property.label))
+                        )))
+                    )
                 }
                 for additionalPropertyLabel in additionalPropertyLabels {
                     CodeBlockItemSyntax(

--- a/Sources/SafeDICore/Models/Instantiable.swift
+++ b/Sources/SafeDICore/Models/Instantiable.swift
@@ -58,11 +58,4 @@ public struct Instantiable: Codable, Hashable {
         case structType
         case extensionType
     }
-
-    // MARK: Internal
-
-    var instantiatedDependencies: [Dependency] {
-        dependencies
-            .filter { $0.source == .instantiated }
-    }
 }

--- a/Sources/SafeDICore/Models/Scope.swift
+++ b/Sources/SafeDICore/Models/Scope.swift
@@ -47,9 +47,9 @@ final class Scope: Hashable {
     let instantiable: Instantiable
 
     /// The properties that this scope is responsible for instantiating.
-    var propertiesToInstantiate = [PropertyToInstantiate]()
+    var propertiesToGenerate = [PropertyToGenerate]()
 
-    enum PropertyToInstantiate {
+    enum PropertyToGenerate {
         case instantiated(Property, Scope)
         case aliased(Property, fulfilledBy: Property)
     }
@@ -93,7 +93,7 @@ final class Scope: Hashable {
             let scopeGenerator = ScopeGenerator(
                 instantiable: instantiable,
                 property: property,
-                propertiesToGenerate: try propertiesToInstantiate.map {
+                propertiesToGenerate: try propertiesToGenerate.map {
                     switch $0 {
                     case let .instantiated(property, scope):
                         try scope.createScopeGenerator(

--- a/Sources/SafeDICore/Models/Scope.swift
+++ b/Sources/SafeDICore/Models/Scope.swift
@@ -36,11 +36,27 @@ final class Scope {
     /// The properties that this scope is responsible for instantiating.
     var propertiesToInstantiate = [PropertyToInstantiate]()
 
-    struct PropertyToInstantiate {
-        let property: Property
-        let instantiable: Instantiable
-        let scope: Scope
-        let type: Property.PropertyType
+    enum PropertyToInstantiate {
+        case instantiated(Property, Scope)
+        case aliased(Property, fulfilledBy: Property)
+
+        var property: Property {
+            switch self {
+            case
+                let .instantiated(property, _),
+                let .aliased(property, _):
+                property
+            }
+        }
+
+        var scope: Scope? {
+            switch self {
+            case let .instantiated(_, scope):
+                scope
+            case .aliased:
+                nil
+            }
+        }
     }
 
     var properties: [Property] {
@@ -55,7 +71,9 @@ final class Scope {
             .compactMap {
                 switch $0.source {
                 case .received:
-                    return $0.fulfillingProperty ?? $0.property
+                    $0.property
+                case let .aliased(fulfillingProperty):
+                    fulfillingProperty
                 case .forwarded,
                         .instantiated:
                     return nil
@@ -81,38 +99,40 @@ final class Scope {
                 instantiableStack
                     .flatMap(\.dependencies)
                     .filter {
-                        $0.source != .received
-                        && !propertyStack.contains($0.property)
-                        && $0.property != property
+                        switch $0.source {
+                        // The source has been injected into the dependency tree.
+                        case .instantiated,
+                                .forwarded,
+                            // This property has been re-injected into the dependency tree under a new alias.
+                                .aliased:
+                            return !propertyStack.contains($0.property) && $0.property != property
+                        case .received:
+                            return false
+                        }
                     }
                     .map(\.property)
             ).subtracting(
                 // We want the local version of any instantiated property.
                 propertiesToInstantiate.map(\.property)
-                + instantiable
-                    .dependencies
-                    // We want the local version of any aliased property.
-                    .filter { $0.fulfillingProperty != nil }
-                    .map(\.property)
             )
             let scopeGenerator = ScopeGenerator(
                 instantiable: instantiable,
                 property: property,
                 propertiesToGenerate: try propertiesToInstantiate.map {
-                    try $0.scope.createScopeGenerator(
-                        for: $0.property,
-                        instantiableStack: childInstantiableStack,
-                        propertyStack: childPropertyStack
-                    )
-                } + instantiable.dependencies.compactMap {
-                    guard let fulfillingProperty = $0.fulfillingProperty else {
-                        return nil
+                    switch $0 {
+                    case let .instantiated(property, scope):
+                        try scope.createScopeGenerator(
+                            for: property,
+                            instantiableStack: childInstantiableStack,
+                            propertyStack: childPropertyStack
+                        )
+                    case let .aliased(property, fulfilledBy: fulfillingProperty):
+                        ScopeGenerator(
+                            property: property,
+                            fulfillingProperty: fulfillingProperty,
+                            receivedProperties: receivedProperties
+                        )
                     }
-                    return ScopeGenerator(
-                        property: $0.property,
-                        fulfillingProperty: fulfillingProperty,
-                        receivedProperties: receivedProperties
-                    )
                 },
                 receivedProperties: receivedProperties
             )

--- a/Sources/SafeDICore/Visitors/InstantiableVisitor.swift
+++ b/Sources/SafeDICore/Visitors/InstantiableVisitor.swift
@@ -95,32 +95,15 @@ public final class InstantiableVisitor: SyntaxVisitor {
                 let label = IdentifierPatternSyntax(binding.pattern)?.identifier.text,
                 let typeDescription = binding.typeAnnotation?.type.typeDescription
             {
-                let fulfillingPropertyName = node.attributes.receivedMacro?.fulfillingPropertyName
-                let fulfillingTypeDescription: TypeDescription? = node
-                    .attributes
-                    .instantiatedMacro?
-                    .fulfillingTypeDescription
-                ?? node
-                    .attributes
-                    .receivedMacro?
-                    .fulfillingTypeDescription
-
                 dependencies.append(
                     Dependency(
                         property: { 
-                            switch dependencySource {
-                            case .instantiated,
-                                    .received,
-                                    .forwarded:
-                                Property(
-                                    label: label,
-                                    typeDescription: typeDescription
-                                )
-                            }
+                            Property(
+                                label: label,
+                                typeDescription: typeDescription
+                            )
                         }(),
-                        source: dependencySource,
-                        fulfillingPropertyName: fulfillingPropertyName,
-                        fulfillingTypeDescription: fulfillingTypeDescription
+                        source: dependencySource
                     )
                 )
             }
@@ -221,13 +204,7 @@ public final class InstantiableVisitor: SyntaxVisitor {
         dependencies = initializer.arguments.map {
             Dependency(
                 property: $0.asProperty,
-                source: .received,
-                // We do not support type injecting renamed properties into external instantiable's initializer method.
-                // We can add this functionality in the future, possibly with a freestanding macro used to declare an argument within the method declaration.
-                fulfillingPropertyName: nil,
-                // We do not support type injecting type-erased properties into external instantiable's initializer method.
-                // We can add this functionality in the future, possibly with a freestanding macro used to declare an argument within the method declaration.
-                fulfillingTypeDescription: nil
+                source: .received
             )
         }
 

--- a/Tests/SafeDICoreTests/FileVisitorTests.swift
+++ b/Tests/SafeDICoreTests/FileVisitorTests.swift
@@ -64,18 +64,14 @@ final class FileVisitorTests: XCTestCase {
                                 label: "user",
                                 typeDescription: .simple(name: "User")
                             ),
-                            source: .forwarded,
-                            fulfillingPropertyName: nil,
-                            fulfillingTypeDescription: nil
+                            source: .forwarded
                         ),
                         Dependency(
                             property: Property(
                                 label: "networkService",
                                 typeDescription: .simple(name: "NetworkService")
                             ),
-                            source: .received,
-                            fulfillingPropertyName: nil,
-                            fulfillingTypeDescription: nil
+                            source: .received
                         )
                     ],
                     declarationType: .classType
@@ -129,18 +125,14 @@ final class FileVisitorTests: XCTestCase {
                                 label: "user",
                                 typeDescription: .simple(name: "User")
                             ),
-                            source: .forwarded,
-                            fulfillingPropertyName: nil,
-                            fulfillingTypeDescription: nil
+                            source: .forwarded
                         ),
                         Dependency(
                             property: Property(
                                 label: "networkService",
                                 typeDescription: .simple(name: "NetworkService")
                             ),
-                            source: .received,
-                            fulfillingPropertyName: nil,
-                            fulfillingTypeDescription: nil
+                            source: .received
                         )
                     ],
                     declarationType: .classType

--- a/Tests/SafeDICoreTests/InitializerTests.swift
+++ b/Tests/SafeDICoreTests/InitializerTests.swift
@@ -95,9 +95,7 @@ final class InitializerTests: XCTestCase {
                             label: "variant",
                             typeDescription: .simple(name: "Variant")
                         ),
-                        source: .forwarded,
-                        fulfillingPropertyName: nil,
-                        fulfillingTypeDescription: nil
+                        source: .forwarded
                     )
                 ]
             )
@@ -125,9 +123,7 @@ final class InitializerTests: XCTestCase {
                             label: "variant",
                             typeDescription: .simple(name: "Variant")
                         ),
-                        source: .forwarded,
-                        fulfillingPropertyName: nil,
-                        fulfillingTypeDescription: nil
+                        source: .forwarded
                     )
                 ]
             )
@@ -164,9 +160,7 @@ final class InitializerTests: XCTestCase {
                             label: "variant",
                             typeDescription: .simple(name: "Variant")
                         ),
-                        source: .forwarded,
-                        fulfillingPropertyName: nil,
-                        fulfillingTypeDescription: nil
+                        source: .forwarded
                     )
                 ]
             )
@@ -193,9 +187,7 @@ final class InitializerTests: XCTestCase {
                             label: "variant",
                             typeDescription: .simple(name: "Variant")
                         ),
-                        source: .forwarded,
-                        fulfillingPropertyName: nil,
-                        fulfillingTypeDescription: nil
+                        source: .forwarded
                     )
                 ]
             )
@@ -222,9 +214,7 @@ final class InitializerTests: XCTestCase {
                             label: "variant",
                             typeDescription: .simple(name: "Variant")
                         ),
-                        source: .forwarded,
-                        fulfillingPropertyName: nil,
-                        fulfillingTypeDescription: nil
+                        source: .forwarded
                     )
                 ]
             )

--- a/Tests/SafeDIMacrosTests/InjectableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InjectableMacroTests.swift
@@ -31,9 +31,9 @@ import SafeDICore
 final class InjectableMacroTests: XCTestCase {
 
     let testMacros: [String: Macro.Type] = [
-        Dependency.Source.instantiated.rawValue: InjectableMacro.self,
-        Dependency.Source.received.rawValue: InjectableMacro.self,
-        Dependency.Source.forwarded.rawValue: InjectableMacro.self,
+        Dependency.Source.instantiatedRawValue: InjectableMacro.self,
+        Dependency.Source.receivedRawValue: InjectableMacro.self,
+        Dependency.Source.forwardedRawValue: InjectableMacro.self,
     ]
 
     // MARK: XCTestCase

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -31,9 +31,9 @@ import SafeDICore
 final class InstantiableMacroTests: XCTestCase {
     let testMacros: [String: Macro.Type] = [
         InstantiableVisitor.macroName: InstantiableMacro.self,
-        Dependency.Source.instantiated.rawValue: InjectableMacro.self,
-        Dependency.Source.received.rawValue: InjectableMacro.self,
-        Dependency.Source.forwarded.rawValue: InjectableMacro.self,
+        Dependency.Source.instantiatedRawValue: InjectableMacro.self,
+        Dependency.Source.receivedRawValue: InjectableMacro.self,
+        Dependency.Source.forwardedRawValue: InjectableMacro.self,
     ]
 
     // MARK: XCTestCase


### PR DESCRIPTION
**This PR is best reviewed commit by commit, in split view, with whitespace ignored**

There's a lot going on here, but the high level is that we are refactoring how we store and generate dependencies to remove a ton of potential issues.

We had a ton of little bugs because we were:
1. Storing associated information as optional properties away from associated enum cases
2. Validating our dependency tree twice – once in the dependency tree generator and once during code generation

We fix both of these architectural issues in this PR (in separate commits), as well as a few other minor bugs that I found along the way.

Because we have updated the `Dependency.Source` – which `SafeDITool` may persist – **this PR is a breaking change** and we will need to roll to a 0.3.0 when this merges.