### PR TITLE
Enable Xcode 16 plugin to use versioned release build

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -25,6 +25,10 @@ let package = Package(
             name: "SafeDIGenerator",
             targets: ["SafeDIGenerator"]
         ),
+        .plugin(
+            name: "InstallSafeDITool",
+            targets: ["InstallSafeDITool"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.0"),
@@ -109,6 +113,20 @@ let package = Package(
             swiftSettings: [
                 .swiftLanguageMode(.v6),
             ]
+        ),
+        .plugin(
+            name: "InstallSafeDITool",
+            capability: .command(
+                intent: .custom(
+                    verb: "safedi-release-install",
+                    description: "Installs a release version of the SafeDITool build plugin executable."
+                ),
+                permissions: [
+                    .writeToPackageDirectory(reason: "Downloads the SafeDI release build plugin executable into your project directory."),
+                    .allowNetworkConnections(scope: .all(ports: []), reason: "Downloads the SafeDI release build plugin executable from GitHub."),
+                ]
+            ),
+            dependencies: []
         ),
 
         // Core

--- a/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
+++ b/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
@@ -1,0 +1,91 @@
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import PackagePlugin
+
+@main
+struct InstallSafeDITool: CommandPlugin {
+    func performCommand(
+        context: PackagePlugin.PluginContext,
+        arguments _: [String]
+    ) async throws {
+        guard let safeDIOrigin = context.package.dependencies.first(where: { $0.package.displayName == "SafeDI" })?.package.origin else {
+            print("No package origin found for SafeDI package")
+            return
+        }
+        switch safeDIOrigin {
+        case let .repository(url, displayVersion, _):
+            let expectedToolFolder = context.package.directoryURL.appending(
+                components: ".safedi",
+                displayVersion
+            )
+            let expectedToolLocation = expectedToolFolder.appending(component: "safeditool")
+
+            guard let url = URL(string: url)?.deletingPathExtension() else {
+                print("No package origin found for SafeDI package")
+                return
+            }
+            #if arch(arm64)
+                let toolName = "SafeDITool-arm64"
+            #elseif arch(x86_64)
+                let toolName = "SafeDITool-x86_64"
+            #else
+                print("Unexpected architecture type")
+                return
+            #endif
+
+            let downloadURL = url.appending(
+                components: "releases",
+                "download",
+                displayVersion,
+                toolName
+            )
+            let (downloadedURL, _) = try await URLSession.shared.download(
+                for: URLRequest(url: downloadURL)
+            )
+
+            try FileManager.default.createDirectory(
+                at: expectedToolFolder,
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.moveItem(
+                at: downloadedURL,
+                to: expectedToolLocation
+            )
+            let gitIgnoreLocation = expectedToolFolder.appending(component: ".gitignore")
+            if !FileManager.default.fileExists(atPath: gitIgnoreLocation.path()) {
+                try """
+                safeditool
+                """.write(
+                    to: gitIgnoreLocation,
+                    atomically: true,
+                    encoding: .utf8
+                )
+            }
+
+        case .registry, .root, .local:
+            fallthrough
+
+        @unknown default:
+            print("Cannot download SafeDITool from \(safeDIOrigin)")
+        }
+    }
+}

--- a/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
+++ b/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
@@ -73,7 +73,7 @@ struct InstallSafeDITool: CommandPlugin {
             let gitIgnoreLocation = expectedToolFolder.appending(component: ".gitignore")
             if !FileManager.default.fileExists(atPath: gitIgnoreLocation.path()) {
                 try """
-                safeditool
+                \(expectedToolLocation.lastPathComponent)
                 """.write(
                     to: gitIgnoreLocation,
                     atomically: true,

--- a/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
+++ b/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
@@ -39,9 +39,11 @@ struct InstallSafeDITool: CommandPlugin {
                 print("could not extract version for SafeDI")
                 return
             }
-            let expectedToolFolder = context.package.directoryURL.appending(
-                components: ".safedi",
-                String(version)
+            let safediFolder = context.package.directoryURL.appending(
+                component: ".safedi"
+            )
+            let expectedToolFolder = safediFolder.appending(
+                component: String(version)
             )
             let expectedToolLocation = expectedToolFolder.appending(component: "safeditool")
 
@@ -83,10 +85,10 @@ struct InstallSafeDITool: CommandPlugin {
                 at: downloadedURL,
                 to: expectedToolLocation
             )
-            let gitIgnoreLocation = expectedToolFolder.appending(component: ".gitignore")
+            let gitIgnoreLocation = safediFolder.appending(component: ".gitignore")
             if !FileManager.default.fileExists(atPath: gitIgnoreLocation.path()) {
                 try """
-                \(expectedToolLocation.lastPathComponent)
+                */\(expectedToolLocation.lastPathComponent)
                 """.write(
                     to: gitIgnoreLocation,
                     atomically: true,

--- a/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
+++ b/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
@@ -34,16 +34,17 @@ struct InstallSafeDITool: CommandPlugin {
         switch safeDIOrigin {
         case let .repository(url, displayVersion, _):
             guard let versionMatch = try /Optional\((.*?)\)|^(.*?)$/.firstMatch(in: displayVersion),
-                  let version = versionMatch.output.1 ?? versionMatch.output.2
+                  let versionSubstring = versionMatch.output.1 ?? versionMatch.output.2
             else {
                 print("could not extract version for SafeDI")
                 return
             }
+            let version = String(versionSubstring)
             let safediFolder = context.package.directoryURL.appending(
                 component: ".safedi"
             )
             let expectedToolFolder = safediFolder.appending(
-                component: String(version)
+                component: version
             )
             let expectedToolLocation = expectedToolFolder.appending(component: "safeditool")
 
@@ -63,7 +64,7 @@ struct InstallSafeDITool: CommandPlugin {
             let downloadURL = url.appending(
                 components: "releases",
                 "download",
-                displayVersion,
+                version,
                 toolName
             )
             let (downloadedURL, _) = try await URLSession.shared.download(

--- a/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
+++ b/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
@@ -29,7 +29,7 @@ struct InstallSafeDITool: CommandPlugin {
     ) async throws {
         guard let safeDIOrigin = context.package.dependencies.first(where: { $0.package.displayName == "SafeDI" })?.package.origin else {
             Diagnostics.error("No package origin found for SafeDI package")
-            return
+            exit(1)
         }
         switch safeDIOrigin {
         case let .repository(url, displayVersion, _):
@@ -39,7 +39,7 @@ struct InstallSafeDITool: CommandPlugin {
                   let versionSubstring = versionMatch.output.1 ?? versionMatch.output.2
             else {
                 Diagnostics.error("Could not extract version for SafeDI")
-                return
+                exit(1)
             }
             let version = String(versionSubstring)
             let safediFolder = context.package.directoryURL.appending(
@@ -52,7 +52,7 @@ struct InstallSafeDITool: CommandPlugin {
 
             guard let url = URL(string: url)?.deletingPathExtension() else {
                 Diagnostics.error("No package url found for SafeDI package")
-                return
+                exit(1)
             }
             #if arch(arm64)
                 let toolName = "SafeDITool-arm64"
@@ -60,7 +60,7 @@ struct InstallSafeDITool: CommandPlugin {
                 let toolName = "SafeDITool-x86_64"
             #else
                 Diagnostics.error("Unexpected architecture type")
-                return
+                exit(1)
             #endif
 
             let githubDownloadURL = url.appending(
@@ -78,7 +78,7 @@ struct InstallSafeDITool: CommandPlugin {
                   chmod(downloadedURL.path(), mode_t(currentPermissions.uint16Value | S_IXUSR | S_IXGRP | S_IXOTH)) == 0
             else {
                 Diagnostics.error("Failed to make downloaded file \(downloadedURL.path()) executable")
-                return
+                exit(1)
             }
             try FileManager.default.createDirectory(
                 at: expectedToolFolder,
@@ -104,6 +104,7 @@ struct InstallSafeDITool: CommandPlugin {
 
         @unknown default:
             Diagnostics.error("Cannot download SafeDITool from \(safeDIOrigin) – downloading only works when using a versioned release of SafeDI")
+            exit(1)
         }
     }
 }

--- a/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
+++ b/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
@@ -48,7 +48,7 @@ struct InstallSafeDITool: CommandPlugin {
             let expectedToolLocation = expectedToolFolder.appending(component: "safeditool")
 
             guard let url = URL(string: url)?.deletingPathExtension() else {
-                print("No package origin found for SafeDI package")
+                print("No package url found for SafeDI package")
                 return
             }
             #if arch(arm64)

--- a/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
+++ b/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
@@ -33,9 +33,15 @@ struct InstallSafeDITool: CommandPlugin {
         }
         switch safeDIOrigin {
         case let .repository(url, displayVersion, _):
+            guard let versionMatch = try /Optional\((.*?)\)|^(.*?)$/.firstMatch(in: displayVersion),
+                  let version = versionMatch.output.1 ?? versionMatch.output.2
+            else {
+                print("could not extract version for SafeDI")
+                return
+            }
             let expectedToolFolder = context.package.directoryURL.appending(
                 components: ".safedi",
-                displayVersion
+                String(version)
             )
             let expectedToolLocation = expectedToolFolder.appending(component: "safeditool")
 

--- a/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
+++ b/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
@@ -301,6 +301,7 @@ extension Data {
             }
             switch safeDIOrigin {
             case let .repository(_, displayVersion, _):
+                // This regular expression is duplicated by InstallSafeDITool since plugins can not share code.
                 guard let versionMatch = try? /Optional\((.*?)\)|^(.*?)$/.firstMatch(in: displayVersion),
                       let version = versionMatch.output.1 ?? versionMatch.output.2
                 else {

--- a/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
+++ b/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
@@ -281,7 +281,12 @@ extension Data {
             }
             switch safeDIOrigin {
             case let .repository(_, displayVersion, _):
-                return displayVersion
+                guard let versionMatch = try? /Optional\((.*?)\)|^(.*?)$/.firstMatch(in: displayVersion),
+                      let version = versionMatch.output.1 ?? versionMatch.output.2
+                else {
+                    return nil
+                }
+                return String(version)
             case .registry, .root, .local:
                 fallthrough
             @unknown default:

--- a/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
+++ b/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
@@ -97,12 +97,12 @@ struct SafeDIGenerateDependencyTree: BuildToolPlugin {
 
             let armMacBrewInstallLocation = "/opt/homebrew/bin/safeditool"
             let intelMacBrewInstallLocation = "/usr/local/bin/safeditool"
-            let toolLocation: PackagePlugin.Path = if FileManager.default.fileExists(atPath: Self.armMacBrewInstallLocation) {
+            let toolLocation: PackagePlugin.Path = if FileManager.default.fileExists(atPath: armMacBrewInstallLocation) {
                 // SafeDITool has been installed via homebrew on an ARM Mac.
-                PackagePlugin.Path(Self.armMacBrewInstallLocation)
-            } else if FileManager.default.fileExists(atPath: Self.intelMacBrewInstallLocation) {
+                PackagePlugin.Path(armMacBrewInstallLocation)
+            } else if FileManager.default.fileExists(atPath: intelMacBrewInstallLocation) {
                 // SafeDITool has been installed via homebrew on an Intel Mac.
-                PackagePlugin.Path(Self.intelMacBrewInstallLocation)
+                PackagePlugin.Path(intelMacBrewInstallLocation)
             } else {
                 // Fall back to the just-in-time built tool.
                 try context.tool(named: "SafeDITool").path

--- a/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
+++ b/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
@@ -60,21 +60,22 @@ struct SafeDIGenerateDependencyTree: BuildToolPlugin {
             ]
 
             let downloadedToolLocation = context.downloadedToolLocation
-            if context.hasSafeDIFolder, downloadedToolLocation == nil {
+            let safeDIVersion = context.safeDIVersion
+            if context.hasSafeDIFolder, let safeDIVersion, downloadedToolLocation == nil {
                 Diagnostics.error("""
-                \(context.safediFolder.path()) exists, but there is no SafeDITool binary for this release present.
+                \(context.safediFolder.path()) exists, but contains no SafeDITool binary for version \(safeDIVersion).
 
-                To download the current release SafeDITool binary, run:
+                To download the release SafeDITool binary for version \(safeDIVersion), run:
                 \tswift package --package-path \(context.package.directoryURL.path()) --allow-network-connections all --allow-writing-to-package-directory safedi-release-install
 
                 To use a debug SafeDITool binary instead, remove the `.safedi` directory by running:
                 \trm -rf \(context.safediFolder.path())
                 """)
-            } else if downloadedToolLocation == nil {
+            } else if downloadedToolLocation == nil, let safeDIVersion {
                 Diagnostics.warning("""
                 Using a debug SafeDITool binary, which is 15x slower than a release SafeDITool binary.
 
-                To download the current release SafeDITool binary, run:
+                To download the release SafeDITool binary for version \(safeDIVersion), run:
                 \tswift package --package-path \(context.package.directoryURL.path()) --allow-network-connections all --allow-writing-to-package-directory safedi-release-install
                 """)
             }

--- a/README.md
+++ b/README.md
@@ -437,10 +437,20 @@ If your first-party code is entirely contained in a Swift Package with one or mo
 
 You can see this in integration in practice in the [ExamplePackageIntegration](Examples/ExamplePackageIntegration) package.
 
+##### Xcode 15
+
 For faster builds, you can install a release version of `SafeDITool` [rather than a debug version](https://github.com/apple/swift-package-manager/issues/7233) via `brew`:
 
 ```zsh
 brew install dfed/safedi/safeditool
+```
+
+##### Xcode 16
+
+for faster builds, you can install a release version of `SafeDITool` [rather than a debug version](https://github.com/apple/swift-package-manager/issues/7233) via `swift`:
+
+```zsh
+swift package --allow-network-connections all --allow-writing-to-package-directory safedi-release-install
 ```
 
 #### Other configurations


### PR DESCRIPTION
Xcode 16 allows for plugins to determine their own display version, which enables us to:
1. Write a package command plugin that can download the current release build of the `SafeDITool` from Github
2. Use that release version if it exists in our package build plugin

This PR does both of these things. Note that we do not touch the Swift 5.10 & Xcode 15 code-path, which still looks for an unversioned :sob: release installed via Homebrew.