### PR TITLE
Run tests multiple times in CI, not locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,10 @@ jobs:
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer
       - name: Build and Test Framework
-        run: xcrun swift test -c release --enable-code-coverage -Xswiftc -enable-testing
+        run: |
+          for i in {1..5}; do # Run tests a few times to ensure code-gen is stable.
+            xcrun swift test -c release --enable-code-coverage -Xswiftc -enable-testing
+          done
       - name: Prepare Coverage Reports
         run: ./Scripts/prepare-coverage-reports.sh
       - name: Upload Coverage Reports

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -39,10 +39,8 @@ import SafeDICore
         // MARK: XCTestCase
 
         override func invokeTest() {
-            func executeTest() {
-                withMacroTesting(macros: testMacros) {
-                    super.invokeTest()
-                }
+            withMacroTesting(macros: testMacros) {
+                super.invokeTest()
             }
         }
 

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -44,16 +44,6 @@ import SafeDICore
                     super.invokeTest()
                 }
             }
-            #if os(Linux) // Linux does not support multiple invokations of the same test.
-                executeTest()
-            #else
-                // Stop test execution on the first failure so we don't get repeated failures per repeated test run.
-                continueAfterFailure = false
-                // Run each test five times to ensure ordering is consistent.
-                for _ in 0..<5 {
-                    executeTest()
-                }
-            #endif
         }
 
         // MARK: Generation tests

--- a/Tests/SafeDIToolTests/SafeDIToolCodeGenerationErrorTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolCodeGenerationErrorTests.swift
@@ -40,17 +40,6 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
         }
     }
 
-    #if !os(Linux) // Linux does not support multiple invokations of the same test.
-        override func invokeTest() {
-            // Stop test execution on the first failure so we don't get repeated failures per repeated test run.
-            continueAfterFailure = false
-            // Run each test five times to ensure ordering is consistent.
-            for _ in 0..<5 {
-                super.invokeTest()
-            }
-        }
-    #endif
-
     // MARK: Error Tests
 
     @MainActor

--- a/Tests/SafeDIToolTests/SafeDIToolCodeGenerationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolCodeGenerationTests.swift
@@ -40,17 +40,6 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         }
     }
 
-    #if !os(Linux) // Linux does not support multiple invokations of the same test.
-        override func invokeTest() {
-            // Stop test execution on the first failure so we don't get repeated failures per repeated test run.
-            continueAfterFailure = false
-            // Run each test five times to ensure ordering is consistent.
-            for _ in 0..<5 {
-                super.invokeTest()
-            }
-        }
-    #endif
-
     // MARK: Code Generation Tests
 
     @MainActor

--- a/Tests/SafeDIToolTests/SafeDIToolDOTGenerationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolDOTGenerationTests.swift
@@ -40,17 +40,6 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         }
     }
 
-    #if !os(Linux) // Linux does not support multiple invokations of the same test.
-        override func invokeTest() {
-            // Stop test execution on the first failure so we don't get repeated failures per repeated test run.
-            continueAfterFailure = false
-            // Run each test five times to ensure ordering is consistent.
-            for _ in 0..<5 {
-                super.invokeTest()
-            }
-        }
-    #endif
-
     // MARK: DOT Generation Tests
 
     @MainActor


### PR DESCRIPTION
In #91 we started marking tests with `@MainActor`, which works great when tests pass. When tests fail, it _might_ crash since `invokeTest` may not be called on `main`. So I moved our repeat testing code to CI and out of Xcode.