### PR TITLE
Explicitly declare root instantiables

### DIFF
--- a/Examples/ExampleMultiProjectIntegration/ExampleMultiProjectIntegration/Views/ExampleApp.swift
+++ b/Examples/ExampleMultiProjectIntegration/ExampleMultiProjectIntegration/Views/ExampleApp.swift
@@ -24,7 +24,7 @@ import Subproject
 import SwiftUI
 
 // @Instantiable macro marks this type as capable of being instantiated by SafeDI.
-@Instantiable
+@Instantiable(isRoot: true)
 @MainActor
 @main
 public struct NotesApp: Instantiable, App {

--- a/Examples/ExampleMultiProjectIntegration/ExampleMultiProjectIntegration/Views/ExampleApp.swift
+++ b/Examples/ExampleMultiProjectIntegration/ExampleMultiProjectIntegration/Views/ExampleApp.swift
@@ -23,7 +23,7 @@ import SafeDI
 import Subproject
 import SwiftUI
 
-// @Instantiable macro marks this type as capable of being instantiated by SafeDI.
+// @Instantiable macro marks this type as capable of being instantiated by SafeDI. The `isRoot` parameter marks this type as being the root of the dependency tree.
 @Instantiable(isRoot: true)
 @MainActor
 @main

--- a/Examples/ExamplePackageIntegration/Sources/RootModule/Root.swift
+++ b/Examples/ExamplePackageIntegration/Sources/RootModule/Root.swift
@@ -25,7 +25,7 @@ import Foundation
 import SafeDI
 import SharedModule
 
-@Instantiable @MainActor
+@Instantiable(isRoot: true) @MainActor
 public final class Root: Instantiable {
     public init(childA: ChildA, childB: ChildB, childC: ChildC, shared: SharedThing, userDefaults: UserDefaults) {
         self.childA = childA

--- a/Examples/ExampleProjectIntegration/ExampleProjectIntegration/Views/ExampleApp.swift
+++ b/Examples/ExampleProjectIntegration/ExampleProjectIntegration/Views/ExampleApp.swift
@@ -23,7 +23,7 @@ import SafeDI
 import SwiftUI
 
 // @Instantiable macro marks this type as capable of being instantiated by SafeDI.
-@Instantiable
+@Instantiable(isRoot: true)
 @MainActor
 @main
 public struct NotesApp: Instantiable, App {

--- a/Examples/ExampleProjectIntegration/ExampleProjectIntegration/Views/ExampleApp.swift
+++ b/Examples/ExampleProjectIntegration/ExampleProjectIntegration/Views/ExampleApp.swift
@@ -22,7 +22,7 @@ import Combine
 import SafeDI
 import SwiftUI
 
-// @Instantiable macro marks this type as capable of being instantiated by SafeDI.
+// @Instantiable macro marks this type as capable of being instantiated by SafeDI. The `isRoot` parameter marks this type as being the root of the dependency tree.
 @Instantiable(isRoot: true)
 @MainActor
 @main

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ public struct ParentView: View, Instantiable {
 
 ### Creating the root of your dependency tree
 
-Any type decorated `@Instantiable(isRoot: true)` is a root of a SafeDI dependency tree. SafeDI creates a `public init()` initializer that instantiates the dependency tree in an extension on each root type.
+Any type decorated with `@Instantiable(isRoot: true)` is a root of a SafeDI dependency tree. SafeDI creates a no-parameter `public init()` initializer that instantiates the dependency tree in an extension on each root type.
 
 ### Comparing SafeDI and Manual Injection: Key Differences
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ When you want to instantiate a dependency after `init(…)`, you need to declare
 The [`Instantiator`](Sources/SafeDI/DelayedInstantiation/Instantiator.swift) type is how SafeDI enables deferred instantiation of an `@Instantiable` type. `Instantiator` has a single generic that matches the type of the to-be-instantiated instance. Creating an `Instantiator` property is as simple as creating any other property in the SafeDI ecosystem:
 
 ```swift
-@Instantiable
+@Instantiable(isRoot: true)
 public struct MyApp: App, Instantiable {
     public init(contentViewInstantiator: Instantiator<ContentView>) {
         self.contentViewInstantiator = contentViewInstantiator
@@ -353,13 +353,7 @@ public struct ParentView: View, Instantiable {
 
 ### Creating the root of your dependency tree
 
-SafeDI automatically finds the root(s) of your dependency tree, and creates an extension on each root that contains a `public init()` function that instantiates the dependency tree.
-
-An `@Instantiable` type qualifies as the root of a dependency tree if and only if:
-
-1. The type‘s SafeDI-injected properties are all `@Instantiated` or `@Received(fulfilledByDependencyNamed:ofType:)`
-2. The type‘s `@Received(fulfilledByDependencyNamed:ofType:)` properties can be fulfilled by `@Instantiated` or `@Received(fulfilledByDependencyNamed:ofType:)` properties declared on this type
-3. The type is not instantiated by another `@Instantiable` type
+Any type decorated `@Instantiable(isRoot: true)` is a root of a SafeDI dependency tree. SafeDI creates a `public init()` initializer that instantiates the dependency tree in an extension on each root type.
 
 ### Comparing SafeDI and Manual Injection: Key Differences
 

--- a/Sources/SafeDI/PropertyDecoration/Instantiable.swift
+++ b/Sources/SafeDI/PropertyDecoration/Instantiable.swift
@@ -52,10 +52,12 @@
 ///     }
 ///
 /// - Parameters:
+///   - isRoot: Whether the decorated type represents a root of a dependency tree.
 ///   - additionalTypes: The types (in addition to the type decorated with this macro) of properties that can be decorated with `@Instantiated` and yield a result of this type. The types provided *must* be either superclasses of this type or protocols to which this type conforms.
 ///   - conformsElsewhere: Whether the decorated type already conforms to the `Instantiable` protocol elsewhere. If set to `true`, the macro does not enforce that this declaration conforms to `Instantiable`.
 @attached(member, names: arbitrary)
 public macro Instantiable(
+    isRoot: Bool = false,
     fulfillingAdditionalTypes additionalTypes: [Any.Type] = [],
     conformsElsewhere: Bool = false
 ) = #externalMacro(module: "SafeDIMacros", type: "InstantiableMacro")

--- a/Sources/SafeDICore/Extensions/AttributeSyntaxExtensions.swift
+++ b/Sources/SafeDICore/Extensions/AttributeSyntaxExtensions.swift
@@ -21,11 +21,25 @@
 import SwiftSyntax
 
 extension AttributeSyntax {
-    public var fulfillingAdditionalTypes: ExprSyntax? {
+    public var isRoot: ExprSyntax? {
         guard let arguments,
               let labeledExpressionList = LabeledExprListSyntax(arguments),
               let firstLabeledExpression = labeledExpressionList.first,
-              firstLabeledExpression.label?.text == "fulfillingAdditionalTypes"
+              firstLabeledExpression.label?.text == "isRoot"
+        else {
+            return nil
+        }
+
+        return firstLabeledExpression.expression
+    }
+
+    public var fulfillingAdditionalTypes: ExprSyntax? {
+        guard let arguments,
+              let labeledExpressionList = LabeledExprListSyntax(arguments),
+              let firstLabeledExpression = labeledExpressionList.first(where: {
+                  // In `@Instantiatable`, the `fulfillingAdditionalTypes` parameter is the second parameter, though the first parameter has a default.
+                  $0.label?.text == "fulfillingAdditionalTypes"
+              })
         else {
             return nil
         }

--- a/Sources/SafeDICore/Generators/DependencyTreeGenerator.swift
+++ b/Sources/SafeDICore/Generators/DependencyTreeGenerator.swift
@@ -358,10 +358,7 @@ public actor DependencyTreeGenerator {
                 let parentContainsProperty = receivableProperties.contains(receivedProperty)
                 let propertyIsCreatedAtThisScope = createdProperties.contains(receivedProperty)
                 if !parentContainsProperty, !propertyIsCreatedAtThisScope {
-                    if property == nil {
-                        // This property's scope is not a real root instantiable! Remove it from the list.
-                        rootInstantiables.remove(scope.instantiable.concreteInstantiable)
-                    } else {
+                    if property != nil {
                         // This property is in a dependency tree and is unfulfillable. Record the problem.
                         unfulfillableProperties.insert(.init(
                             property: receivedProperty,

--- a/Sources/SafeDICore/Generators/DependencyTreeGenerator.swift
+++ b/Sources/SafeDICore/Generators/DependencyTreeGenerator.swift
@@ -243,15 +243,13 @@ public actor DependencyTreeGenerator {
         // Create the mapping.
         let typeDescriptionToScopeMap: [TypeDescription: Scope] = reachableTypeDescriptions
             .reduce(into: [TypeDescription: Scope]()) { partialResult, typeDescription in
-                guard let instantiable = typeDescriptionToFulfillingInstantiableMap[typeDescription],
-                      partialResult[instantiable.concreteInstantiable] == nil
-                else {
-                    // We've already created a scope for this `instantiable`. Skip.
-                    return
-                }
-                let scope = Scope(instantiable: instantiable)
-                for instantiableType in instantiable.instantiableTypes {
-                    partialResult[instantiableType] = scope
+                if let instantiable = typeDescriptionToFulfillingInstantiableMap[typeDescription],
+                   partialResult[instantiable.concreteInstantiable] == nil
+                {
+                    let scope = Scope(instantiable: instantiable)
+                    for instantiableType in instantiable.instantiableTypes {
+                        partialResult[instantiableType] = scope
+                    }
                 }
             }
 

--- a/Sources/SafeDICore/Models/Instantiable.swift
+++ b/Sources/SafeDICore/Models/Instantiable.swift
@@ -23,12 +23,14 @@ public struct Instantiable: Codable, Hashable, Sendable {
 
     public init(
         instantiableType: TypeDescription,
+        isRoot: Bool,
         initializer: Initializer?,
         additionalInstantiables: [TypeDescription]?,
         dependencies: [Dependency],
         declarationType: DeclarationType
     ) {
         instantiableTypes = [instantiableType] + (additionalInstantiables ?? [])
+        self.isRoot = isRoot
         self.initializer = initializer
         self.dependencies = dependencies
         self.declarationType = declarationType
@@ -43,6 +45,8 @@ public struct Instantiable: Codable, Hashable, Sendable {
         instantiableTypes[0]
     }
 
+    /// Whether the instantiable type is a root of a dependency graph.
+    public let isRoot: Bool
     /// A memberwise initializer for the concrete instantiable type.
     /// If `nil`, the Instanitable type is incorrectly configured.
     public let initializer: Initializer?

--- a/Sources/SafeDICore/Models/Property.swift
+++ b/Sources/SafeDICore/Models/Property.swift
@@ -47,6 +47,11 @@ public struct Property: Codable, Hashable, Comparable, Sendable {
         )
     }
 
+    /// The property represented as source code.
+    public var asSource: String {
+        "\(label): \(typeDescription.asSource)"
+    }
+
     // MARK: Hashable
 
     public static func < (lhs: Property, rhs: Property) -> Bool {
@@ -54,11 +59,6 @@ public struct Property: Codable, Hashable, Comparable, Sendable {
     }
 
     // MARK: Internal
-
-    /// The property represented as source code.
-    var asSource: String {
-        "\(label): \(typeDescription.asSource)"
-    }
 
     var asFunctionParamter: FunctionParameterSyntax {
         switch typeDescription {

--- a/Sources/SafeDITool/SafeDITool.swift
+++ b/Sources/SafeDITool/SafeDITool.swift
@@ -99,6 +99,7 @@ struct SafeDITool: AsyncParsableCommand, Sendable {
             }
             return Instantiable(
                 instantiableType: unnormalizedInstantiable.concreteInstantiable,
+                isRoot: unnormalizedInstantiable.isRoot,
                 initializer: normalizedInitializer,
                 additionalInstantiables: normalizedAdditionalInstantiables,
                 dependencies: normalizedDependencies,

--- a/Tests/SafeDICoreTests/FileVisitorTests.swift
+++ b/Tests/SafeDICoreTests/FileVisitorTests.swift
@@ -48,6 +48,7 @@ final class FileVisitorTests: XCTestCase {
             [
                 Instantiable(
                     instantiableType: .simple(name: "LoggedInViewController"),
+                    isRoot: false,
                     initializer: Initializer(
                         arguments: [
                             .init(
@@ -111,6 +112,7 @@ final class FileVisitorTests: XCTestCase {
             [
                 Instantiable(
                     instantiableType: .simple(name: "LoggedInViewController"),
+                    isRoot: false,
                     initializer: Initializer(
                         arguments: [
                             .init(
@@ -146,6 +148,7 @@ final class FileVisitorTests: XCTestCase {
                 ),
                 Instantiable(
                     instantiableType: .simple(name: "SomeOtherInstantiable"),
+                    isRoot: false,
                     initializer: Initializer(arguments: []),
                     additionalInstantiables: nil,
                     dependencies: [],
@@ -173,6 +176,7 @@ final class FileVisitorTests: XCTestCase {
             [
                 Instantiable(
                     instantiableType: .simple(name: "OuterLevel"),
+                    isRoot: false,
                     initializer: Initializer(arguments: []),
                     additionalInstantiables: [
                         .simple(name: "SomeProtocol"),
@@ -182,6 +186,7 @@ final class FileVisitorTests: XCTestCase {
                 ),
                 Instantiable(
                     instantiableType: .nested(name: "InnerLevel", parentType: .simple(name: "OuterLevel")),
+                    isRoot: false,
                     initializer: Initializer(arguments: []),
                     additionalInstantiables: [],
                     dependencies: [],
@@ -208,6 +213,7 @@ final class FileVisitorTests: XCTestCase {
             [
                 Instantiable(
                     instantiableType: .simple(name: "OuterLevel"),
+                    isRoot: false,
                     initializer: Initializer(arguments: []),
                     additionalInstantiables: [],
                     dependencies: [],
@@ -215,6 +221,7 @@ final class FileVisitorTests: XCTestCase {
                 ),
                 Instantiable(
                     instantiableType: .nested(name: "InnerLevel", parentType: .simple(name: "OuterLevel")),
+                    isRoot: false,
                     initializer: Initializer(arguments: []),
                     additionalInstantiables: [],
                     dependencies: [],
@@ -252,6 +259,7 @@ final class FileVisitorTests: XCTestCase {
             [
                 Instantiable(
                     instantiableType: .simple(name: "OuterLevel"),
+                    isRoot: false,
                     initializer: Initializer(arguments: []),
                     additionalInstantiables: [],
                     dependencies: [],
@@ -259,6 +267,7 @@ final class FileVisitorTests: XCTestCase {
                 ),
                 Instantiable(
                     instantiableType: .nested(name: "InnerLevel1", parentType: .simple(name: "OuterLevel")),
+                    isRoot: false,
                     initializer: Initializer(arguments: []),
                     additionalInstantiables: [],
                     dependencies: [],
@@ -266,6 +275,7 @@ final class FileVisitorTests: XCTestCase {
                 ),
                 Instantiable(
                     instantiableType: .nested(name: "InnerLevel2", parentType: .simple(name: "OuterLevel")),
+                    isRoot: false,
                     initializer: Initializer(arguments: []),
                     additionalInstantiables: [],
                     dependencies: [],
@@ -273,6 +283,7 @@ final class FileVisitorTests: XCTestCase {
                 ),
                 Instantiable(
                     instantiableType: .nested(name: "InnerLevel3", parentType: .simple(name: "OuterLevel")),
+                    isRoot: false,
                     initializer: Initializer(arguments: []),
                     additionalInstantiables: [],
                     dependencies: [],
@@ -297,6 +308,7 @@ final class FileVisitorTests: XCTestCase {
             [
                 Instantiable(
                     instantiableType: .nested(name: "InnerLevel", parentType: .simple(name: "OuterLevel")),
+                    isRoot: false,
                     initializer: Initializer(arguments: []),
                     additionalInstantiables: [],
                     dependencies: [],

--- a/Tests/SafeDIToolTests/SafeDIToolCodeGenerationErrorTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolCodeGenerationErrorTests.swift
@@ -54,7 +54,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import UIKit
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class RootViewController: UIViewController {
                         @Instantiated(fulfilledByType: "DoesNotExist")
                         let networkService: NetworkService
@@ -81,7 +81,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import SafeDI
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated let childBuilder: Instantiator<Child>
                     }
@@ -125,7 +125,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import SafeDI
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated let childBuilder: Instantiator<Child>
                     }
@@ -178,7 +178,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import UIKit
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class RootViewController: UIViewController {
                         @Instantiated
                         let networkService: NetworkService
@@ -214,7 +214,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import UIKit
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class RootViewController: UIViewController {
                         @Instantiated
                         let networkService: NetworkService
@@ -241,7 +241,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import SafeDI
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated(fulfilledByType: "SomeErasedType") let erasedType: ErasedType
                         @Instantiated let child: Child
@@ -284,7 +284,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import SafeDI
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated(fulfilledByType: "SomeErasedType") let erasedType: any ErasedType
                         @Instantiated let child: Child
@@ -327,7 +327,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import SafeDI
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated let thing: Thing
                         @Instantiated let child: Child
@@ -368,7 +368,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import SafeDI
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated let thing: Thing!
                         @Instantiated let child: Child
@@ -409,7 +409,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import SafeDI
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated let thing: Thing
                         @Instantiated let child: Child
@@ -450,7 +450,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import SafeDI
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated let thing: Thing?
                         @Instantiated let child: Child
@@ -491,7 +491,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import SafeDI
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated let thing: Thing
                         @Instantiated let child: Child
@@ -536,7 +536,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import SafeDI
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated let thing: Thing
                         @Instantiated let otherThing: OtherThing
@@ -590,7 +590,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import UIKit
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class RootViewController: UIViewController {
                         @Instantiated
                         let networkService: NetworkService
@@ -613,7 +613,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
             try await executeSafeDIToolTest(
                 swiftFileContent: [
                     """
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated
                         let childA: ChildA
@@ -669,7 +669,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
             try await executeSafeDIToolTest(
                 swiftFileContent: [
                     """
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated
                         let childA: ChildA
@@ -755,7 +755,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import UIKit
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class RootViewController: UIViewController {
                         public init(authService: AuthService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                             self.authService = authService
@@ -816,7 +816,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import UIKit
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class RootViewController: UIViewController {
                         public init(authService: AuthService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                             self.authService = authService
@@ -859,7 +859,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import UIKit
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class RootViewController: UIViewController {
                         @Instantiated
                         let networkService: NetworkService
@@ -917,7 +917,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import UIKit
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class RootViewController: UIViewController {
                         @Instantiated
                         let networkService: NetworkService
@@ -993,7 +993,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import UIKit
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class RootViewController: UIViewController {
                         public init(authService: AuthService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                             self.authService = authService
@@ -1034,7 +1034,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import UIKit
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class RootViewController: UIViewController {
                         @Instantiated
                         let urlSessionWrapper: URLSessionWrapper
@@ -1048,7 +1048,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
     }
 
     @MainActor
-    func test_run_onCodeWithDuplicateInstantiable_throwsError() async {
+    func test_run_onCodeWithDuplicateInstantiableNames_throwsError() async {
         await assertThrowsError(
             """
             @Instantiable-decorated types and extensions must have globally unique type names and fulfill globally unqiue types. Found multiple types or extensions fulfilling `RootViewController`
@@ -1076,7 +1076,35 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
     }
 
     @MainActor
-    func test_run_onCodeWithDuplicateInstantiableAndInstantiable_throwsError() async {
+    func test_run_onCodeWithDuplicateInstantiableNamesWhereOneIsRoot_throwsError() async {
+        await assertThrowsError(
+            """
+            @Instantiable-decorated types and extensions must have globally unique type names and fulfill globally unqiue types. Found multiple types or extensions fulfilling `RootViewController`
+            """
+        ) {
+            try await executeSafeDIToolTest(
+                swiftFileContent: [
+                    """
+                    import UIKit
+
+                    @Instantiable(isRoot: true)
+                    public final class RootViewController: UIViewController {}
+                    """,
+                    """
+                    import UIKit
+
+                    @Instantiable
+                    public final class RootViewController: UIViewController {}
+                    """,
+                ],
+                buildDependencyTreeOutput: true,
+                filesToDelete: &filesToDelete
+            )
+        }
+    }
+
+    @MainActor
+    func test_run_onCodeWithDuplicateInstantiableNamesViaDeclarationAndExtension_throwsError() async {
         await assertThrowsError(
             """
             @Instantiable-decorated types and extensions must have globally unique type names and fulfill globally unqiue types. Found multiple types or extensions fulfilling `RootViewController`
@@ -1108,7 +1136,71 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
     }
 
     @MainActor
-    func test_run_onCodeWithDuplicateInstantiableViaExtension_throwsError() async {
+    func test_run_onCodeWithDuplicateInstantiableNamesViaDeclarationAndExtensionWhereDeclarationIsRoot_throwsError() async {
+        await assertThrowsError(
+            """
+            @Instantiable-decorated types and extensions must have globally unique type names and fulfill globally unqiue types. Found multiple types or extensions fulfilling `RootViewController`
+            """
+        ) {
+            try await executeSafeDIToolTest(
+                swiftFileContent: [
+                    """
+                    import UIKit
+
+                    @Instantiable(isRoot: true)
+                    public final class RootViewController: UIViewController {}
+                    """,
+                    """
+                    import UIKit
+
+                    @Instantiable
+                    extension RootViewController: Instantiable {
+                        public static func instantiate() -> RootViewController {
+                            RootViewController()
+                        }
+                    }
+                    """,
+                ],
+                buildDependencyTreeOutput: true,
+                filesToDelete: &filesToDelete
+            )
+        }
+    }
+
+    @MainActor
+    func test_run_onCodeWithDuplicateInstantiableNamesViaDeclarationAndExtensionWhereExtensionIsRoot_throwsError() async {
+        await assertThrowsError(
+            """
+            @Instantiable-decorated types and extensions must have globally unique type names and fulfill globally unqiue types. Found multiple types or extensions fulfilling `RootViewController`
+            """
+        ) {
+            try await executeSafeDIToolTest(
+                swiftFileContent: [
+                    """
+                    import UIKit
+
+                    @Instantiable
+                    public final class RootViewController: UIViewController {}
+                    """,
+                    """
+                    import UIKit
+
+                    @Instantiable(isRoot: true)
+                    extension RootViewController: Instantiable {
+                        public static func instantiate() -> RootViewController {
+                            RootViewController()
+                        }
+                    }
+                    """,
+                ],
+                buildDependencyTreeOutput: true,
+                filesToDelete: &filesToDelete
+            )
+        }
+    }
+
+    @MainActor
+    func test_run_onCodeWithDuplicateInstantiableNamesViaExtension_throwsError() async {
         await assertThrowsError(
             """
             @Instantiable-decorated types and extensions must have globally unique type names and fulfill globally unqiue types. Found multiple types or extensions fulfilling `UserDefaults`
@@ -1155,7 +1247,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import UIKit
 
-                    @Instantiable(fulfillingAdditionalTypes: [UIViewController.self])
+                    @Instantiable(isRoot: true, fulfillingAdditionalTypes: [UIViewController.self])
                     public final class RootViewController: UIViewController {}
                     """,
                     """
@@ -1182,7 +1274,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
             try await executeSafeDIToolTest(
                 swiftFileContent: [
                     """
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated
                         let a: A
@@ -1227,7 +1319,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
             try await executeSafeDIToolTest(
                 swiftFileContent: [
                     """
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class Root {
                         @Instantiated let a: A
                     }
@@ -1268,7 +1360,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
             try await executeSafeDIToolTest(
                 swiftFileContent: [
                     """
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public struct Root {
                         @Instantiated let aBuilder: Instantiator<A>
                     }
@@ -1309,7 +1401,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
             try await executeSafeDIToolTest(
                 swiftFileContent: [
                     """
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public struct Root {
                         @Instantiated
                         let a: A
@@ -1354,7 +1446,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
             try await executeSafeDIToolTest(
                 swiftFileContent: [
                     """
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public struct Root {
                         @Instantiated
                         private let a: A
@@ -1403,7 +1495,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
             try await executeSafeDIToolTest(
                 swiftFileContent: [
                     """
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public struct Root {
                         @Instantiated
                         private let a: A
@@ -1454,7 +1546,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
             try await executeSafeDIToolTest(
                 swiftFileContent: [
                     """
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public struct Root {
                         @Instantiated
                         private let a: A
@@ -1530,7 +1622,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import UIKit
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class RootViewController: UIViewController {
                         public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<String, UIViewController>) {
                             self.authService = authService
@@ -1616,7 +1708,7 @@ final class SafeDIToolCodeGenerationErrorTests: XCTestCase {
                     """
                     import UIKit
 
-                    @Instantiable
+                    @Instantiable(isRoot: true)
                     public final class RootViewController: UIViewController {
                         public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<String, UIViewController>) {
                             self.authService = authService

--- a/Tests/SafeDIToolTests/SafeDIToolCodeGenerationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolCodeGenerationTests.swift
@@ -71,7 +71,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
 
                 public protocol NetworkService {}
 
-                @Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
+                @Instantiable(isRoot: true, fulfillingAdditionalTypes: [NetworkService.self])
                 public final class DefaultNetworkService: NetworkService {
                     let urlSession: URLSession = .shared
                 }
@@ -114,7 +114,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(networkService: NetworkService) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -166,7 +166,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public actor Root {
                     public init(networkService: NetworkService) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -218,7 +218,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     public init(networkService: NetworkService) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -270,7 +270,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root1 {
                     public init(networkService: NetworkService) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -280,7 +280,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root2 {
                     public init(networkService: NetworkService) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -327,7 +327,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     public init(userService: any UserService) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -394,7 +394,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class SomeInstantiated: Instantiable {
                     public init(someClass: any SomeProtocol<OtherType>) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -433,7 +433,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     public init(userService: UserService?) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -518,7 +518,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<User, UIViewController>) {
                         self.authService = authService
@@ -628,7 +628,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                         self.authService = authService
@@ -731,7 +731,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(networkServiceBuilder: Instantiator<NetworkService>) {
                         self.networkServiceBuilder = networkServiceBuilder
@@ -811,7 +811,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<(userID: String, userName: String), UIViewController>) {
                         self.authService = authService
@@ -941,7 +941,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<LoggedInViewController.ForwardedProperties, UIViewController>) {
                         self.authService = authService
@@ -1039,7 +1039,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import SwiftUI
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct RootView: View {
                     public init(splashScreenView: AnyView) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1093,7 +1093,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import SwiftUI
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct RootView: View {
                     public init(splashScreenViewBuilder: ErasedInstantiator<(), AnyView>) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1181,7 +1181,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                         self.authService = authService
@@ -1303,7 +1303,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                         self.authService = authService
@@ -1398,7 +1398,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable()
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1408,7 +1408,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class Child {
                     // This Child is incorrectly configured! It is missing the required initializer.
 
@@ -1418,7 +1418,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class Grandchild {
                     public init() {}
                 }
@@ -1454,7 +1454,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable()
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1464,7 +1464,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class Child {
                     public init(grandchild: Grandchild, nonInjectedProperty: Int = 5) {
                         self.grandchild = grandchild
@@ -1477,7 +1477,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class Grandchild {
                     public init() {}
                 }
@@ -1513,7 +1513,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable()
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1523,7 +1523,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 final class Child {
                     public init(grandchild: Grandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1533,7 +1533,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class Grandchild {
                     public init() {}
                 }
@@ -1569,7 +1569,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable()
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1579,7 +1579,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 final class Child {
                     public init(grandchild: Grandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1589,7 +1589,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class Grandchild {
                     public init() {}
                 }
@@ -1625,7 +1625,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable()
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(childA: ChildA, childB: ChildB, greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1637,7 +1637,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class ChildA {
                     public init(grandchildAA: GrandchildAA, grandchildAB: GrandchildAB) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1648,7 +1648,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAA {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1658,7 +1658,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAB {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1668,7 +1668,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class ChildB {
                     public init(grandchildBA: GrandchildBA, grandchildBB: GrandchildBB) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1679,7 +1679,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBA {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1689,7 +1689,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBB {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1699,7 +1699,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GreatGrandchild {
                     public init() {}
                 }
@@ -1744,7 +1744,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable()
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(childA: ChildA, childB: ChildB) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1755,7 +1755,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class ChildA {
                     public init(grandchildAA: GrandchildAA, grandchildAB: GrandchildAB, greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1767,7 +1767,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAA {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1777,7 +1777,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAB {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1787,7 +1787,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class ChildB {
                     public init(grandchildBA: GrandchildBA, grandchildBB: GrandchildBB, greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1799,7 +1799,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBA {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1809,7 +1809,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBB {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1819,7 +1819,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GreatGrandchild {
                     public init() {}
                 }
@@ -1865,7 +1865,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -1950,7 +1950,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child, recreated: Recreated) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2037,7 +2037,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child, recreated: Recreated) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2138,7 +2138,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2259,7 +2259,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(childABuilder: SendableErasedInstantiator<Recreated, ChildAProtocol>, childB: ChildB, recreated: Recreated) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2391,7 +2391,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable()
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(childA: ChildA, childB: ChildB) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2402,7 +2402,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class ChildA {
                     public init(grandchildAA: GrandchildAA, grandchildAB: GrandchildAB) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2413,7 +2413,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAA {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2423,7 +2423,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAB {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2433,7 +2433,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class ChildB {
                     public init(grandchildBA: GrandchildBA, grandchildBB: GrandchildBB) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2444,7 +2444,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBA {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2454,7 +2454,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBB {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2464,7 +2464,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GreatGrandchild {
                     public init() {}
                 }
@@ -2524,7 +2524,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable()
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child, keyValueStore: KeyValueStore) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2535,7 +2535,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class Child {
                     public init(keyValueStore: KeyValueStore) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2630,7 +2630,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<User, UIViewController>) {
                         self.authService = authService
@@ -2734,7 +2734,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let greatGrandchildModuleOutput = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GreatGrandchild: Sendable {
                     public init() {}
                 }
@@ -2749,7 +2749,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import GreatGrandchildModule
 
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAA {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2761,7 +2761,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import GreatGrandchildModule
 
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAB {
                     public init(greatGrandchild: GreatGrandchild) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2773,7 +2773,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import GreatGrandchildModule
 
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBA {
                     public init(greatGrandchildInstantiator: SendableInstantiator<GreatGrandchild>) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2785,7 +2785,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import GreatGrandchildModule
 
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBB {
                     public init(greatGrandchildInstantiator: SendableInstantiator<GreatGrandchild>) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2820,7 +2820,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 @preconcurrency import GrandchildModule
 
-                @Instantiable()
+                @Instantiable
                 public final class ChildB {
                     public init(grandchildBA: GrandchildBA, grandchildBB: GrandchildBB) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2845,7 +2845,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 import ChildModule
 
                 @MainActor
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(childA: ChildA, childB: ChildB) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2930,7 +2930,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     public init(defaultUserService: DefaultUserService, userService: any UserService) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -2989,26 +2989,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 @Instantiable
                 public struct NotRoot {
-                    @Instantiated
-                    private let defaultUserService: DefaultUserService
-
-                    // This received property's alias is improperly configured, meaning that this type is not a root.
-                    @Received(fulfilledByDependencyNamed: "userService", ofType: DefaultUserService.self)
-                    private let userService: any UserService
-                }
-                """,
-                """
-                import Foundation
-
-                public protocol UserService {
-                    var userName: String? { get set }
-                }
-
-                @Instantiable(fulfillingAdditionalTypes: [UserService.self])
-                public final class DefaultUserService: UserService {
                     public init() {}
-
-                    public var userName: String?
                 }
                 """,
             ],
@@ -3023,9 +3004,32 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
             // Any modifications made to this file will be overwritten on subsequent builds.
             // Please refrain from editing this file directly.
 
-            #if canImport(Foundation)
-            import Foundation
-            #endif
+            // No root @Instantiable-decorated types found, or root types already had a `public init()` method.
+            """
+        )
+    }
+
+    @MainActor
+    func test_run_successfullyGeneratesOutputFileWhenIsRootIsFalse() async throws {
+        let output = try await executeSafeDIToolTest(
+            swiftFileContent: [
+                """
+                @Instantiable(isRoot: false)
+                public struct NotRoot {
+                    public init() {}
+                }
+                """,
+            ],
+            buildDependencyTreeOutput: true,
+            filesToDelete: &filesToDelete
+        )
+
+        XCTAssertEqual(
+            try XCTUnwrap(output.dependencyTree),
+            """
+            // This file was generated by the SafeDIGenerateDependencyTree build tool plugin.
+            // Any modifications made to this file will be overwritten on subsequent builds.
+            // Please refrain from editing this file directly.
 
             // No root @Instantiable-decorated types found, or root types already had a `public init()` method.
             """
@@ -3084,7 +3088,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                         self.authService = authService
@@ -3196,7 +3200,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(childBuilder: Instantiator<Child>) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -3314,7 +3318,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                         self.authService = authService
@@ -3466,7 +3470,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService) {
                         self.authService = authService
@@ -3546,7 +3550,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService) {
                         self.authService = authService
@@ -3643,7 +3647,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                         self.authService = authService
@@ -3802,7 +3806,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                         self.authService = authService
@@ -3912,7 +3916,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -3988,7 +3992,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -4374,7 +4378,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(childBuilder: Instantiator<Child>?) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -4419,7 +4423,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     public init(aBuilder: Instantiator<A>) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -4497,7 +4501,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     public init(a: A) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -4575,7 +4579,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     public init(a: A) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -4629,7 +4633,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     public init(aBuilder: Instantiator<A>) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -4684,7 +4688,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     public init(stringContainer: Container<String>, intContainer: Container<Int>, floatContainer: Container<Float>, voidContainer: Container<Void>) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -4746,7 +4750,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     public init(stringContainer: MyModule.Container<String>, intContainer: MyModule.Container<Int>, floatContainer: MyModule.Container<Float>, voidContainer: MyModule.Container<Void>) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -4825,7 +4829,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -4910,7 +4914,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -5004,7 +5008,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -5099,7 +5103,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -5167,7 +5171,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -5230,7 +5234,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     public init(child: Child) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -5283,7 +5287,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class TypeWithDependency {
                     public init(erasedType: ErasedType ) {
                         fatalError("SafeDI doesn't inspect the initializer body")
@@ -5336,7 +5340,7 @@ final class SafeDIToolCodeGenerationTests: XCTestCase {
                     // Extension defined before an @Instantiable should not make a difference.
                 }
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class TypeWithDependency {
                     public init(erasedType: ErasedType ) {
                         fatalError("SafeDI doesn't inspect the initializer body")

--- a/Tests/SafeDIToolTests/SafeDIToolDOTGenerationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolDOTGenerationTests.swift
@@ -76,7 +76,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     @Instantiated
                     let networkService: NetworkService
@@ -113,14 +113,14 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root1 {
                     @Instantiated
                     let networkService: NetworkService
                 }
                 """,
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root2 {
                     @Instantiated
                     let networkService: NetworkService
@@ -175,7 +175,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<User, UIViewController>) {
                         self.authService = authService
@@ -264,7 +264,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                         self.authService = authService
@@ -366,7 +366,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<(userID: String, userName: String), UIViewController>) {
                         self.authService = authService
@@ -476,7 +476,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<LoggedInViewController.ForwardedProperties, UIViewController>) {
                         self.authService = authService
@@ -583,7 +583,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                         self.authService = authService
@@ -684,7 +684,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                         self.authService = authService
@@ -760,7 +760,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable()
+                @Instantiable(isRoot: true)
                 public final class Root {
                     @Instantiated
                     let childA: ChildA
@@ -771,7 +771,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class ChildA {
                     @Instantiated
                     let grandchildAA: GrandchildAA
@@ -780,21 +780,21 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAA {
                     @Received
                     let greatGrandchild: GreatGrandchild
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAB {
                     @Received
                     let greatGrandchild: GreatGrandchild
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class ChildB {
                     @Instantiated
                     let grandchildBA: GrandchildBA
@@ -803,21 +803,21 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBA {
                     @Received
                     let greatGrandchild: GreatGrandchild
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBB {
                     @Received
                     let greatGrandchild: GreatGrandchild
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GreatGrandchild {}
                 """,
 
@@ -848,7 +848,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable()
+                @Instantiable(isRoot: true)
                 public final class Root {
                     @Instantiated
                     let childA: ChildA
@@ -857,7 +857,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class ChildA {
                     @Instantiated
                     let grandchildAA: GrandchildAA
@@ -868,21 +868,21 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAA {
                     @Received
                     let greatGrandchild: GreatGrandchild
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAB {
                     @Received
                     let greatGrandchild: GreatGrandchild
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class ChildB {
                     @Instantiated
                     let grandchildBA: GrandchildBA
@@ -893,21 +893,21 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBA {
                     @Received
                     let greatGrandchild: GreatGrandchild
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBB {
                     @Received
                     let greatGrandchild: GreatGrandchild
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GreatGrandchild {}
                 """,
 
@@ -939,7 +939,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     @Instantiated
                     let child: Child
@@ -1000,7 +1000,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable()
+                @Instantiable(isRoot: true)
                 public final class Root {
                     @Instantiated
                     let childA: ChildA
@@ -1009,7 +1009,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class ChildA {
                     @Instantiated
                     let grandchildAA: GrandchildAA
@@ -1018,21 +1018,21 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAA {
                     @Instantiated
                     let greatGrandchild: GreatGrandchild
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAB {
                     @Instantiated
                     let greatGrandchild: GreatGrandchild
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class ChildB {
                     @Instantiated
                     let grandchildBA: GrandchildBA
@@ -1041,21 +1041,21 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBA {
                     @Instantiated
                     let greatGrandchild: GreatGrandchild
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBB {
                     @Instantiated
                     let greatGrandchild: GreatGrandchild
                 }
                 """,
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GreatGrandchild {}
                 """,
 
@@ -1089,7 +1089,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let greatGrandchildModuleOutput = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable()
+                @Instantiable
                 public final class GreatGrandchild: Sendable {}
                 """,
             ],
@@ -1102,7 +1102,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 """
                 import GreatGrandchildModule
 
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAA {
                     @Instantiated
                     let greatGrandchild: GreatGrandchild
@@ -1111,7 +1111,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 """
                 import GreatGrandchildModule
 
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildAB {
                     @Instantiated
                     let greatGrandchild: GreatGrandchild
@@ -1120,7 +1120,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 """
                 import GreatGrandchildModule
 
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBA {
                     @Instantiated
                     var greatGrandchildInstantiator: SendableInstantiator<GreatGrandchild>
@@ -1129,7 +1129,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 """
                 import GreatGrandchildModule
 
-                @Instantiable()
+                @Instantiable
                 public final class GrandchildBB {
                     @Instantiated
                     greatGrandchildInstantiator: SendableInstantiator<GreatGrandchild>
@@ -1159,7 +1159,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 """
                 @preconcurrency import GrandchildModule
 
-                @Instantiable()
+                @Instantiable
                 public final class ChildB {
                     @Instantiated
                     let grandchildBA: GrandchildBA
@@ -1182,7 +1182,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 import ChildModule
 
                 @MainActor
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     @Instantiated
                     let childA: ChildA
@@ -1225,7 +1225,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     @Instantiated
                     private let defaultUserService: DefaultUserService
@@ -1302,7 +1302,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
                 """
                 import UIKit
 
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class RootViewController: UIViewController {
                     public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
                         self.authService = authService
@@ -1342,7 +1342,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     @Instantiated
                     let child: Child
@@ -1398,7 +1398,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public final class Root {
                     @Instantiated
                     let a: A
@@ -1772,7 +1772,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     @Instantiated
                     let aBuilder: Instantiator<A>
@@ -1823,7 +1823,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     @Instantiated
                     let a: A
@@ -1874,7 +1874,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     @Instantiated
                     let a: A
@@ -1910,7 +1910,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     @Instantiated
                     let aBuilder: Instantiator<A>
@@ -1949,7 +1949,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     @Instantiated let stringContainer: Container<String>
                     @Instantiated let intContainer: Container<Int>
@@ -2001,7 +2001,7 @@ final class SafeDIToolDOTGenerationTests: XCTestCase {
         let output = try await executeSafeDIToolTest(
             swiftFileContent: [
                 """
-                @Instantiable
+                @Instantiable(isRoot: true)
                 public struct Root {
                     @Instantiated let stringContainer: MyModule.Container<String>
                     @Instantiated let intContainer: MyModule.Container<Int>


### PR DESCRIPTION
Finding the `@Instantiable`-decorated types that are roots of a dependency tree automatically is a bit magical, but also comes with a concrete downside: when writing a brand new type that only has `@Instantiated` dependencies, `SafeDI` complains during builds until that new type is `@Instantiated` by another `@Instantiable`-decorated type.

This case is difficult for newcomers to SafeDI to debug, and also annoys veteran SafeDI consumers.

This PR represents a breaking change from the `0.9.*` release, and is intended to land prior to a `1.0.0` release. This PR will land _after_ a `0.9.1` release is created.