### PR TITLE
Codesign and notarize release build. Enable utilizing SafeDITool installed via brew.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,16 +17,54 @@ jobs:
         run: xcrun swift build -c release --product SafeDITool
       - name: Give SafeDITool executable permissions
         run: chmod +x .build/*/release/SafeDITool
+      - name: Make codesigning folder
+        run:  |
+          mkdir codesign
+          cp .build/*/release/SafeDITool codesign/
+      - name: Codesign
+        run: |
+          # Decode the p12 certificate
+          echo "${{ secrets.BASE_64_ENCODED_P12 }}" | base64 --decode > codesign/certificate.p12
+          # Create a new keychain
+          security create-keychain -p "" build.keychain
+          # Import the p12 into the keychain
+          security import codesign/certificate.p12 -k build.keychain -P "${{ secrets.P12_PASSWORD }}" -T /usr/bin/codesign
+          # Add the new keychain to the list of keychains to search
+          security list-keychains -s build.keychain
+          # Make the new keychain the default keychain
+          security default-keychain -s build.keychain
+          # Unlock the keychain so it can be used
+          security unlock-keychain -p "" build.keychain
+          # Allows codesign access to the keys in the keychain without user interaction
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
+          # Codesign
+          codesign --force --options runtime --timestamp --sign "${{ secrets.DEVELOPER_ID_CERTIFICATE }}" codesign/SafeDITool
+      - name: Notarize
+        run: |
+          # Create zip
+          pushd codesign && zip -r SafeDITool.zip SafeDITool && popd
+          # Delete original, unsigned tool
+          rm codesign/SafeDITool
+          # Create p8 file
+          echo "${{ secrets.NOTARY_P8 }}" > codesign/AuthKey_${{ secrets.NOTARY_KEY_ID }}.p8
+          # Notarize
+          xcrun notarytool submit codesign/SafeDITool.zip --key codesign/AuthKey_${{ secrets.NOTARY_KEY_ID }}.p8 --key-id ${{ secrets.NOTARY_KEY_ID }} --issuer ${{ secrets.NOTARY_ISSUER_ID }}
+      - name: Unzip notarized tool
+        run: pushd codesign && unzip SafeDITool.zip && popd
       - name: Upload SafeDITool artifact
         uses: actions/upload-artifact@v4
         with:
           name: SafeDITool
-          path: .build/*/release/SafeDITool
+          path: codesign/SafeDITool
       - name: Upload SafeDITool as release binary
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.RELEASE_UPLOADER }}
-          file: .build/*/release/SafeDITool
+          file: codesign/SafeDITool
           tag: ${{ github.ref }}
           overwrite: false
-          file_glob: true
+      - name: Cleanup
+        if: always() # This ensures that the cleanup step runs even if earlier steps fail
+        run: |
+          security delete-keychain build.keychain
+          rm -rf codesign

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,13 +8,20 @@ jobs:
   build-release-cli:
     name: Build Release CLI
     runs-on: macos-13
+    strategy:
+      matrix:
+        architecture: [
+          'x86_64',
+          'arm64',
+        ]
+      fail-fast: false
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
       - name: Build SafeDITool
-        run: xcrun swift build -c release --product SafeDITool
+        run: xcrun swift build -c release --product SafeDITool --arch ${{ matrix.architecture }}
       - name: Give SafeDITool executable permissions
         run: chmod +x .build/*/release/SafeDITool
       - name: Make codesigning folder
@@ -62,6 +69,7 @@ jobs:
           repo_token: ${{ secrets.RELEASE_UPLOADER }}
           file: codesign/SafeDITool
           tag: ${{ github.ref }}
+          asset_name: SafeDITool-${{ matrix.architecture }}
           overwrite: false
       - name: Cleanup
         if: always() # This ensures that the cleanup step runs even if earlier steps fail

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ xcuserdata/
 checkout/
 .swiftpm
 .build/
+codesign/

--- a/Package.swift
+++ b/Package.swift
@@ -23,8 +23,8 @@ let package = Package(
         /// A SafeDI plugin that must be run on the root source module in a project.
         .plugin(
             name: "SafeDIGenerator",
-            targets: ["SafeDIGenerateDependencyTree"]
-        )
+            targets: ["SafeDIGenerator"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
@@ -69,7 +69,7 @@ let package = Package(
 
         // Plugins
         .plugin(
-            name: "SafeDIGenerateDependencyTree",
+            name: "SafeDIGenerator",
             capability: .buildTool(),
             dependencies: ["SafeDITool"]
         ),

--- a/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
+++ b/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
@@ -41,16 +41,31 @@ struct SafeDIGenerateDependencyTree: BuildToolPlugin {
             outputSwiftFile.string
         ]
 
+        let toolPath: PackagePlugin.Path
+        if FileManager.default.fileExists(atPath: Self.armMacBrewInstallLocation) {
+            // SafeDITool has been installed via homebrew on an ARM Mac.
+            toolPath = PackagePlugin.Path(Self.armMacBrewInstallLocation)
+        } else if FileManager.default.fileExists(atPath: Self.intelMacBrewInstallLocation) {
+            // SafeDITool has been installed via homebrew on an Intel Mac.
+            toolPath = PackagePlugin.Path(Self.intelMacBrewInstallLocation)
+        } else {
+            // Fall back to the just-in-time built tool.
+            toolPath = try context.tool(named: "SafeDITool").path
+        }
+
         return [
             .buildCommand(
                 displayName: "SafeDIGenerateDependencyTree",
-                executable: try context.tool(named: "SafeDITool").path,
+                executable: toolPath,
                 arguments: arguments,
                 environment: [:],
                 inputFiles: targetSwiftFiles + dependenciesSourceFiles,
                 outputFiles: [outputSwiftFile])
         ]
     }
+
+    private static let armMacBrewInstallLocation = "/opt/homebrew/bin/safeditool"
+    private static let intelMacBrewInstallLocation = "/usr/local/bin/safeditool"
 }
 
 extension Target {


### PR DESCRIPTION
This PR was tested by running [this script in ci](https://github.com/dfed/SafeDI/actions/runs/7634224786). It works!

I also made `SafeDIGenerator` capable of utilizing a `brew`-installed external installed `safeditool`.