### PR TITLE
Bump dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e53979bfc46557c5c4d686d89f419fcde783143fddfdef282b1e16ebd3dc105f",
+  "originHash" : "dc3bea121a5b98d056df3ebf34bb4af99009b01c1aea8c1805be9c40a6eed750",
   "pins" : [
     {
       "identity" : "jjliso8601dateformatter",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing.git",
       "state" : {
-        "revision" : "5c4a1b9d7c23cd5c08ea50677d8e89080365cb00",
-        "version" : "0.4.0"
+        "revision" : "a35257b7e9ce44e92636447003a8eeefb77b145c",
+        "version" : "0.5.1"
       }
     },
     {
@@ -42,14 +42,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "625ccca8570773dd84a34ee51a81aa2bc5a4f97a",
-        "version" : "1.16.0"
+        "revision" : "c097f955b4e724690f0fc8ffb7a6d4b881c9c4e3",
+        "version" : "1.17.2"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
         "version" : "510.0.2"

--- a/Package.swift
+++ b/Package.swift
@@ -29,9 +29,9 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.0"),
         .package(url: "https://github.com/michaeleisel/ZippyJSON.git", from: "1.2.0"),
-        .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.4.0"),
+        .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.5.0"),
     ],
     targets: [
         // Macros

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -30,9 +30,9 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         // TODO: Bump to 600.0.0 once it's available.
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.0"),
         .package(url: "https://github.com/michaeleisel/ZippyJSON.git", from: "1.2.0"),
-        .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.4.0"),
+        .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.5.0"),
     ],
     targets: [
         // Macros


### PR DESCRIPTION
`swift-syntax` moved from `apple` to `swiftlang` orgs, so we're updating our pointer too.

I'm also updating `pointfreeco/swift-macro-testing` while we're here.