### PR TITLE
Enable instantiating @MainActor-bound types in Swift 5.10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ public struct MyApp: App, Instantiable {
 }
 ```
 
-An `Instantiator` is `@MainActor`-bound – if you want to instantiate a type in a nonisolated environment, use an [`NonisolatedInstantiator`]](Sources/SafeDI/DelayedInstantiation/NonisolatedInstantiator.swift).
+An `Instantiator` is `@MainActor`-bound – if you want to instantiate a type in a nonisolated environment, use a [`NonisolatedInstantiator`]](Sources/SafeDI/DelayedInstantiation/NonisolatedInstantiator.swift).
 
 #### Utilizing @Instantiated with type erased properties
 
@@ -313,7 +313,7 @@ The `fulfilledByType` parameter takes a `String` identical to the type name of t
 
 The `erasedToConcreteExistential` parameter takes a boolean value that indicates whether the fulfilling type is being erased to a concrete [existential](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/opaquetypes/#Boxed-Protocol-Types) type. A concrete existential type is a non-protocol type that wraps a protocol and is usually prefixed with `Any`. A fulfilling type does not inherit from a concrete existential type, and therefore when the property‘s type is a concrete existential the fulfilling type must be wrapped in the erasing concrete existential type‘s initializer before it is returned. When the property‘s type is not a concrete existential, the fulfilling type is cast as the property‘s type. For example, an `AnyView` is a concrete and existential type-erased form of some `struct MyExampleView: View`, while a `UIViewController` is a concrete but not existential type-erased form of some `final class MyExampleViewController: UIViewController`. This parameter defaults to `false`.
 
-The [`ErasedInstantiator`](Sources/SafeDI/DelayedInstantiation/ErasedInstantiator.swift) type is how SafeDI enables instantiating any `@Instantiable` type when using type erasure. `ErasedInstantiator` has two generics. The first generic must match the type’s `ForwardedProperties` typealias. The second generic matches the type of the to-be-instantiated instance. An `type’s` is `@MainActor`-bound – if you want to instantiate an erased type in a nonisolated environment, use an [`NonisolatedErasedInstantiator`](Sources/SafeDI/DelayedInstantiation/NonisolatedErasedInstantiator.swift).
+The [`ErasedInstantiator`](Sources/SafeDI/DelayedInstantiation/ErasedInstantiator.swift) type is how SafeDI enables instantiating any `@Instantiable` type when using type erasure. `ErasedInstantiator` has two generics. The first generic must match the type’s `ForwardedProperties` typealias. The second generic matches the type of the to-be-instantiated instance. An `ErasedInstantiator` is `@MainActor`-bound – if you want to instantiate an erased type in a nonisolated environment, use a [`NonisolatedErasedInstantiator`](Sources/SafeDI/DelayedInstantiation/NonisolatedErasedInstantiator.swift).
 
 ```swift
 import SwiftUI
@@ -327,7 +327,7 @@ public struct ParentView: View, Instantiable {
         }
     }
 
