### PR TITLE
Ensure TypeDescription generates correct source for composite type when subtype has spaces

### DIFF
--- a/Sources/SafeDICore/Models/TypeDescription.swift
+++ b/Sources/SafeDICore/Models/TypeDescription.swift
@@ -168,12 +168,13 @@ public enum TypeDescription: Codable, Hashable, Comparable, Sendable {
     }
 
     public struct TupleElement: Codable, Hashable, Sendable {
+        init(label: String? = nil, _ typeDescription: TypeDescription) {
+            self.label = label
+            self.typeDescription = typeDescription
+        }
+
         public let label: String?
         public let typeDescription: TypeDescription
-
-        static func singleElement(_ typeDescription: TypeDescription) -> Self {
-            self.init(label: nil, typeDescription: typeDescription)
-        }
     }
 
     var isOptional: Bool {
@@ -253,7 +254,7 @@ public enum TypeDescription: Codable, Hashable, Comparable, Sendable {
             self
         case .composition, .some, .any, .attributed, .closure:
             // These types contain spaces and may be ambigous without being wrapped.
-            .tuple([.singleElement(self)])
+            .tuple([.init(self)])
         }
     }
 }
@@ -333,7 +334,7 @@ extension TypeSyntax {
             let elements = typeIdentifier.elements.map {
                 TypeDescription.TupleElement(
                     label: $0.secondName?.text ?? $0.firstName?.text,
-                    typeDescription: $0.type.typeDescription
+                    $0.type.typeDescription
                 )
             }
             if elements.isEmpty {
@@ -436,7 +437,7 @@ extension ExprSyntax {
                 return .tuple(tupleElements.map {
                     TypeDescription.TupleElement(
                         label: $0.label?.text,
-                        typeDescription: $0.expression.typeDescription
+                        $0.expression.typeDescription
                     )
                 })
             }

--- a/Sources/SafeDICore/Models/TypeDescription.swift
+++ b/Sources/SafeDICore/Models/TypeDescription.swift
@@ -246,7 +246,7 @@ public enum TypeDescription: Codable, Hashable, Comparable, Sendable {
         }
     }
 
-    /// A representation of this type that is wrapped in a single element tuple to ensure cohesiveness of the type description. Can be used in source code.
+    /// A representation of this type that may be wrapped in a single element tuple to ensure cohesiveness of the type description.
     private var wrappedIfAmbiguous: Self {
         switch self {
         case .void, .simple, .optional, .implicitlyUnwrappedOptional, .metatype, .nested, .array, .dictionary, .tuple, .unknown:

--- a/Sources/SafeDICore/Models/TypeDescription.swift
+++ b/Sources/SafeDICore/Models/TypeDescription.swift
@@ -117,9 +117,9 @@ public enum TypeDescription: Codable, Hashable, Comparable, Sendable {
                 return type.asSource
             }
         case let .array(element):
-            return "Array<\(element.asSource)>"
+            return "[\(element.asSource)]"
         case let .dictionary(key, value):
-            return "Dictionary<\(key.asSource), \(value.asSource)>"
+            return "[\(key.asSource): \(value.asSource)]"
         case let .tuple(types):
             return """
                 (\(types.map {

--- a/Tests/SafeDICoreTests/TypeDescriptionTests.swift
+++ b/Tests/SafeDICoreTests/TypeDescriptionTests.swift
@@ -258,7 +258,7 @@ final class TypeDescriptionTests: XCTestCase {
 
         let typeDescription = try XCTUnwrap(visitor.arrayTypeIdentifier)
         XCTAssertFalse(typeDescription.isUnknown, "Type description is not of known type!")
-        XCTAssertEqual(typeDescription.asSource, "Array<Int>")
+        XCTAssertEqual(typeDescription.asSource, "[Int]")
     }
 
     func test_typeDescription_whenCalledOnATypeSyntaxNodeRepresentingAnArray_notOfFormArrayTypeSyntax_findsTheType() throws {
@@ -297,7 +297,7 @@ final class TypeDescriptionTests: XCTestCase {
 
         let typeDescription = try XCTUnwrap(visitor.dictionaryTypeIdentifier)
         XCTAssertFalse(typeDescription.isUnknown, "Type description is not of known type!")
-        XCTAssertEqual(typeDescription.asSource, "Dictionary<Int, String>")
+        XCTAssertEqual(typeDescription.asSource, "[Int: String]")
     }
 
     func test_typeDescription_whenCalledOnATypeSyntaxNodeRepresentingADictionary_notOfFormDictionaryTypeSyntax_findsTheType() throws {
@@ -539,7 +539,7 @@ final class TypeDescriptionTests: XCTestCase {
         visitor.walk(Parser.parse(source: content))
         let typeDescription = try XCTUnwrap(visitor.typeDescription)
         XCTAssertFalse(typeDescription.isUnknown, "Type description is not of known type!")
-        XCTAssertEqual(typeDescription.asSource, "Array<Int>")
+        XCTAssertEqual(typeDescription.asSource, "[Int]")
     }
 
     func test_typeDescription_whenCalledOnAExprSyntaxNodeRepresentingADictionaryType_findsTheType() throws {
@@ -550,7 +550,7 @@ final class TypeDescriptionTests: XCTestCase {
         visitor.walk(Parser.parse(source: content))
         let typeDescription = try XCTUnwrap(visitor.typeDescription)
         XCTAssertFalse(typeDescription.isUnknown, "Type description is not of known type!")
-        XCTAssertEqual(typeDescription.asSource, "Dictionary<Int, String>")
+        XCTAssertEqual(typeDescription.asSource, "[Int: String]")
     }
 
     func test_typeDescription_whenCalledOnAExprSyntaxNodeRepresentingATupleTypeWithoutLabels_findsTheType() throws {


### PR DESCRIPTION
After #42 we would improperly generate code for types that _must_ be wrapped within a single-element tuple. Example: an optional closure `() -> Void` would be generated as `() -> Void?` rather than `(() -> Void)?`. This PR ensures that we wrap types in a single-element tuple if they would otherwise be ambiguous.

While I was here, I also got us generating code that fulfills `ArrayTypeSyntax` and `DictionaryTypeSyntax` for the `.array` and `.dictionary` type descriptions.