### PR TITLE
Enable opting out of `Instantiable` protocol conformance

### DIFF
--- a/Sources/SafeDI/PropertyDecoration/Instantiable.swift
+++ b/Sources/SafeDI/PropertyDecoration/Instantiable.swift
@@ -51,10 +51,13 @@
 ///         }
 ///     }
 ///
-/// - Parameter additionalTypes: The types (in addition to the type decorated with this macro) of properties that can be decorated with `@Instantiated` and yield a result of this type. The types provided *must* be either superclasses of this type or protocols to which this type conforms.
+/// - Parameters:
+///   - additionalTypes: The types (in addition to the type decorated with this macro) of properties that can be decorated with `@Instantiated` and yield a result of this type. The types provided *must* be either superclasses of this type or protocols to which this type conforms.
+///   - conformsElsewhere: Whether the decorated type already conforms to the `Instantiable` protocol elsewhere. If set to `true`, the macro does not enforce that this declaration conforms to `Instantiable`.
 @attached(member, names: arbitrary)
 public macro Instantiable(
-    fulfillingAdditionalTypes additionalTypes: [Any.Type] = []
+    fulfillingAdditionalTypes additionalTypes: [Any.Type] = [],
+    conformsElsewhere: Bool = false
 ) = #externalMacro(module: "SafeDIMacros", type: "InstantiableMacro")
 
 /// A type that can be instantiated with runtime-injected properties.

--- a/Sources/SafeDICore/Extensions/AttributeSyntaxExtensions.swift
+++ b/Sources/SafeDICore/Extensions/AttributeSyntaxExtensions.swift
@@ -33,6 +33,20 @@ extension AttributeSyntax {
         return firstLabeledExpression.expression
     }
 
