### PR TITLE
Change the branch in ExampleProjectIntegration if the PR is not from a fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
       - name: Replace 'main' branch with the current branch
+        if: github.repository == github.event.repository.full_name # Only do this if the branch is from our repo.
         run: sed -i '' "s#branch = main;#branch = ${{ github.head_ref || github.ref_name }};#" "Examples/ExampleProjectIntegration/ExampleProjectIntegration.xcodeproj/project.pbxproj"
       - name: Build Project Integration
         run: pushd Examples/ExampleProjectIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExampleProjectIntegration; popd


### PR DESCRIPTION
Forks shouldn't be submitting breaking changes anyways – we should invite folk to be contributors for that.