### PR TITLE
Always run ExampleProjectIntegration CI against the current branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+      - name: Replace 'main' branch with the current branch
+        run: sed -i '' "s#branch = main;#branch = ${{ github.head_ref || github.ref_name }};#" "Examples/ExampleProjectIntegration/ExampleProjectIntegration.xcodeproj/project.pbxproj"
       - name: Build Project Integration
         run: pushd Examples/ExampleProjectIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExampleProjectIntegration; popd
 


### PR DESCRIPTION
This change enables us to test `ExampleProjectIntegration` in CI against our current branch rather than `main`, which enables us to land breaking changes without breaking `main` for a commit like we did [here](https://github.com/dfed/SafeDI/actions/runs/8584780794).