### PR TITLE
Remove unnecessary subtraction when calculating dependency ordering

### DIFF
--- a/Sources/SafeDICore/Generators/ScopeGenerator.swift
+++ b/Sources/SafeDICore/Generators/ScopeGenerator.swift
@@ -50,8 +50,6 @@ actor ScopeGenerator {
             propertiesToGenerate.flatMap { [propertiesToFulfill] propertyToGenerate in
                 // All the properties this child and its children require be passed in.
                 propertyToGenerate.requiredReceivedProperties
-                    // Minus all the properties this child fulfills for themselves.
-                    .subtracting(propertyToGenerate.propertiesToFulfill)
                     // Minus all the properties we fulfill.
                     .subtracting(propertiesToFulfill)
             }


### PR DESCRIPTION
`requiredReceivedProperties` and `propertiesToFulfill` for a single scope generator have no overlap, so we don't need to subtract one from the other when determining our dependency ordering.