+    public var conformsElsewhere: ExprSyntax? {
+        guard let arguments,
+              let labeledExpressionList = LabeledExprListSyntax(arguments),
+              let firstLabeledExpression = labeledExpressionList.first(where: {
+                  // In `@Instantiated`, the `conformsElsewhere` parameter is the second parameter, though the first parameter has a default.
+                  $0.label?.text == "conformsElsewhere"
+              })
+        else {
+            return nil
+        }
+
+        return firstLabeledExpression.expression
+    }
+
     public var fulfilledByDependencyNamed: ExprSyntax? {
         guard let arguments,
               let labeledExpressionList = LabeledExprListSyntax(arguments),

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -52,8 +52,16 @@ public struct InstantiableMacro: MemberMacro {
             ?? ClassDeclSyntax(declaration)
             ?? StructDeclSyntax(declaration)
         {
-            let extendsInstantiable = concreteDeclaration.inheritanceClause?.inheritedTypes.contains(where: \.type.typeDescription.isInstantiable) ?? false
-            if !extendsInstantiable {
+            lazy var extendsInstantiable = concreteDeclaration.inheritanceClause?.inheritedTypes.contains(where: \.type.typeDescription.isInstantiable) ?? false
+            let mustExtendInstantiable = if let conformsElsewhereArgument = declaration.attributes.instantiableMacro?.conformsElsewhere,
+                                            let boolExpression = BooleanLiteralExprSyntax(conformsElsewhereArgument)
+            {
+                boolExpression.literal.tokenKind == .keyword(.false)
+            } else {
+                true
+            }
+
+            if mustExtendInstantiable, !extendsInstantiable {
                 var modifiedDeclaration = concreteDeclaration
                 var inheritedType = InheritedTypeSyntax(
                     type: IdentifierTypeSyntax(name: .identifier("Instantiable"))
@@ -161,8 +169,16 @@ public struct InstantiableMacro: MemberMacro {
             return generateForwardedProperties(from: forwardedProperties)
 
         } else if let extensionDeclaration = ExtensionDeclSyntax(declaration) {
-            let extendsInstantiable = extensionDeclaration.inheritanceClause?.inheritedTypes.contains(where: \.type.typeDescription.isInstantiable) ?? false
-            if !extendsInstantiable {
+            lazy var extendsInstantiable = extensionDeclaration.inheritanceClause?.inheritedTypes.contains(where: \.type.typeDescription.isInstantiable) ?? false
+            let mustExtendInstantiable = if let conformsElsewhereArgument = declaration.attributes.instantiableMacro?.conformsElsewhere,
+                                            let boolExpression = BooleanLiteralExprSyntax(conformsElsewhereArgument)
+            {
+                boolExpression.literal.tokenKind == .keyword(.false)
+            } else {
+                true
+            }
+
+            if mustExtendInstantiable, !extendsInstantiable {
                 var modifiedDeclaration = extensionDeclaration
                 var inheritedType = InheritedTypeSyntax(
                     type: IdentifierTypeSyntax(name: .identifier("Instantiable"))

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -44,6 +44,46 @@ import SafeDICore
             }
         }
 
+        // MARK: Behavior Tests
+
+        func test_extension_expandsWithoutIssueOnTypeDeclarationWhenInstantiableConformanceMissingAndConformsElsewhereIsTrue() {
+            assertMacro {
+                """
+                @Instantiable(conformsElsewhere: true)
+                public final class ExampleService {
+                    public init() {}
+                }
+                """
+            } expansion: {
+                """
+                public final class ExampleService {
+                    public init() {}
+                }
+                """
+            }
+        }
+
+        func test_extension_expandsWithoutIssueOnExtensionWhenInstantiableConformanceMissingAndConformsElsewhereIsTrue() {
+            assertMacro {
+                """
+                @Instantiable(conformsElsewhere: true)
+                extension ExampleService: CustomStringConvertible {
+                    public static func instantiate() -> ExampleService { fatalError() }
+
+                    public var description: String { "ExampleService" }
+                }
+                """
+            } expansion: {
+                """
+                extension ExampleService: CustomStringConvertible {
+                    public static func instantiate() -> ExampleService { fatalError() }
+
+                    public var description: String { "ExampleService" }
+                }
+                """
+            }
+        }
+
         // MARK: Error tests
 
         func test_declaration_throwsErrorWhenOnProtocol() {
@@ -1401,6 +1441,44 @@ import SafeDICore
             }
         }
 
+        func test_declaration_fixit_addsFixitWhenInstantiableConformanceMissingAndConformsElsewhereIsFalse() {
+            assertMacro {
+                """
+                @Instantiable(conformsElsewhere: false)
+                public final class ExampleService: CustomStringConvertible {
+                    public init() {}
+                    public var description: String { "ExampleService" }
+                }
+                """
+            } diagnostics: {
+                """
+                @Instantiable(conformsElsewhere: false)
+                ┬──────────────────────────────────────
+                ╰─ 🛑 @Instantiable-decorated type or extension must declare conformance to `Instantiable`
+                   ✏️ Declare conformance to `Instantiable`
+                public final class ExampleService: CustomStringConvertible {
+                    public init() {}
+                    public var description: String { "ExampleService" }
+                }
+                """
+            } fixes: {
+                """
+                @Instantiable(conformsElsewhere: false)
+                public final class ExampleService: CustomStringConvertible, Instantiable {
+                    public init() {}
+                    public var description: String { "ExampleService" }
+                }
+                """
+            } expansion: {
+                """
+                public final class ExampleService: CustomStringConvertible, Instantiable {
+                    public init() {}
+                    public var description: String { "ExampleService" }
+                }
+                """
+            }
+        }
+
         func test_declaration_doesNotAddFixitWhenRetroactiveInstantiableConformanceExists() {
             assertMacro {
                 """
@@ -2111,6 +2189,48 @@ import SafeDICore
             } fixes: {
                 """
                 @Instantiable
+                extension ExampleService: CustomStringConvertible, Instantiable {
+                    public static func instantiate() -> ExampleService { fatalError() }
+
+                    public var description: String { "ExampleService" }
+                }
+                """
+            } expansion: {
+                """
+                extension ExampleService: CustomStringConvertible, Instantiable {
+                    public static func instantiate() -> ExampleService { fatalError() }
+
+                    public var description: String { "ExampleService" }
+                }
+                """
+            }
+        }
+
+        func test_extension_fixit_addsFixitWhenInstantiableConformanceMissingAndConformsElsewhereIsFalse() {
+            assertMacro {
+                """
+                @Instantiable(conformsElsewhere: false)
+                extension ExampleService: CustomStringConvertible {
+                    public static func instantiate() -> ExampleService { fatalError() }
+
+                    public var description: String { "ExampleService" }
+                }
+                """
+            } diagnostics: {
+                """
+                @Instantiable(conformsElsewhere: false)
+                ┬──────────────────────────────────────
+                ╰─ 🛑 @Instantiable-decorated type or extension must declare conformance to `Instantiable`
+                   ✏️ Declare conformance to `Instantiable`
+                extension ExampleService: CustomStringConvertible {
+                    public static func instantiate() -> ExampleService { fatalError() }
+
+                    public var description: String { "ExampleService" }
+                }
+                """
+            } fixes: {
+                """
+                @Instantiable(conformsElsewhere: false)
                 extension ExampleService: CustomStringConvertible, Instantiable {
                     public static func instantiate() -> ExampleService { fatalError() }
 


### PR DESCRIPTION
Enables `@Instantiable`-decorated types and extensions to avoid being forced to conform to `Instantiable` by providing a flag to the macro. By enabling macro-decorated declarations to avoid conformance, we enable multiple locations to create `@Instantiable` extensions.

This feature is particularly powerful when paired with https://github.com/dfed/SafeDI/issues/86. You can imagine the following code:
```swift
public final class Container<Element>: Instantiable {
    public init(value: Element) {
        self.value = value
    }

    public let value: Element
}
```

And then in some other file that defines a `MyCustomEnum` writing:
```swift
@Instantiable(conformsElsewhere: true)
extension Container {
    public static func instantiate() -> Container<MyCustomEnum> {
        .init(value: .defaultValue)
    }
}
```

And in yet another file that defines a `MyCustomValue` writing:
```swift
@Instantiable(conformsElsewhere: true)
extension Container {
    public static func instantiate() -> Container<MyCustomValue?> {
        .init(value: nil)
    }
}
```