### PR TITLE
Run CI on visionOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
-      - name: Download visionOS
-        run: xcrun xcodebuild -downloadPlatform visionOS
       - name: Build Framework
         run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination generic/platform=visionos
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,19 @@ jobs:
       - name: Build Framework
         run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination ${{ matrix.platforms }}
 
+  xcodebuild-15-2:
+    name: Build with xcodebuild on Xcode 15 (generic/platform=visionos)
+    runs-on: macos-14
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Select Xcode Version
+        run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+      - name: Download visionOS
+        run: xcrun xcodebuild -downloadPlatform visionOS
+      - name: Build Framework
+        run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination generic/platform=visionos
+
   spm-package-integration-15:
     name: Build Package Integration on Xcode 15
     runs-on: macos-13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,26 +17,16 @@ jobs:
           'platform=macos',
           'generic/platform=tvos',
           'generic/platform=watchos',
+          'generic/platform=visionos'
         ]
       fail-fast: false
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
-      - name: Build Framework
-        run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination ${{ matrix.platforms }}
-
-  xcodebuild-15-2:
-    name: Build with xcodebuild on Xcode 15 (generic/platform=visionos)
-    runs-on: macos-14
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-      - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
       - name: Build Framework
-        run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination generic/platform=visionos
+        run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination ${{ matrix.platforms }}
 
   spm-package-integration-15:
     name: Build Package Integration on Xcode 15
@@ -45,7 +35,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
       - name: Build Package Integration
         run: xcrun swift build -c release --package-path Examples/ExamplePackageIntegration
 
@@ -56,7 +46,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
       - name: Build Project Integration
         run: pushd Examples/ExampleProjectIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExampleProjectIntegration; popd
 
@@ -67,7 +57,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
       - name: Build and Test Framework
         run: xcrun swift test -c release --enable-code-coverage -Xswiftc -enable-testing
       - name: Prepare Coverage Reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   xcodebuild-15:
     name: Build with xcodebuild on Xcode 15
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       matrix:
         platforms: [
@@ -42,7 +42,7 @@ jobs:
 
   spm-package-integration-15:
     name: Build Package Integration on Xcode 15
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
 
   spm-project-integration-15:
     name: Build Project Integration on Xcode 15
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
 
   spm-15:
     name: Build and Test on Xcode 15
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,26 @@ jobs:
           'platform=macos',
           'generic/platform=tvos',
           'generic/platform=watchos',
-          'generic/platform=visionos'
         ]
       fail-fast: false
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
       - name: Build Framework
         run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination ${{ matrix.platforms }}
+
+  xcodebuild-15-2:
+    name: Build with xcodebuild on Xcode 15 (generic/platform=visionos)
+    runs-on: macos-14
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - name: Select Xcode Version
+        run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+      - name: Build Framework
+        run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination generic/platform=visionos
 
   spm-package-integration-15:
     name: Build Package Integration on Xcode 15
@@ -35,7 +45,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
       - name: Build Package Integration
         run: xcrun swift build -c release --package-path Examples/ExamplePackageIntegration
 
@@ -46,7 +56,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
       - name: Build Project Integration
         run: pushd Examples/ExampleProjectIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExampleProjectIntegration; popd
 
@@ -57,7 +67,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app/Contents/Developer
       - name: Build and Test Framework
         run: xcrun swift test -c release --enable-code-coverage -Xswiftc -enable-testing
       - name: Prepare Coverage Reports

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-release-cli:
     name: Build Release CLI
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       matrix:
         architecture: [
@@ -79,7 +79,7 @@ jobs:
 
   bump-cask:
     name: Create Cask Bumping PR
-    runs-on: macos-13
+    runs-on: macos-14
     needs: build-release-cli
     steps:
       - name: Bump Brew Version


### PR DESCRIPTION
We now have [ARM Macs available for open source](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/) so let's try #17 again