-    // The Instantiator‘s `instantiate()` function will build a `ChildView` wrapped in a concrete `AnyView`.
+    // The ErasedInstantiator `instantiate()` function will build a `ChildView` wrapped in a concrete `AnyView`.
     // All that is required for this code to compile is for there to be an
     // `@Instantiable public struct ChildView: View` in the codebase.
     @Instantiated(fulfilledByType: "ChildView", erasedToConcreteExistential: true)

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ To install the SafeDI framework into your package with [Swift Package Manager](h
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/dfed/SafeDI", from: "0.4.0"),
+    .package(url: "https://github.com/dfed/SafeDI", from: "0.5.0"),
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The `fulfilledByType` parameter takes a `String` identical to the type name of t
 
 The `erasedToConcreteExistential` parameter takes a boolean value that indicates whether the fulfilling type is being erased to a concrete [existential](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/opaquetypes/#Boxed-Protocol-Types) type. A concrete existential type is a non-protocol type that wraps a protocol and is usually prefixed with `Any`. A fulfilling type does not inherit from a concrete existential type, and therefore when the property‘s type is a concrete existential the fulfilling type must be wrapped in the erasing concrete existential type‘s initializer before it is returned. When the property‘s type is not a concrete existential, the fulfilling type is cast as the property‘s type. For example, an `AnyView` is a concrete and existential type-erased form of some `struct MyExampleView: View`, while a `UIViewController` is a concrete but not existential type-erased form of some `final class MyExampleViewController: UIViewController`. This parameter defaults to `false`.
 
-The [`ErasedInstantiator`](Sources/SafeDI/DelayedInstantiation/ErasedInstantiator.swift) type is how SafeDI enables instantiating any `@Instantiable` type when using type erasure. `ErasedInstantiator` has two generics. The first generic must match the type’s `ForwardedProperties` typealias. The second generic matches the type of the to-be-instantiated instance.
+The [`ErasedInstantiator`](Sources/SafeDI/DelayedInstantiation/ErasedInstantiator.swift) type is how SafeDI enables instantiating any `@Instantiable` type when using type erasure. `ErasedInstantiator` has two generics. The first generic must match the type’s `ForwardedProperties` typealias. The second generic matches the type of the to-be-instantiated instance. An `type’s` is `@MainActor`-bound – if you want to instantiate an erased type in a nonisolated environment, use an [`NonisolatedErasedInstantiator`](Sources/SafeDI/DelayedInstantiation/NonisolatedErasedInstantiator.swift).
 
 ```swift
 import SwiftUI
@@ -332,6 +332,8 @@ public struct MyApp: App, Instantiable {
     private let contentViewInstantiator: Instantiator<ContentView>
 }
 ```
+
+An `Instantiator` is `@MainActor`-bound – if you want to instantiate a type in a nonisolated environment, use an [`NonisolatedInstantiator`]](Sources/SafeDI/DelayedInstantiation/NonisolatedInstantiator.swift).
 
 ### Creating the root of your dependency tree
 

--- a/README.md
+++ b/README.md
@@ -156,36 +156,6 @@ Property declarations within `@Instantiable` types decorated with [`@Instantiate
 
 `@Instantiated`-decorated properties must be an `@Instantiable` type, or of an `additionalType` listed in an `@Instantiable(fulfillingAdditionalTypes:)`‘s declaration.
 
-#### Utilizing @Instantiated with type erased properties
-
-When you want to instantiate a type-erased property, you may specify which concrete type you expect to fulfill your property by utilizing `@Instantiated`‘s `fulfilledByType` and `erasedToConcreteExistential` parameters.
-
-The `fulfilledByType` parameter takes a `String` identical to the type name of the concrete type that will be assigned to the type-erased property. Representing the type as a string literal allows for dependency inversion: the code that receives the concrete type does not need to have a dependency on the module that defines the concrete type.
-
-The `erasedToConcreteExistential` parameter takes a boolean value that indicates whether the fulfilling type is being erased to a concrete [existential](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/opaquetypes/#Boxed-Protocol-Types) type. A concrete existential type is a non-protocol type that wraps a protocol and is usually prefixed with `Any`. A fulfilling type does not inherit from a concrete existential type, and therefore when the property‘s type is a concrete existential the fulfilling type must be wrapped in the erasing concrete existential type‘s initializer before it is returned. When the property‘s type is not a concrete existential, the fulfilling type is cast as the property‘s type. For example, an `AnyView` is a concrete and existential type-erased form of some `struct MyExampleView: View`, while a `UIViewController` is a concrete but not existential type-erased form of some `final class MyExampleViewController: UIViewController`. This parameter defaults to `false`.
-
-The [`ErasedInstantiator`](Sources/SafeDI/DelayedInstantiation/ErasedInstantiator.swift) type is how SafeDI enables instantiating any `@Instantiable` type when using type erasure. `ErasedInstantiator` has two generics. The first generic must match the type’s `ForwardedProperties` typealias. The second generic matches the type of the to-be-instantiated instance. An `type’s` is `@MainActor`-bound – if you want to instantiate an erased type in a nonisolated environment, use an [`NonisolatedErasedInstantiator`](Sources/SafeDI/DelayedInstantiation/NonisolatedErasedInstantiator.swift).
-
-```swift
-import SwiftUI
-
-@Instantiable
-public struct ParentView: View, Instantiable {
-    public var body: some View {
-        VStack {
-            Text("Child View")
-            childViewBuilder.instantiate()
-        }
-    }
-
-    // The Instantiator‘s `instantiate()` function will build a `ChildView` wrapped in a concrete `AnyView`.
-    // All that is required for this code to compile is for there to be an
-    // `@Instantiable public struct ChildView: View` in the codebase.
-    @Instantiated(fulfilledByType: "ChildView", erasedToConcreteExistential: true)
-    private let childViewBuilder: ErasedInstantiator<(), AnyView>
-}
-```
-
 ### @Forwarded
 
 Property declarations within `@Instantiable` types decorated with [`@Forwarded`](Sources/SafeDI/PropertyDecoration/Forwarded.swift) represent dependencies that come from the runtime, e.g. user input or backend-delivered content. Like an `@Instantiated`-decorated property, a `@Forwarded`-decorated property is available to be `@Received` by objects instantiated further down the dependency tree.
@@ -334,6 +304,36 @@ public struct MyApp: App, Instantiable {
 ```
 
 An `Instantiator` is `@MainActor`-bound – if you want to instantiate a type in a nonisolated environment, use an [`NonisolatedInstantiator`]](Sources/SafeDI/DelayedInstantiation/NonisolatedInstantiator.swift).
+
+#### Utilizing @Instantiated with type erased properties
+
+When you want to instantiate a type-erased property, you may specify which concrete type you expect to fulfill your property by utilizing `@Instantiated`‘s `fulfilledByType` and `erasedToConcreteExistential` parameters.
+
+The `fulfilledByType` parameter takes a `String` identical to the type name of the concrete type that will be assigned to the type-erased property. Representing the type as a string literal allows for dependency inversion: the code that receives the concrete type does not need to have a dependency on the module that defines the concrete type.
+
+The `erasedToConcreteExistential` parameter takes a boolean value that indicates whether the fulfilling type is being erased to a concrete [existential](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/opaquetypes/#Boxed-Protocol-Types) type. A concrete existential type is a non-protocol type that wraps a protocol and is usually prefixed with `Any`. A fulfilling type does not inherit from a concrete existential type, and therefore when the property‘s type is a concrete existential the fulfilling type must be wrapped in the erasing concrete existential type‘s initializer before it is returned. When the property‘s type is not a concrete existential, the fulfilling type is cast as the property‘s type. For example, an `AnyView` is a concrete and existential type-erased form of some `struct MyExampleView: View`, while a `UIViewController` is a concrete but not existential type-erased form of some `final class MyExampleViewController: UIViewController`. This parameter defaults to `false`.
+
+The [`ErasedInstantiator`](Sources/SafeDI/DelayedInstantiation/ErasedInstantiator.swift) type is how SafeDI enables instantiating any `@Instantiable` type when using type erasure. `ErasedInstantiator` has two generics. The first generic must match the type’s `ForwardedProperties` typealias. The second generic matches the type of the to-be-instantiated instance. An `type’s` is `@MainActor`-bound – if you want to instantiate an erased type in a nonisolated environment, use an [`NonisolatedErasedInstantiator`](Sources/SafeDI/DelayedInstantiation/NonisolatedErasedInstantiator.swift).
+
+```swift
+import SwiftUI
+
+@Instantiable
+public struct ParentView: View, Instantiable {
+    public var body: some View {
+        VStack {
+            Text("Child View")
+            childViewBuilder.instantiate()
+        }
+    }
+
+    // The Instantiator‘s `instantiate()` function will build a `ChildView` wrapped in a concrete `AnyView`.
+    // All that is required for this code to compile is for there to be an
+    // `@Instantiable public struct ChildView: View` in the codebase.
+    @Instantiated(fulfilledByType: "ChildView", erasedToConcreteExistential: true)
+    private let childViewBuilder: ErasedInstantiator<(), AnyView>
+}
+```
 
 ### Creating the root of your dependency tree
 

--- a/Sources/SafeDI/DelayedInstantiation/ErasedInstantiator.swift
+++ b/Sources/SafeDI/DelayedInstantiation/ErasedInstantiator.swift
@@ -24,12 +24,12 @@
 /// - SeeAlso: `Instantiator`
 public final class ErasedInstantiator<ForwardedProperties, Instantiable> {
     /// - Parameter instantiator: A closure that takes `ForwardedProperties` and returns an instance of `Instantiable`.
-    public init(_ instantiator: @escaping (ForwardedProperties) -> Instantiable) {
+    public init(_ instantiator: @escaping @MainActor (ForwardedProperties) -> Instantiable) {
         self.instantiator = instantiator
     }
 
     /// - Parameter instantiator: A closure that returns an instance of `Instantiable`.
-    public init(_ instantiator: @escaping () -> Instantiable) where ForwardedProperties == Void {
+    public init(_ instantiator: @escaping @MainActor () -> Instantiable) where ForwardedProperties == Void {
         self.instantiator = { _ in instantiator() }
     }
 
@@ -37,6 +37,7 @@ public final class ErasedInstantiator<ForwardedProperties, Instantiable> {
     ///
     /// - Parameter arguments: Arguments required for instantiation.
     /// - Returns: An `Instantiable` instance.
+    @MainActor
     public func instantiate(_ arguments: ForwardedProperties) -> Instantiable {
         instantiator(arguments)
     }
@@ -44,9 +45,10 @@ public final class ErasedInstantiator<ForwardedProperties, Instantiable> {
     /// Instantiates and returns a new instance of the `@Instantiable` type.
     ///
     /// - Returns: An `Instantiable` instance.
+    @MainActor
     public func instantiate() -> Instantiable where ForwardedProperties == Void {
         instantiator(())
     }
 
-    private let instantiator: (ForwardedProperties) -> Instantiable
+    private let instantiator: @MainActor (ForwardedProperties) -> Instantiable
 }

--- a/Sources/SafeDI/DelayedInstantiation/ErasedInstantiator.swift
+++ b/Sources/SafeDI/DelayedInstantiation/ErasedInstantiator.swift
@@ -19,7 +19,9 @@
 // SOFTWARE.
 
 /// A SafeDI dependency designed for the deferred instantiation of a type-erased instance of a
-/// type decorated with `@Instantiable`. Instantiation is thread-safe.
+/// type decorated with `@Instantiable`.
+///
+/// This instantiator can be used to instantiate types that are @MainActor-bound.
 ///
 /// - SeeAlso: `Instantiator`
 public final class ErasedInstantiator<ForwardedProperties, Instantiable> {

--- a/Sources/SafeDI/DelayedInstantiation/ErasedInstantiator.swift
+++ b/Sources/SafeDI/DelayedInstantiation/ErasedInstantiator.swift
@@ -24,6 +24,8 @@
 /// This instantiator can be used to instantiate types that are @MainActor-bound.
 ///
 /// - SeeAlso: `Instantiator`
+/// - SeeAlso: `NonisolatedInstantiator`
+/// - SeeAlso: `NonisolatedErasedInstantiator`
 public final class ErasedInstantiator<ForwardedProperties, Instantiable> {
     /// - Parameter instantiator: A closure that takes `ForwardedProperties` and returns an instance of `Instantiable`.
     public init(_ instantiator: @escaping @MainActor (ForwardedProperties) -> Instantiable) {

--- a/Sources/SafeDI/DelayedInstantiation/Instantiator.swift
+++ b/Sources/SafeDI/DelayedInstantiation/Instantiator.swift
@@ -26,26 +26,28 @@
 /// - SeeAlso: `ErasedInstantiator`
 public final class Instantiator<T: Instantiable> {
     /// - Parameter instantiator: A closure that returns an instance of `Instantiable`.
-    public init(_ instantiator: @escaping (T.ForwardedProperties) -> T) {
+    public init(_ instantiator: @escaping @MainActor (T.ForwardedProperties) -> T) {
         self.instantiator = instantiator
     }
 
     /// - Parameter instantiator: A closure that returns an instance of `Instantiable`.
-    public init(_ instantiator: @escaping () -> T) where T.ForwardedProperties == Void {
+    public init(_ instantiator: @escaping @MainActor () -> T) where T.ForwardedProperties == Void {
         self.instantiator = { _ in instantiator() }
     }
 
     /// Instantiates and returns a new instance of the `@Instantiable` type.
     /// - Returns: An instance of `T`.
+    @MainActor
     public func instantiate(_ forwardedProperties: T.ForwardedProperties) -> T {
         instantiator(forwardedProperties)
     }
 
     /// Instantiates and returns a new instance of the `@Instantiable` type.
     /// - Returns: An instance of `T`.
+    @MainActor
     public func instantiate() -> T where T.ForwardedProperties == Void {
         instantiator(())
     }
 
-    private let instantiator: (T.ForwardedProperties) -> T
+    private let instantiator: @MainActor (T.ForwardedProperties) -> T
 }

--- a/Sources/SafeDI/DelayedInstantiation/Instantiator.swift
+++ b/Sources/SafeDI/DelayedInstantiation/Instantiator.swift
@@ -26,6 +26,8 @@
 /// This instantiator can be used to instantiate types that are @MainActor-bound.
 ///
 /// - SeeAlso: `ErasedInstantiator`
+/// - SeeAlso: `NonisolatedInstantiator`
+/// - SeeAlso: `NonisolatedErasedInstantiator`
 public final class Instantiator<T: Instantiable> {
     /// - Parameter instantiator: A closure that returns an instance of `Instantiable`.
     public init(_ instantiator: @escaping @MainActor (T.ForwardedProperties) -> T) {

--- a/Sources/SafeDI/DelayedInstantiation/NonisolatedErasedInstantiator.swift
+++ b/Sources/SafeDI/DelayedInstantiation/NonisolatedErasedInstantiator.swift
@@ -18,38 +18,37 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/// A SafeDI dependency responsible for the deferred instantiation of an `@Instantiable`-decorated type.
-/// This class facilitates the delayed creation of an `@Instantiable` instance, making it particularly
-/// useful in scenarios where immediate instantiation is not necessary or desirable. `Instantiator`
-/// facilitates control over memory usage and enables just-in-time instantiation.
+/// A SafeDI dependency designed for the deferred instantiation of a type-erased instance of a
+/// type decorated with `@Instantiable`.
 ///
-/// This instantiator can be used to instantiate types that are @MainActor-bound.
+/// This instantiator can be used to instantiate types that are not isolated to any particular actor.
 ///
-/// - SeeAlso: `ErasedInstantiator`
-public final class Instantiator<T: Instantiable> {
-    /// - Parameter instantiator: A closure that returns an instance of `Instantiable`.
-    public init(_ instantiator: @escaping @MainActor (T.ForwardedProperties) -> T) {
+/// - SeeAlso: `NonisolatedInstantiator`
+public final class NonisolatedErasedInstantiator<ForwardedProperties, Instantiable> {
+    /// - Parameter instantiator: A closure that takes `ForwardedProperties` and returns an instance of `Instantiable`.
+    public init(_ instantiator: @escaping (ForwardedProperties) -> Instantiable) {
         self.instantiator = instantiator
     }
 
     /// - Parameter instantiator: A closure that returns an instance of `Instantiable`.
-    public init(_ instantiator: @escaping @MainActor () -> T) where T.ForwardedProperties == Void {
+    public init(_ instantiator: @escaping () -> Instantiable) where ForwardedProperties == Void {
         self.instantiator = { _ in instantiator() }
     }
 
-    /// Instantiates and returns a new instance of the `@Instantiable` type.
-    /// - Returns: An instance of `T`.
-    @MainActor
-    public func instantiate(_ forwardedProperties: T.ForwardedProperties) -> T {
-        instantiator(forwardedProperties)
+    /// Instantiates and returns a new instance of the `@Instantiable` type, using the provided arguments.
+    ///
+    /// - Parameter arguments: Arguments required for instantiation.
+    /// - Returns: An `Instantiable` instance.
+    public func instantiate(_ arguments: ForwardedProperties) -> Instantiable {
+        instantiator(arguments)
     }
 
     /// Instantiates and returns a new instance of the `@Instantiable` type.
-    /// - Returns: An instance of `T`.
-    @MainActor
-    public func instantiate() -> T where T.ForwardedProperties == Void {
+    ///
+    /// - Returns: An `Instantiable` instance.
+    public func instantiate() -> Instantiable where ForwardedProperties == Void {
         instantiator(())
     }
 
-    private let instantiator: @MainActor (T.ForwardedProperties) -> T
+    private let instantiator: (ForwardedProperties) -> Instantiable
 }

--- a/Sources/SafeDI/DelayedInstantiation/NonisolatedErasedInstantiator.swift
+++ b/Sources/SafeDI/DelayedInstantiation/NonisolatedErasedInstantiator.swift
@@ -23,7 +23,9 @@
 ///
 /// This instantiator can be used to instantiate types that are not isolated to any particular actor.
 ///
+/// - SeeAlso: `Instantiator`
 /// - SeeAlso: `NonisolatedInstantiator`
+/// - SeeAlso: `ErasedInstantiator`
 public final class NonisolatedErasedInstantiator<ForwardedProperties, Instantiable> {
     /// - Parameter instantiator: A closure that takes `ForwardedProperties` and returns an instance of `Instantiable`.
     public init(_ instantiator: @escaping (ForwardedProperties) -> Instantiable) {

--- a/Sources/SafeDI/DelayedInstantiation/NonisolatedInstantiator.swift
+++ b/Sources/SafeDI/DelayedInstantiation/NonisolatedInstantiator.swift
@@ -23,33 +23,31 @@
 /// useful in scenarios where immediate instantiation is not necessary or desirable. `Instantiator`
 /// facilitates control over memory usage and enables just-in-time instantiation.
 ///
-/// This instantiator can be used to instantiate types that are @MainActor-bound.
+/// This instantiator can be used to instantiate types that are not isolated to any particular actor.
 ///
-/// - SeeAlso: `ErasedInstantiator`
-public final class Instantiator<T: Instantiable> {
+/// - SeeAlso: `NonisolatedErasedInstantiator`
+public final class NonisolatedInstantiator<T: Instantiable> {
     /// - Parameter instantiator: A closure that returns an instance of `Instantiable`.
-    public init(_ instantiator: @escaping @MainActor (T.ForwardedProperties) -> T) {
+    public init(_ instantiator: @escaping (T.ForwardedProperties) -> T) {
         self.instantiator = instantiator
     }
 
     /// - Parameter instantiator: A closure that returns an instance of `Instantiable`.
-    public init(_ instantiator: @escaping @MainActor () -> T) where T.ForwardedProperties == Void {
+    public init(_ instantiator: @escaping () -> T) where T.ForwardedProperties == Void {
         self.instantiator = { _ in instantiator() }
     }
 
     /// Instantiates and returns a new instance of the `@Instantiable` type.
     /// - Returns: An instance of `T`.
-    @MainActor
     public func instantiate(_ forwardedProperties: T.ForwardedProperties) -> T {
         instantiator(forwardedProperties)
     }
 
     /// Instantiates and returns a new instance of the `@Instantiable` type.
     /// - Returns: An instance of `T`.
-    @MainActor
     public func instantiate() -> T where T.ForwardedProperties == Void {
         instantiator(())
     }
 
-    private let instantiator: @MainActor (T.ForwardedProperties) -> T
+    private let instantiator: (T.ForwardedProperties) -> T
 }

--- a/Sources/SafeDI/DelayedInstantiation/NonisolatedInstantiator.swift
+++ b/Sources/SafeDI/DelayedInstantiation/NonisolatedInstantiator.swift
@@ -25,6 +25,8 @@
 ///
 /// This instantiator can be used to instantiate types that are not isolated to any particular actor.
 ///
+/// - SeeAlso: `Instantiator`
+/// - SeeAlso: `ErasedInstantiator`
 /// - SeeAlso: `NonisolatedErasedInstantiator`
 public final class NonisolatedInstantiator<T: Instantiable> {
     /// - Parameter instantiator: A closure that returns an instance of `Instantiable`.

--- a/Sources/SafeDICore/Generators/DependencyTreeGenerator.swift
+++ b/Sources/SafeDICore/Generators/DependencyTreeGenerator.swift
@@ -232,10 +232,7 @@ public final class DependencyTreeGenerator {
                         continue
                     }
                     let type = dependency.property.propertyType
-                    switch type {
-                    case .erasedInstantiator, .instantiator:
-                        break
-                    case .constant:
+                    if type.isConstant {
                         guard instantiable.dependencies.filter(\.isForwarded).isEmpty else {
                             throw DependencyTreeGeneratorError
                                 .instantiableHasForwardedProperty(

--- a/Sources/SafeDICore/Models/Dependency.swift
+++ b/Sources/SafeDICore/Models/Dependency.swift
@@ -94,4 +94,6 @@ public struct Dependency: Codable, Hashable {
 
     static let instantiatorType = "Instantiator"
     static let erasedInstantiatorType = "ErasedInstantiator"
+    static let nonisolatedInstantiatorType = "NonisolatedInstantiator"
+    static let nonisolatedErasedInstantiatorType = "NonisolatedErasedInstantiator"
 }

--- a/Sources/SafeDICore/Models/Initializer.swift
+++ b/Sources/SafeDICore/Models/Initializer.swift
@@ -268,35 +268,15 @@ public struct Initializer: Codable, Hashable {
 
 extension ConcreteDeclType {
     fileprivate var initializerModifiers: DeclModifierListSyntax {
-        switch self {
-        case .actorType:
-            DeclModifierListSyntax(
-                arrayLiteral: DeclModifierSyntax(
-                    name: TokenSyntax(
-                        TokenKind.identifier("public"),
-                        presence: .present
-                    ),
-                    trailingTrivia: .space
-                )
-            )
-        case .classType, .structType:
-            DeclModifierListSyntax(
-                arrayLiteral: DeclModifierSyntax(
-                    name: TokenSyntax(
-                        TokenKind.identifier("nonisolated"),
-                        presence: .present
-                    ),
-                    trailingTrivia: .space
+        DeclModifierListSyntax(
+            arrayLiteral: DeclModifierSyntax(
+                name: TokenSyntax(
+                    TokenKind.identifier("public"),
+                    presence: .present
                 ),
-                DeclModifierSyntax(
-                    name: TokenSyntax(
-                        TokenKind.identifier("public"),
-                        presence: .present
-                    ),
-                    trailingTrivia: .space
-                )
+                trailingTrivia: .space
             )
-        }
+        )
     }
 }
 

--- a/Sources/SafeDICore/Models/Property.swift
+++ b/Sources/SafeDICore/Models/Property.swift
@@ -136,7 +136,7 @@ public struct Property: Codable, Hashable, Comparable, Sendable {
         /// An `Instantiator` property.
         /// The instantiated product is not forwarded down the dependency tree. This is done intentionally to avoid unexpected retains.
         case instantiator
-        /// A `ErasedInstantiator` property.
+        /// An `ErasedInstantiator` property.
         /// The instantiated product is not forwarded down the dependency tree. This is done intentionally to avoid unexpected retains.
         case erasedInstantiator
         /// A `NonisolatedInstantiator` property.

--- a/Sources/SafeDICore/Models/Property.swift
+++ b/Sources/SafeDICore/Models/Property.swift
@@ -139,30 +139,45 @@ public struct Property: Codable, Hashable, Comparable, Sendable {
         /// A `ErasedInstantiator` property.
         /// The instantiated product is not forwarded down the dependency tree. This is done intentionally to avoid unexpected retains.
         case erasedInstantiator
+        /// A `NonisolatedInstantiator` property.
+        /// The instantiated product is not forwarded down the dependency tree. This is done intentionally to avoid unexpected retains.
+        case nonisolatedInstantiator
+        /// A `NonisolatedErasedInstantiator` property.
+        /// The instantiated product is not forwarded down the dependency tree. This is done intentionally to avoid unexpected retains.
+        case nonisolatedErasedInstantiator
 
         public var isConstant: Bool {
             switch self {
             case .constant:
                 true
-            case .instantiator, .erasedInstantiator:
+            case .instantiator, .erasedInstantiator, .nonisolatedInstantiator, .nonisolatedErasedInstantiator:
                 false
             }
         }
 
         public var isInstantiator: Bool {
             switch self {
-            case .instantiator:
+            case .instantiator, .nonisolatedInstantiator:
                 true
-            case .constant, .erasedInstantiator:
+            case .constant, .erasedInstantiator, .nonisolatedErasedInstantiator:
                 false
             }
         }
 
         public var isErasedInstantiator: Bool {
             switch self {
-            case .erasedInstantiator:
+            case .erasedInstantiator, .nonisolatedErasedInstantiator:
                 true
-            case .constant, .instantiator:
+            case .constant, .instantiator, .nonisolatedInstantiator:
+                false
+            }
+        }
+
+        public var isMainActorBound: Bool {
+            switch self {
+            case .instantiator, .erasedInstantiator:
+                true
+            case .constant, .nonisolatedInstantiator, .nonisolatedErasedInstantiator:
                 false
             }
         }

--- a/Sources/SafeDICore/Models/TypeDescription.swift
+++ b/Sources/SafeDICore/Models/TypeDescription.swift
@@ -184,6 +184,10 @@ public enum TypeDescription: Codable, Hashable, Comparable, Sendable {
                 return .instantiator
             } else if name == Dependency.erasedInstantiatorType {
                 return .erasedInstantiator
+            } else if name == Dependency.nonisolatedInstantiatorType {
+                return .nonisolatedInstantiator
+            } else if name == Dependency.nonisolatedErasedInstantiatorType {
+                return .nonisolatedErasedInstantiator
             } else {
                 return .constant
             }
@@ -244,11 +248,15 @@ public enum TypeDescription: Codable, Hashable, Comparable, Sendable {
     var asInstantiatedType: TypeDescription {
         switch self {
         case let .simple(name, generics):
-            if name == Dependency.instantiatorType, let builtType = generics.first {
+            if name == Dependency.instantiatorType || name == Dependency.nonisolatedInstantiatorType,
+               let builtType = generics.first
+            {
                 // This is a type that is lazily instantiated.
                 // The first generic is the built type.
                 return builtType
-            } else if name == Dependency.erasedInstantiatorType, let builtType = generics.dropFirst().first {
+            } else if name == Dependency.erasedInstantiatorType || name == Dependency.nonisolatedErasedInstantiatorType,
+                      let builtType = generics.dropFirst().first
+            {
                 // This is a type that is lazily instantiated with explicitly declared forwarded arguments due to type erasure.
                 // The second generic is the built type.
                 return builtType

--- a/Sources/SafeDIMacros/Macros/InjectableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InjectableMacro.swift
@@ -144,13 +144,13 @@ public struct InjectableMacro: PeerMacro {
             case .fulfilledByDependencyNamedInvalidType:
                 "The argument `fulfilledByDependencyNamed` must be a string literal"
             case .fulfilledByTypeUseOnInstantiator:
-                "The argument `fulfilledByType` can not be used on an Instantiator. Use an `ErasedInstantiator` instead"
+                "The argument `fulfilledByType` can not be used on an `Instantiator` or `NonisolatedInstantiator`. Use an `ErasedInstantiator` or `NonisolatedErasedInstantiator` instead"
             case .ofTypeArgumentInvalidType:
                 "The argument `ofType` must be a type literal"
             case .erasedToConcreteExistentialInvalidType:
                 "The argument `erasedToConcreteExistential` must be a bool literal"
             case .erasedInstantiatorUsedWithoutFulfilledByType:
-                "An `ErasedInstantiator` cannot be used without the argument `fulfilledByType`"
+                "`ErasedInstantiator` and `NonisolatedErasedInstantiator` cannot be used without the argument `fulfilledByType`"
             }
         }
     }

--- a/Sources/SafeDIMacros/Macros/InjectableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InjectableMacro.swift
@@ -150,7 +150,7 @@ public struct InjectableMacro: PeerMacro {
             case .erasedToConcreteExistentialInvalidType:
                 "The argument `erasedToConcreteExistential` must be a bool literal"
             case .erasedInstantiatorUsedWithoutFulfilledByType:
-                "`ErasedInstantiator` and `NonisolatedErasedInstantiator` cannot be used without the argument `fulfilledByType`"
+                "`ErasedInstantiator` and `NonisolatedErasedInstantiator` require use of the argument `fulfilledByType`"
             }
         }
     }

--- a/Tests/SafeDIMacrosTests/InjectableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InjectableMacroTests.swift
@@ -149,7 +149,7 @@ final class InjectableMacroTests: XCTestCase {
             public struct ExampleService {
                 @Instantiated(fulfilledByType: "LoginViewController")
                 ┬────────────────────────────────────────────────────
-                ╰─ 🛑 The argument `fulfilledByType` can not be used on an Instantiator. Use an `ErasedInstantiator` instead
+                ╰─ 🛑 The argument `fulfilledByType` can not be used on an `Instantiator` or `NonisolatedInstantiator`. Use an `ErasedInstantiator` or `NonisolatedErasedInstantiator` instead
                 let loginViewControllerBuilder: Instantiator<UIViewController>
             }
             """
@@ -169,7 +169,7 @@ final class InjectableMacroTests: XCTestCase {
             public struct ExampleService {
                 @Instantiated
                 ┬────────────
-                ╰─ 🛑 An `ErasedInstantiator` cannot be used without the argument `fulfilledByType`
+                ╰─ 🛑 `ErasedInstantiator` and `NonisolatedErasedInstantiator` cannot be used without the argument `fulfilledByType`
                 let loginViewControllerBuilder: ErasedInstantiator<UIViewController>
             }
             """

--- a/Tests/SafeDIMacrosTests/InjectableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InjectableMacroTests.swift
@@ -169,7 +169,7 @@ final class InjectableMacroTests: XCTestCase {
             public struct ExampleService {
                 @Instantiated
                 ┬────────────
-                ╰─ 🛑 `ErasedInstantiator` and `NonisolatedErasedInstantiator` cannot be used without the argument `fulfilledByType`
+                ╰─ 🛑 `ErasedInstantiator` and `NonisolatedErasedInstantiator` require use of the argument `fulfilledByType`
                 let loginViewControllerBuilder: ErasedInstantiator<UIViewController>
             }
             """

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -74,7 +74,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init() {
+                public init() {
                 }
             }
             """
@@ -97,7 +97,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init() {
+                public init() {
                 }
             }
             """
@@ -162,7 +162,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init() {
+                public init() {
                 }
             }
             """
@@ -187,7 +187,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init() {
+                public init() {
                 }
             }
             """
@@ -374,7 +374,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init(instantiatedA: InstantiatedA) {
+                public init(instantiatedA: InstantiatedA) {
                     self.instantiatedA = instantiatedA
                 }
             }
@@ -429,7 +429,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init(instantiatedA: InstantiatedA) {
+                public init(instantiatedA: InstantiatedA) {
                     self.instantiatedA = instantiatedA
                 }
             }
@@ -460,7 +460,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init(instantiatedA: InstantiatedA) {
+                public init(instantiatedA: InstantiatedA) {
                     self.instantiatedA = instantiatedA
                 }
             }
@@ -491,7 +491,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init(instantiatedA: InstantiatedA) {
+                public init(instantiatedA: InstantiatedA) {
                     self.instantiatedA = instantiatedA
                 }
             }
@@ -522,7 +522,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init(instantiatedA: InstantiatedA) {
+                public init(instantiatedA: InstantiatedA) {
                     self.instantiatedA = instantiatedA
                 }
             }
@@ -555,7 +555,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init(instantiatedA: InstantiatedA) {
+                public init(instantiatedA: InstantiatedA) {
                     self.instantiatedA = instantiatedA
                 }
             }
@@ -599,7 +599,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init(forwardedA: ForwardedA, receivedA: ReceivedA, receivedB: ReceivedB) {
+                public init(forwardedA: ForwardedA, receivedA: ReceivedA, receivedB: ReceivedB) {
                     self.forwardedA = forwardedA
                     self.receivedA = receivedA
                     self.receivedB = receivedB
@@ -659,7 +659,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init(userID: String, userName: String) {
+                public init(userID: String, userName: String) {
                     self.userID = userID
                     self.userName = userName
                 }
@@ -689,7 +689,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init(closure: @escaping () -> Void) {
+                public init(closure: @escaping () -> Void) {
                     self.closure = closure
                 }
 
@@ -718,7 +718,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init(closure: @escaping @Sendable () -> Void) {
+                public init(closure: @escaping @Sendable () -> Void) {
                     self.closure = closure
                 }
 
@@ -747,7 +747,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init(instantiatableAInstantiator: Instantiator<ReceivedA>) {
+                public init(instantiatableAInstantiator: Instantiator<ReceivedA>) {
                     self.instantiatableAInstantiator = instantiatableAInstantiator
                 }
             }
@@ -920,7 +920,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init() {
+                public init() {
                 }
             }
             """
@@ -962,7 +962,7 @@ final class InstantiableMacroTests: XCTestCase {
                 // As a result, this initializer can not be used within a #Preview macro closure.
                 // This initializer is only generated because you have not written this macro yourself.
                 // Copy/pasting this generated initializer into your code will enable this initializer to be used within other Swift Macros.
-                nonisolated public init() {
+                public init() {
                 }
             }
             """
@@ -1441,7 +1441,7 @@ final class InstantiableMacroTests: XCTestCase {
             """
             @Instantiable
             public struct ExampleService: Instantiable {
-            nonisolated public init() {
+            public init() {
             // If the following properties were decorated with the @Instantiated, @Received, or @Forwarded macros, had default values, or were written as computed properties, this initializer could have been auto-generated by the @Instantiable macro.
             uninitializedProperty = <#T##assign_uninitializedProperty#>
             }
@@ -1452,7 +1452,7 @@ final class InstantiableMacroTests: XCTestCase {
         } expansion: {
             """
             public struct ExampleService: Instantiable {
-            nonisolated public init() {
+            public init() {
             // If the following properties were decorated with the @Instantiated, @Received, or @Forwarded macros, had default values, or were written as computed properties, this initializer could have been auto-generated by the @Instantiable macro.
             uninitializedProperty = <#T##assign_uninitializedProperty#>
             }
@@ -1490,7 +1490,7 @@ final class InstantiableMacroTests: XCTestCase {
             """
             @Instantiable
             public struct ExampleService: Instantiable {
-            nonisolated public init(receivedA: ReceivedA) {
+            public init(receivedA: ReceivedA) {
             self.receivedA = receivedA
             // If the following properties were decorated with the @Instantiated, @Received, or @Forwarded macros, had default values, or were written as computed properties, this initializer could have been auto-generated by the @Instantiable macro.
             uninitializedProperty = <#T##assign_uninitializedProperty#>
@@ -1505,7 +1505,7 @@ final class InstantiableMacroTests: XCTestCase {
         } expansion: {
             """
             public struct ExampleService: Instantiable {
-            nonisolated public init(receivedA: ReceivedA) {
+            public init(receivedA: ReceivedA) {
             self.receivedA = receivedA
             // If the following properties were decorated with the @Instantiated, @Received, or @Forwarded macros, had default values, or were written as computed properties, this initializer could have been auto-generated by the @Instantiable macro.
             uninitializedProperty = <#T##assign_uninitializedProperty#>
@@ -1549,7 +1549,7 @@ final class InstantiableMacroTests: XCTestCase {
             """
             @Instantiable
             public struct ExampleService: Instantiable {
-            nonisolated public init(receivedA: ReceivedA) {
+            public init(receivedA: ReceivedA) {
             self.receivedA = receivedA
             // If the following properties were decorated with the @Instantiated, @Received, or @Forwarded macros, had default values, or were written as computed properties, this initializer could have been auto-generated by the @Instantiable macro.
             uninitializedProperty1 = <#T##assign_uninitializedProperty1#>
@@ -1569,7 +1569,7 @@ final class InstantiableMacroTests: XCTestCase {
         } expansion: {
             """
             public struct ExampleService: Instantiable {
-            nonisolated public init(receivedA: ReceivedA) {
+            public init(receivedA: ReceivedA) {
             self.receivedA = receivedA
             // If the following properties were decorated with the @Instantiated, @Received, or @Forwarded macros, had default values, or were written as computed properties, this initializer could have been auto-generated by the @Instantiable macro.
             uninitializedProperty1 = <#T##assign_uninitializedProperty1#>

--- a/Tests/SafeDITests/ErasedInstantiatorTests.swift
+++ b/Tests/SafeDITests/ErasedInstantiatorTests.swift
@@ -23,6 +23,7 @@ import XCTest
 @testable import SafeDI
 
 final class ErasedInstantiatorTests: XCTestCase {
+    @MainActor
     func test_instantiate_returnsNewObjectEachTime() {
         let systemUnderTest = ErasedInstantiator() { id in BuiltProduct(id: id) }
         let id = UUID().uuidString

--- a/Tests/SafeDITests/ErasedInstantiatorTests.swift
+++ b/Tests/SafeDITests/ErasedInstantiatorTests.swift
@@ -50,7 +50,7 @@ final class ErasedInstantiatorTests: XCTestCase {
         let id: String
     }
 
-    private final class BuiltProductWithForwardedArgument: Equatable, Identifiable, Instantiable {
+    private final class BuiltProductWithForwardedArgument: Equatable, Identifiable {
         init(id: String) {
             self.id = id
         }

--- a/Tests/SafeDITests/ErasedInstantiatorTests.swift
+++ b/Tests/SafeDITests/ErasedInstantiatorTests.swift
@@ -25,10 +25,9 @@ import XCTest
 final class ErasedInstantiatorTests: XCTestCase {
     func test_instantiate_returnsNewObjectEachTime() async {
         await Task { @MainActor in
-            let systemUnderTest = ErasedInstantiator() { id in BuiltProduct(id: id) }
-            let id = UUID().uuidString
-            let firstBuiltProduct = systemUnderTest.instantiate(id)
-            let secondBuiltProduct = systemUnderTest.instantiate(id)
+            let systemUnderTest = ErasedInstantiator<Void, BuiltProduct>() { BuiltProduct() }
+            let firstBuiltProduct = systemUnderTest.instantiate()
+            let secondBuiltProduct = systemUnderTest.instantiate()
             XCTAssertFalse(firstBuiltProduct === secondBuiltProduct)
         }.value
     }
@@ -36,30 +35,23 @@ final class ErasedInstantiatorTests: XCTestCase {
     func test_instantiate_withForwardedArgument_returnsNewObjectEachTime() async {
         await Task { @MainActor in
             let systemUnderTest = ErasedInstantiator() { id in BuiltProductWithForwardedArgument(id: id) }
-            let firstBuiltProduct = systemUnderTest.instantiate("12345")
-            let secondBuiltProduct = systemUnderTest.instantiate("54321")
-            XCTAssertNotEqual(firstBuiltProduct, secondBuiltProduct)
+            let id = UUID().uuidString
+            let firstBuiltProduct = systemUnderTest.instantiate(id)
+            let secondBuiltProduct = systemUnderTest.instantiate(id)
+            XCTAssertFalse(firstBuiltProduct === secondBuiltProduct)
         }.value
     }
 
-    private final class BuiltProduct: Identifiable {
-        init(id: String) {
-            self.id = id
-        }
-
-        let id: String
+    private final class BuiltProduct {
+        let id = UUID().uuidString
     }
 
-    private final class BuiltProductWithForwardedArgument: Equatable, Identifiable {
+    private final class BuiltProductWithForwardedArgument {
         init(id: String) {
             self.id = id
         }
 
         typealias ForwardedProperties = String
-
-        static func == (lhs: BuiltProductWithForwardedArgument, rhs: BuiltProductWithForwardedArgument) -> Bool {
-            lhs.id == rhs.id
-        }
 
         @Forwarded
         let id: String

--- a/Tests/SafeDITests/InstantiatorTests.swift
+++ b/Tests/SafeDITests/InstantiatorTests.swift
@@ -23,6 +23,7 @@ import XCTest
 @testable import SafeDI
 
 final class InstantiatorTests: XCTestCase {
+    @MainActor
     func test_instantiate_returnsNewObjectEachTime() {
         let systemUnderTest = Instantiator() { BuiltProduct() }
         let firstBuiltProduct = systemUnderTest.instantiate()
@@ -30,6 +31,7 @@ final class InstantiatorTests: XCTestCase {
         XCTAssertNotEqual(firstBuiltProduct, secondBuiltProduct)
     }
 
+    @MainActor
     func test_instantiate_withForwardedArgument_returnsNewObjectEachTime() {
         let systemUnderTest = Instantiator() { id in BuiltProductWithForwardedArgument(id: id) }
         let firstBuiltProduct = systemUnderTest.instantiate("12345")

--- a/Tests/SafeDITests/InstantiatorTests.swift
+++ b/Tests/SafeDITests/InstantiatorTests.swift
@@ -28,37 +28,30 @@ final class InstantiatorTests: XCTestCase {
             let systemUnderTest = Instantiator() { BuiltProduct() }
             let firstBuiltProduct = systemUnderTest.instantiate()
             let secondBuiltProduct = systemUnderTest.instantiate()
-            XCTAssertNotEqual(firstBuiltProduct, secondBuiltProduct)
+            XCTAssertFalse(firstBuiltProduct === secondBuiltProduct)
         }.value
     }
 
     func test_instantiate_withForwardedArgument_returnsNewObjectEachTime() async {
         await Task { @MainActor in
             let systemUnderTest = Instantiator() { id in BuiltProductWithForwardedArgument(id: id) }
-            let firstBuiltProduct = systemUnderTest.instantiate("12345")
-            let secondBuiltProduct = systemUnderTest.instantiate("54321")
-            XCTAssertNotEqual(firstBuiltProduct, secondBuiltProduct)
+            let id = UUID().uuidString
+            let firstBuiltProduct = systemUnderTest.instantiate(id)
+            let secondBuiltProduct = systemUnderTest.instantiate(id)
+            XCTAssertFalse(firstBuiltProduct === secondBuiltProduct)
         }.value
     }
 
-    private final class BuiltProduct: Equatable, Identifiable, Instantiable {
-        static func == (lhs: BuiltProduct, rhs: BuiltProduct) -> Bool {
-            lhs.id == rhs.id
-        }
-
+    private final class BuiltProduct: Instantiable {
         let id = UUID().uuidString
     }
 
-    private final class BuiltProductWithForwardedArgument: Equatable, Identifiable, Instantiable {
+    private final class BuiltProductWithForwardedArgument: Instantiable {
         init(id: String) {
             self.id = id
         }
 
         typealias ForwardedProperties = String
-
-        static func == (lhs: BuiltProductWithForwardedArgument, rhs: BuiltProductWithForwardedArgument) -> Bool {
-            lhs.id == rhs.id
-        }
 
         @Forwarded
         let id: String

--- a/Tests/SafeDITests/InstantiatorTests.swift
+++ b/Tests/SafeDITests/InstantiatorTests.swift
@@ -23,20 +23,22 @@ import XCTest
 @testable import SafeDI
 
 final class InstantiatorTests: XCTestCase {
-    @MainActor
-    func test_instantiate_returnsNewObjectEachTime() {
-        let systemUnderTest = Instantiator() { BuiltProduct() }
-        let firstBuiltProduct = systemUnderTest.instantiate()
-        let secondBuiltProduct = systemUnderTest.instantiate()
-        XCTAssertNotEqual(firstBuiltProduct, secondBuiltProduct)
+    func test_instantiate_returnsNewObjectEachTime() async {
+        await Task { @MainActor in
+            let systemUnderTest = Instantiator() { BuiltProduct() }
+            let firstBuiltProduct = systemUnderTest.instantiate()
+            let secondBuiltProduct = systemUnderTest.instantiate()
+            XCTAssertNotEqual(firstBuiltProduct, secondBuiltProduct)
+        }.value
     }
 
-    @MainActor
-    func test_instantiate_withForwardedArgument_returnsNewObjectEachTime() {
-        let systemUnderTest = Instantiator() { id in BuiltProductWithForwardedArgument(id: id) }
-        let firstBuiltProduct = systemUnderTest.instantiate("12345")
-        let secondBuiltProduct = systemUnderTest.instantiate("54321")
-        XCTAssertNotEqual(firstBuiltProduct, secondBuiltProduct)
+    func test_instantiate_withForwardedArgument_returnsNewObjectEachTime() async {
+        await Task { @MainActor in
+            let systemUnderTest = Instantiator() { id in BuiltProductWithForwardedArgument(id: id) }
+            let firstBuiltProduct = systemUnderTest.instantiate("12345")
+            let secondBuiltProduct = systemUnderTest.instantiate("54321")
+            XCTAssertNotEqual(firstBuiltProduct, secondBuiltProduct)
+        }.value
     }
 
     private final class BuiltProduct: Equatable, Identifiable, Instantiable {

--- a/Tests/SafeDITests/NonisolatedErasedInstantiatorTests.swift
+++ b/Tests/SafeDITests/NonisolatedErasedInstantiatorTests.swift
@@ -24,38 +24,30 @@ import XCTest
 
 final class NonisolatedErasedInstantiatorTests: XCTestCase {
     func test_instantiate_returnsNewObjectEachTime() {
-        let systemUnderTest = NonisolatedErasedInstantiator() { id in BuiltProduct(id: id) }
+        let systemUnderTest = NonisolatedErasedInstantiator<Void, BuiltProduct>() { BuiltProduct() }
+        let firstBuiltProduct = systemUnderTest.instantiate()
+        let secondBuiltProduct = systemUnderTest.instantiate()
+        XCTAssertFalse(firstBuiltProduct === secondBuiltProduct)
+    }
+
+    func test_instantiate_withForwardedArgument_returnsNewObjectEachTime() {
+        let systemUnderTest = NonisolatedErasedInstantiator() { id in BuiltProductWithForwardedArgument(id: id) }
         let id = UUID().uuidString
         let firstBuiltProduct = systemUnderTest.instantiate(id)
         let secondBuiltProduct = systemUnderTest.instantiate(id)
         XCTAssertFalse(firstBuiltProduct === secondBuiltProduct)
     }
 
-    func test_instantiate_withForwardedArgument_returnsNewObjectEachTime() {
-        let systemUnderTest = NonisolatedErasedInstantiator() { id in BuiltProductWithForwardedArgument(id: id) }
-        let firstBuiltProduct = systemUnderTest.instantiate("12345")
-        let secondBuiltProduct = systemUnderTest.instantiate("54321")
-        XCTAssertNotEqual(firstBuiltProduct, secondBuiltProduct)
+    private final class BuiltProduct {
+        let id = UUID().uuidString
     }
 
-    private final class BuiltProduct: Identifiable {
-        init(id: String) {
-            self.id = id
-        }
-
-        let id: String
-    }
-
-    private final class BuiltProductWithForwardedArgument: Equatable, Identifiable {
+    private final class BuiltProductWithForwardedArgument {
         init(id: String) {
             self.id = id
         }
 
         typealias ForwardedProperties = String
-
-        static func == (lhs: BuiltProductWithForwardedArgument, rhs: BuiltProductWithForwardedArgument) -> Bool {
-            lhs.id == rhs.id
-        }
 
         @Forwarded
         let id: String

--- a/Tests/SafeDITests/NonisolatedErasedInstantiatorTests.swift
+++ b/Tests/SafeDITests/NonisolatedErasedInstantiatorTests.swift
@@ -1,0 +1,63 @@
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+
+@testable import SafeDI
+
+final class NonisolatedErasedInstantiatorTests: XCTestCase {
+    func test_instantiate_returnsNewObjectEachTime() {
+        let systemUnderTest = NonisolatedErasedInstantiator() { id in BuiltProduct(id: id) }
+        let id = UUID().uuidString
+        let firstBuiltProduct = systemUnderTest.instantiate(id)
+        let secondBuiltProduct = systemUnderTest.instantiate(id)
+        XCTAssertFalse(firstBuiltProduct === secondBuiltProduct)
+    }
+
+    func test_instantiate_withForwardedArgument_returnsNewObjectEachTime() {
+        let systemUnderTest = NonisolatedErasedInstantiator() { id in BuiltProductWithForwardedArgument(id: id) }
+        let firstBuiltProduct = systemUnderTest.instantiate("12345")
+        let secondBuiltProduct = systemUnderTest.instantiate("54321")
+        XCTAssertNotEqual(firstBuiltProduct, secondBuiltProduct)
+    }
+
+    private final class BuiltProduct: Identifiable {
+        init(id: String) {
+            self.id = id
+        }
+
+        let id: String
+    }
+
+    private final class BuiltProductWithForwardedArgument: Equatable, Identifiable {
+        init(id: String) {
+            self.id = id
+        }
+
+        typealias ForwardedProperties = String
+
+        static func == (lhs: BuiltProductWithForwardedArgument, rhs: BuiltProductWithForwardedArgument) -> Bool {
+            lhs.id == rhs.id
+        }
+
+        @Forwarded
+        let id: String
+    }
+}

--- a/Tests/SafeDITests/NonisolatedInstantiatorTests.swift
+++ b/Tests/SafeDITests/NonisolatedInstantiatorTests.swift
@@ -1,0 +1,66 @@
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+
+@testable import SafeDI
+
+final class NonisolatedInstantiatorTests: XCTestCase {
+    func test_instantiate_returnsNewObjectEachTime() async {
+        await Task { @MainActor in
+            let systemUnderTest = Instantiator() { BuiltProduct() }
+            let firstBuiltProduct = systemUnderTest.instantiate()
+            let secondBuiltProduct = systemUnderTest.instantiate()
+            XCTAssertNotEqual(firstBuiltProduct, secondBuiltProduct)
+        }.value
+    }
+
+    func test_instantiate_withForwardedArgument_returnsNewObjectEachTime() async {
+        await Task { @MainActor in
+            let systemUnderTest = Instantiator() { id in BuiltProductWithForwardedArgument(id: id) }
+            let firstBuiltProduct = systemUnderTest.instantiate("12345")
+            let secondBuiltProduct = systemUnderTest.instantiate("54321")
+            XCTAssertNotEqual(firstBuiltProduct, secondBuiltProduct)
+        }.value
+    }
+
+    private final class BuiltProduct: Equatable, Identifiable, Instantiable {
+        static func == (lhs: BuiltProduct, rhs: BuiltProduct) -> Bool {
+            lhs.id == rhs.id
+        }
+
+        let id = UUID().uuidString
+    }
+
+    private final class BuiltProductWithForwardedArgument: Equatable, Identifiable, Instantiable {
+        init(id: String) {
+            self.id = id
+        }
+
+        typealias ForwardedProperties = String
+
+        static func == (lhs: BuiltProductWithForwardedArgument, rhs: BuiltProductWithForwardedArgument) -> Bool {
+            lhs.id == rhs.id
+        }
+
+        @Forwarded
+        let id: String
+    }
+}

--- a/Tests/SafeDIToolTests/SafeDIToolTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolTests.swift
@@ -488,7 +488,7 @@ final class SafeDIToolTests: XCTestCase {
                 public convenience init() {
                     let networkService: NetworkService = DefaultNetworkService()
                     let authService: AuthService = DefaultAuthService(networkService: networkService)
-                    func __safeDI_loggedInViewControllerBuilder(user: User) -> LoggedInViewController {
+                    @MainActor func __safeDI_loggedInViewControllerBuilder(user: User) -> LoggedInViewController {
                         LoggedInViewController(user: user, networkService: networkService)
                     }
                     let loggedInViewControllerBuilder = ErasedInstantiator<User, UIViewController> {
@@ -602,7 +602,7 @@ final class SafeDIToolTests: XCTestCase {
                 public convenience init() {
                     let networkService: NetworkService = DefaultNetworkService()
                     let authService: AuthService = DefaultAuthService(networkService: networkService)
-                    func __safeDI_loggedInViewControllerBuilder(user: User) -> LoggedInViewController {
+                    @MainActor func __safeDI_loggedInViewControllerBuilder(user: User) -> LoggedInViewController {
                         let userService = UserService(user: user)
                         return LoggedInViewController(user: user, networkService: networkService, userService: userService)
                     }
@@ -726,7 +726,7 @@ final class SafeDIToolTests: XCTestCase {
                 public convenience init() {
                     let networkService: NetworkService = DefaultNetworkService()
                     let authService: AuthService = DefaultAuthService(networkService: networkService)
-                    func __safeDI_loggedInViewControllerBuilder(userID: String, userName: String) -> LoggedInViewController {
+                    @MainActor func __safeDI_loggedInViewControllerBuilder(userID: String, userName: String) -> LoggedInViewController {
                         let userService = UserService(userName: userName, userID: userID)
                         return LoggedInViewController(userName: userName, userID: userID, networkService: networkService, userService: userService)
                     }
@@ -850,7 +850,7 @@ final class SafeDIToolTests: XCTestCase {
                 public convenience init() {
                     let networkService: NetworkService = DefaultNetworkService()
                     let authService: AuthService = DefaultAuthService(networkService: networkService)
-                    func __safeDI_loggedInViewControllerBuilder(userID: String, userName: String) -> LoggedInViewController {
+                    @MainActor func __safeDI_loggedInViewControllerBuilder(userID: String, userName: String) -> LoggedInViewController {
                         let userService = UserService(userName: userName, userID: userID)
                         return LoggedInViewController(userName: userName, userID: userID, networkService: networkService, userService: userService)
                     }
@@ -950,7 +950,7 @@ final class SafeDIToolTests: XCTestCase {
 
             extension RootView {
                 public init() {
-                    func __safeDI_splashScreenViewBuilder() -> SplashScreenView {
+                    @MainActor func __safeDI_splashScreenViewBuilder() -> SplashScreenView {
                         SplashScreenView()
                     }
                     let splashScreenViewBuilder = ErasedInstantiator<(), AnyView> {
@@ -1064,7 +1064,7 @@ final class SafeDIToolTests: XCTestCase {
                 public convenience init() {
                     let networkService: NetworkService = DefaultNetworkService()
                     let authService: AuthService = DefaultAuthService(networkService: networkService)
-                    func __safeDI_loggedInViewControllerBuilder(user: User) -> LoggedInViewController {
+                    @MainActor func __safeDI_loggedInViewControllerBuilder(user: User) -> LoggedInViewController {
                         let userService = UserService(user: user, networkService: networkService)
                         return LoggedInViewController(user: user, userService: userService)
                     }
@@ -1179,8 +1179,8 @@ final class SafeDIToolTests: XCTestCase {
                 public convenience init() {
                     let networkService: NetworkService = DefaultNetworkService()
                     let authService: AuthService = DefaultAuthService(networkService: networkService)
-                    func __safeDI_loggedInViewControllerBuilder(user: User) -> LoggedInViewController {
-                        func __safeDI_userServiceInstantiator() -> UserService {
+                    @MainActor func __safeDI_loggedInViewControllerBuilder(user: User) -> LoggedInViewController {
+                        @MainActor func __safeDI_userServiceInstantiator() -> UserService {
                             UserService(user: user, networkService: networkService)
                         }
                         let userServiceInstantiator = Instantiator<UserService>(__safeDI_userServiceInstantiator)
@@ -1974,7 +1974,7 @@ final class SafeDIToolTests: XCTestCase {
 
             extension Root {
                 public convenience init() {
-                    func __safeDI_childABuilder(recreated: Recreated) -> ChildA {
+                    @MainActor func __safeDI_childABuilder(recreated: Recreated) -> ChildA {
                         let grandchildA: GrandchildA = {
                             let recreated = Recreated()
                             let greatGrandchild = GreatGrandchild(recreated: recreated)
@@ -2297,7 +2297,7 @@ final class SafeDIToolTests: XCTestCase {
                 public convenience init() {
                     let networkService: NetworkService = DefaultNetworkService()
                     let authService: AuthService = DefaultAuthService(networkService: networkService)
-                    func __safeDI_loggedInViewControllerBuilder(user: User) -> LoggedInViewController {
+                    @MainActor func __safeDI_loggedInViewControllerBuilder(user: User) -> LoggedInViewController {
                         let keyValueStore: KeyValueStore = UserDefaults.instantiate(user: user)
                         return LoggedInViewController(user: user, networkService: networkService, keyValueStore: keyValueStore)
                     }
@@ -2452,14 +2452,14 @@ final class SafeDIToolTests: XCTestCase {
                     }()
                     let childB: ChildB = {
                         let grandchildBA: GrandchildBA = {
-                            func __safeDI_greatGrandchildInstantiator() -> GreatGrandchild {
+                            @MainActor func __safeDI_greatGrandchildInstantiator() -> GreatGrandchild {
                                 GreatGrandchild()
                             }
                             let greatGrandchildInstantiator = Instantiator<GreatGrandchild>(__safeDI_greatGrandchildInstantiator)
                             return GrandchildBA(greatGrandchildInstantiator: greatGrandchildInstantiator)
                         }()
                         let grandchildBB: GrandchildBB = {
-                            func __safeDI_greatGrandchildInstantiator() -> GreatGrandchild {
+                            @MainActor func __safeDI_greatGrandchildInstantiator() -> GreatGrandchild {
                                 GreatGrandchild()
                             }
                             let greatGrandchildInstantiator = Instantiator<GreatGrandchild>(__safeDI_greatGrandchildInstantiator)
@@ -2703,10 +2703,10 @@ final class SafeDIToolTests: XCTestCase {
                 public convenience init() {
                     let networkService: NetworkService = DefaultNetworkService()
                     let authService: AuthService = DefaultAuthService(networkService: networkService)
-                    func __safeDI_loggedInViewControllerBuilder(userManager: UserManager) -> LoggedInViewController {
-                        func __safeDI_profileViewControllerBuilder() -> ProfileViewController {
+                    @MainActor func __safeDI_loggedInViewControllerBuilder(userManager: UserManager) -> LoggedInViewController {
+                        @MainActor func __safeDI_profileViewControllerBuilder() -> ProfileViewController {
                             let userVendor: UserVendor = userManager
-                            func __safeDI_editProfileViewControllerBuilder() -> EditProfileViewController {
+                            @MainActor func __safeDI_editProfileViewControllerBuilder() -> EditProfileViewController {
                                 EditProfileViewController(userVendor: userVendor, userManager: userManager)
                             }
                             let editProfileViewControllerBuilder = Instantiator<EditProfileViewController>(__safeDI_editProfileViewControllerBuilder)
@@ -2768,8 +2768,8 @@ final class SafeDIToolTests: XCTestCase {
 
             extension Root {
                 public convenience init() {
-                    func __safeDI_childBuilder(iterator: IndexingIterator<Array<Element>>) -> Child {
-                        func __safeDI_grandchildBuilder() -> Grandchild {
+                    @MainActor func __safeDI_childBuilder(iterator: IndexingIterator<Array<Element>>) -> Child {
+                        @MainActor func __safeDI_grandchildBuilder() -> Grandchild {
                             let anyIterator = AnyIterator(iterator)
                             return Grandchild(anyIterator: anyIterator)
                         }
@@ -2919,11 +2919,11 @@ final class SafeDIToolTests: XCTestCase {
                 public convenience init() {
                     let networkService: NetworkService = DefaultNetworkService()
                     let authService: AuthService = DefaultAuthService(networkService: networkService)
-                    func __safeDI_loggedInViewControllerBuilder(userManager: UserManager) -> LoggedInViewController {
+                    @MainActor func __safeDI_loggedInViewControllerBuilder(userManager: UserManager) -> LoggedInViewController {
                         let userNetworkService: NetworkService = networkService
-                        func __safeDI_profileViewControllerBuilder() -> ProfileViewController {
+                        @MainActor func __safeDI_profileViewControllerBuilder() -> ProfileViewController {
                             let userVendor: UserVendor = userManager
-                            func __safeDI_editProfileViewControllerBuilder() -> EditProfileViewController {
+                            @MainActor func __safeDI_editProfileViewControllerBuilder() -> EditProfileViewController {
                                 EditProfileViewController(userVendor: userVendor, userManager: userManager, userNetworkService: userNetworkService)
                             }
                             let editProfileViewControllerBuilder = Instantiator<EditProfileViewController>(__safeDI_editProfileViewControllerBuilder)
@@ -3226,10 +3226,10 @@ final class SafeDIToolTests: XCTestCase {
                 public convenience init() {
                     let networkService: NetworkService = DefaultNetworkService()
                     let authService: AuthService = DefaultAuthService(networkService: networkService)
-                    func __safeDI_loggedInViewControllerBuilder(userManager: UserManager) -> LoggedInViewController {
+                    @MainActor func __safeDI_loggedInViewControllerBuilder(userManager: UserManager) -> LoggedInViewController {
                         let userVendor: UserVendor = userManager
-                        func __safeDI_profileViewControllerBuilder() -> ProfileViewController {
-                            func __safeDI_editProfileViewControllerBuilder() -> EditProfileViewController {
+                        @MainActor func __safeDI_profileViewControllerBuilder() -> ProfileViewController {
+                            @MainActor func __safeDI_editProfileViewControllerBuilder() -> EditProfileViewController {
                                 EditProfileViewController(userVendor: userVendor, userManager: userManager)
                             }
                             let editProfileViewControllerBuilder = Instantiator<EditProfileViewController>(__safeDI_editProfileViewControllerBuilder)
@@ -3373,9 +3373,9 @@ final class SafeDIToolTests: XCTestCase {
                 public convenience init() {
                     let networkService: NetworkService = DefaultNetworkService()
                     let authService: AuthService = DefaultAuthService(networkService: networkService)
-                    func __safeDI_loggedInViewControllerBuilder(userManager: UserManager) -> LoggedInViewController {
-                        func __safeDI_profileViewControllerBuilder() -> ProfileViewController {
-                            func __safeDI_editProfileViewControllerBuilder() -> EditProfileViewController {
+                    @MainActor func __safeDI_loggedInViewControllerBuilder(userManager: UserManager) -> LoggedInViewController {
+                        @MainActor func __safeDI_profileViewControllerBuilder() -> ProfileViewController {
+                            @MainActor func __safeDI_editProfileViewControllerBuilder() -> EditProfileViewController {
                                 let userVendor: UserVendor = userManager
                                 return EditProfileViewController(userVendor: userVendor, userManager: userManager)
                             }
@@ -3862,7 +3862,7 @@ final class SafeDIToolTests: XCTestCase {
 
             extension Root {
                 public convenience init() {
-                    func __safeDI_childBuilder() -> Child {
+                    @MainActor func __safeDI_childBuilder() -> Child {
                         Child()
                     }
                     let childBuilder: Instantiator<Child>? = Instantiator<Child>(__safeDI_childBuilder)
@@ -3917,9 +3917,9 @@ final class SafeDIToolTests: XCTestCase {
 
             extension Root {
                 public init() {
-                    func __safeDI_aBuilder() -> A {
-                        func __safeDI_bBuilder() -> B {
-                            func __safeDI_cBuilder() -> C {
+                    @MainActor func __safeDI_aBuilder() -> A {
+                        @MainActor func __safeDI_bBuilder() -> B {
+                            @MainActor func __safeDI_cBuilder() -> C {
                                 let aBuilder = Instantiator<A>(__safeDI_aBuilder)
                                 return C(aBuilder: aBuilder)
                             }
@@ -3983,7 +3983,7 @@ final class SafeDIToolTests: XCTestCase {
                 public init() {
                     let a: A = {
                         let b: B = {
-                            func __safeDI_cBuilder() -> C {
+                            @MainActor func __safeDI_cBuilder() -> C {
                                 let a = A(b: b)
                                 return C(a: a)
                             }
@@ -4030,7 +4030,7 @@ final class SafeDIToolTests: XCTestCase {
             extension Root {
                 public init() {
                     let a: A = {
-                        func __safeDI_aBuilder() -> A {
+                        @MainActor func __safeDI_aBuilder() -> A {
                             let aBuilder = Instantiator<A>(__safeDI_aBuilder)
                             return A(aBuilder: aBuilder)
                         }
@@ -4076,7 +4076,7 @@ final class SafeDIToolTests: XCTestCase {
 
             extension Root {
                 public init() {
-                    func __safeDI_aBuilder(context: String) -> A {
+                    @MainActor func __safeDI_aBuilder(context: String) -> A {
                         let aBuilder = Instantiator<A> {
                             __safeDI_aBuilder(context: $0)
                         }

--- a/Tests/SafeDIToolTests/SafeDIToolTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolTests.swift
@@ -1904,7 +1904,7 @@ final class SafeDIToolTests: XCTestCase {
                 @Instantiable
                 public final class Root {
                     @Instantiated(fulfilledByType: "ChildA")
-                    let childABuilder: ErasedInstantiator<Recreated, ChildAProtocol>
+                    let childABuilder: NonisolatedErasedInstantiator<Recreated, ChildAProtocol>
                     @Instantiated
                     let childB: ChildB
                     @Instantiated
@@ -1974,7 +1974,7 @@ final class SafeDIToolTests: XCTestCase {
 
             extension Root {
                 public convenience init() {
-                    @MainActor func __safeDI_childABuilder(recreated: Recreated) -> ChildA {
+                    nonisolated func __safeDI_childABuilder(recreated: Recreated) -> ChildA {
                         let grandchildA: GrandchildA = {
                             let recreated = Recreated()
                             let greatGrandchild = GreatGrandchild(recreated: recreated)
@@ -1986,7 +1986,7 @@ final class SafeDIToolTests: XCTestCase {
                         }()
                         return ChildA(grandchildA: grandchildA, grandchildB: grandchildB, recreated: recreated)
                     }
-                    let childABuilder = ErasedInstantiator<Recreated, ChildAProtocol> {
+                    let childABuilder = NonisolatedErasedInstantiator<Recreated, ChildAProtocol> {
                         __safeDI_childABuilder(recreated: $0)
                     }
                     let recreated = Recreated()
@@ -2348,7 +2348,7 @@ final class SafeDIToolTests: XCTestCase {
                 @Instantiable()
                 public final class GrandchildBA {
                     @Instantiated
-                    var greatGrandchildInstantiator: Instantiator<GreatGrandchild>
+                    var greatGrandchildInstantiator: NonisolatedInstantiator<GreatGrandchild>
                 }
                 """,
                 """
@@ -2357,7 +2357,7 @@ final class SafeDIToolTests: XCTestCase {
                 @Instantiable()
                 public final class GrandchildBB {
                     @Instantiated
-                    greatGrandchildInstantiator: Instantiator<GreatGrandchild>
+                    greatGrandchildInstantiator: NonisolatedInstantiator<GreatGrandchild>
                 }
                 """,
             ],
@@ -2371,7 +2371,8 @@ final class SafeDIToolTests: XCTestCase {
                 import class GrandchildModule.GrandchildAA
                 import class GrandchildModule.GrandchildAB
 
-                @Instantiable()
+                @MainActor
+                @Instantiable
                 public final class ChildA {
                     @Instantiated
                     let grandchildAA: GrandchildAA
@@ -2403,7 +2404,8 @@ final class SafeDIToolTests: XCTestCase {
                 """
                 import ChildModule
 
-                @Instantiable()
+                @MainActor
+                @Instantiable
                 public final class Root {
                     @Instantiated
                     let childA: ChildA
@@ -2452,17 +2454,17 @@ final class SafeDIToolTests: XCTestCase {
                     }()
                     let childB: ChildB = {
                         let grandchildBA: GrandchildBA = {
-                            @MainActor func __safeDI_greatGrandchildInstantiator() -> GreatGrandchild {
+                            nonisolated func __safeDI_greatGrandchildInstantiator() -> GreatGrandchild {
                                 GreatGrandchild()
                             }
-                            let greatGrandchildInstantiator = Instantiator<GreatGrandchild>(__safeDI_greatGrandchildInstantiator)
+                            let greatGrandchildInstantiator = NonisolatedInstantiator<GreatGrandchild>(__safeDI_greatGrandchildInstantiator)
                             return GrandchildBA(greatGrandchildInstantiator: greatGrandchildInstantiator)
                         }()
                         let grandchildBB: GrandchildBB = {
-                            @MainActor func __safeDI_greatGrandchildInstantiator() -> GreatGrandchild {
+                            nonisolated func __safeDI_greatGrandchildInstantiator() -> GreatGrandchild {
                                 GreatGrandchild()
                             }
-                            let greatGrandchildInstantiator = Instantiator<GreatGrandchild>(__safeDI_greatGrandchildInstantiator)
+                            let greatGrandchildInstantiator = NonisolatedInstantiator<GreatGrandchild>(__safeDI_greatGrandchildInstantiator)
                             return GrandchildBB(greatGrandchildInstantiator: greatGrandchildInstantiator)
                         }()
                         return ChildB(grandchildBA: grandchildBA, grandchildBB: grandchildBB)


### PR DESCRIPTION
This PR makes it possible to use SafeDI with Swift 5.10+ and Strict Concurrency checking turned on. To accomplish this, we made the following changes:

1. Made generated `init` methods on `@Instantiable` be isolated to the parent actor context – removed the `nonisolated` from these generated `init` methods.
1. The `instantiate(...)` method for both `Instantiator` and `ErasedInstantiator` become `@MainActor`-bound
1. Created two new instantiator objects: `NonisolatedInstantiator` and `NonisolatedErasedInstantiator`. As the name implies, these instantiators's `instantiate(...)` methods run in a nonisolated context.

We made `Instantiator` and `ErasedInstantiator` `@MainActor`-bound because in most applications the root of the dependency tree is `@MainActor`-bound, and in applications the majority of delayed-built products are `@MainActor`-bound. In an effort to make the common case simple, we have optimized for simplifying the `@MainActor`-bound case.

Addresses #65.

This is a breaking change.

To adopt this change locally, consumers will need to follow their build errors after updating to 0.5.0. If something requires instantiation outside of main actor isolation, utilize a `Nonisolated`-prefixed Instantiator.