### PR TITLE
Use CSV file for dependent module info rather than a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Every `@Instantiable`-decorated type must be:
 
 1. `public` or `open`
 
-2. Have a `public init(…)` or `open init(…)` that has an argument for every injectable property and no other arguments
+2. Have a `public init(…)` or `open init(…)` that has an argument for every injectable property
 
 The `@Instantiable` macro guides engineers through satisfying these requirements with code generation and build-time FixIts.
 

--- a/Sources/SafeDITool/SafeDITool.swift
+++ b/Sources/SafeDITool/SafeDITool.swift
@@ -109,8 +109,11 @@ struct SafeDITool: AsyncParsableCommand, Sendable {
     private func findSwiftFiles() async throws -> Set<String> {
         var swiftFiles = Set<String>()
         if let swiftSourcesFilePath {
-            try swiftFiles.formUnion(String(contentsOfFile: swiftSourcesFilePath)
-                .components(separatedBy: CharacterSet(arrayLiteral: ",")))
+            try swiftFiles.formUnion(
+                String(contentsOfFile: swiftSourcesFilePath)
+                    .components(separatedBy: CharacterSet(arrayLiteral: ","))
+                    .filter { !$0.isEmpty }
+            )
         }
         for included in include {
             let includedURL = included.asFileURL
@@ -198,6 +201,7 @@ struct SafeDITool: AsyncParsableCommand, Sendable {
                 try .init(
                     String(contentsOfFile: dependentModuleInfoFilePath)
                         .components(separatedBy: CharacterSet(arrayLiteral: ","))
+                        .filter { !$0.isEmpty }
                         .map(\.asFileURL)
                 )
             } else {

--- a/Tests/SafeDIToolTests/SafeDIToolCodeGenerationErrorTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolCodeGenerationErrorTests.swift
@@ -1731,7 +1731,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
         tool.include = ["Fake"]
         tool.additionalImportedModules = []
         tool.moduleInfoOutput = nil
-        tool.moduleInfoPaths = []
+        tool.dependentModuleInfoFilePath = nil
         tool.dependencyTreeOutput = nil
         await assertThrowsError("Could not create file enumerator for directory 'Fake'") {
             try await tool.run()
@@ -1744,7 +1744,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
         tool.include = []
         tool.additionalImportedModules = []
         tool.moduleInfoOutput = nil
-        tool.moduleInfoPaths = []
+        tool.dependentModuleInfoFilePath = nil
         tool.dependencyTreeOutput = nil
         await assertThrowsError("Must provide either 'swift-sources-file-path' or '--include'.") {
             try await tool.run()

--- a/Tests/SafeDIToolTests/SafeDIToolCodeGenerationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolCodeGenerationTests.swift
@@ -2546,7 +2546,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
             ],
-            dependentModuleOutputPaths: [greatGrandchildModuleOutput.moduleInfoOutputPath],
+            dependentModuleInfoPaths: [greatGrandchildModuleOutput.moduleInfoOutputPath],
             buildDependencyTreeOutput: false,
             filesToDelete: &filesToDelete
         )
@@ -2578,7 +2578,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
             ],
-            dependentModuleOutputPaths: [
+            dependentModuleInfoPaths: [
                 greatGrandchildModuleOutput.moduleInfoOutputPath,
                 grandchildModuleOutput.moduleInfoOutputPath,
             ],
@@ -2601,7 +2601,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
             ],
-            dependentModuleOutputPaths: [
+            dependentModuleInfoPaths: [
                 greatGrandchildModuleOutput.moduleInfoOutputPath,
                 grandchildModuleOutput.moduleInfoOutputPath,
                 childModuleOutput.moduleInfoOutputPath,

--- a/Tests/SafeDIToolTests/SafeDIToolDOTGenerationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolDOTGenerationTests.swift
@@ -1152,7 +1152,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
             ],
-            dependentModuleOutputPaths: [greatGrandchildModuleOutput.moduleInfoOutputPath],
+            dependentModuleInfoPaths: [greatGrandchildModuleOutput.moduleInfoOutputPath],
             buildDOTFileOutput: false,
             filesToDelete: &filesToDelete
         )
@@ -1184,7 +1184,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
             ],
-            dependentModuleOutputPaths: [
+            dependentModuleInfoPaths: [
                 greatGrandchildModuleOutput.moduleInfoOutputPath,
                 grandchildModuleOutput.moduleInfoOutputPath,
             ],
@@ -1207,7 +1207,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
             ],
-            dependentModuleOutputPaths: [
+            dependentModuleInfoPaths: [
                 greatGrandchildModuleOutput.moduleInfoOutputPath,
                 grandchildModuleOutput.moduleInfoOutputPath,
                 childModuleOutput.moduleInfoOutputPath,


### PR DESCRIPTION
Instead of having a `moduleInfoPaths: [String] ` property, we instead use a `dependentModuleInfoFilePath: String?`. This limit the amount of information needed to be sent to the CLI.