### PR TITLE
Improve formatting of initializer fixit

### DIFF
--- a/Sources/SafeDICore/Models/Initializer.swift
+++ b/Sources/SafeDICore/Models/Initializer.swift
@@ -136,14 +136,24 @@ public struct Initializer: Codable, Hashable, Sendable {
     public static func generateRequiredInitializer(
         for dependencies: [Dependency],
         declarationType: ConcreteDeclType,
-        andAdditionalPropertiesWithLabels additionalPropertyLabels: [String] = []
+        andAdditionalPropertiesWithLabels additionalPropertyLabels: [String] = [],
+        formatForFixit: Bool = false
     ) -> InitializerDeclSyntax {
         InitializerDeclSyntax(
             modifiers: declarationType.initializerModifiers,
             signature: FunctionSignatureSyntax(
                 parameterClause: FunctionParameterClauseSyntax(
                     parameters: FunctionParameterListSyntax(itemsBuilder: {
-                        for functionParameter in dependencies.initializerFunctionParameters {
+                        for functionParameter in dependencies.initializerFunctionParameters.enumerated().map({ index, parameter in
+                            var parameter = parameter
+                            if formatForFixit, dependencies.initializerFunctionParameters.endIndex > 1 {
+                                if index == 0 {
+                                    parameter.leadingTrivia = .newline
+                                }
+                                parameter.trailingTrivia = .newline
+                            }
+                            return parameter
+                        }) {
                             functionParameter
                         }
                     })

--- a/Sources/SafeDICore/Models/Initializer.swift
+++ b/Sources/SafeDICore/Models/Initializer.swift
@@ -136,8 +136,7 @@ public struct Initializer: Codable, Hashable, Sendable {
     public static func generateRequiredInitializer(
         for dependencies: [Dependency],
         declarationType: ConcreteDeclType,
-        andAdditionalPropertiesWithLabels additionalPropertyLabels: [String] = [],
-        formatForFixit: Bool = false
+        andAdditionalPropertiesWithLabels additionalPropertyLabels: [String] = []
     ) -> InitializerDeclSyntax {
         InitializerDeclSyntax(
             modifiers: declarationType.initializerModifiers,
@@ -146,7 +145,7 @@ public struct Initializer: Codable, Hashable, Sendable {
                     parameters: FunctionParameterListSyntax(itemsBuilder: {
                         for functionParameter in dependencies.initializerFunctionParameters.enumerated().map({ index, parameter in
                             var parameter = parameter
-                            if formatForFixit, dependencies.initializerFunctionParameters.endIndex > 1 {
+                            if dependencies.initializerFunctionParameters.endIndex > 1 {
                                 if index == 0 {
                                     parameter.leadingTrivia = .newline
                                 }

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -139,8 +139,7 @@ public struct InstantiableMacro: MemberMacro {
                             leadingTrivia: .newline,
                             decl: Initializer.generateRequiredInitializer(
                                 for: visitor.dependencies,
-                                declarationType: concreteDeclaration.declType,
-                                formatForFixit: true
+                                declarationType: concreteDeclaration.declType
                             ),
                             trailingTrivia: .newline
                         ),
@@ -165,8 +164,7 @@ public struct InstantiableMacro: MemberMacro {
                             decl: Initializer.generateRequiredInitializer(
                                 for: visitor.dependencies,
                                 declarationType: concreteDeclaration.declType,
-                                andAdditionalPropertiesWithLabels: visitor.uninitializedNonOptionalPropertyNames,
-                                formatForFixit: true
+                                andAdditionalPropertiesWithLabels: visitor.uninitializedNonOptionalPropertyNames
                             ),
                             trailingTrivia: .newline
                         ),

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -139,7 +139,8 @@ public struct InstantiableMacro: MemberMacro {
                             leadingTrivia: .newline,
                             decl: Initializer.generateRequiredInitializer(
                                 for: visitor.dependencies,
-                                declarationType: concreteDeclaration.declType
+                                declarationType: concreteDeclaration.declType,
+                                formatForFixit: true
                             ),
                             trailingTrivia: .newline
                         ),
@@ -164,7 +165,8 @@ public struct InstantiableMacro: MemberMacro {
                             decl: Initializer.generateRequiredInitializer(
                                 for: visitor.dependencies,
                                 declarationType: concreteDeclaration.declType,
-                                andAdditionalPropertiesWithLabels: visitor.uninitializedNonOptionalPropertyNames
+                                andAdditionalPropertiesWithLabels: visitor.uninitializedNonOptionalPropertyNames,
+                                formatForFixit: true
                             ),
                             trailingTrivia: .newline
                         ),

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -1218,7 +1218,11 @@ import SafeDICore
                 """
                 @Instantiable
                 public struct ExampleService: Instantiable {
-                public init(forwardedA: ForwardedA, receivedA: ReceivedA, receivedB: ReceivedB) {
+                public init(
+                forwardedA: ForwardedA,
+                receivedA: ReceivedA,
+                receivedB: ReceivedB
+                ) {
                 self.forwardedA = forwardedA
                 self.receivedA = receivedA
                 self.receivedB = receivedB
@@ -1241,7 +1245,11 @@ import SafeDICore
             } expansion: {
                 """
                 public struct ExampleService: Instantiable {
-                public init(forwardedA: ForwardedA, receivedA: ReceivedA, receivedB: ReceivedB) {
+                public init(
+                forwardedA: ForwardedA,
+                receivedA: ReceivedA,
+                receivedB: ReceivedB
+                ) {
                 self.forwardedA = forwardedA
                 self.receivedA = receivedA
                 self.receivedB = receivedB
@@ -1291,7 +1299,10 @@ import SafeDICore
                 """
                 @Instantiable
                 public final class UserService: Instantiable {
-                public init(userID: String, userName: String) {
+                public init(
+                userID: String,
+                userName: String
+                ) {
                 self.userID = userID
                 self.userName = userName
                 }
@@ -1306,7 +1317,10 @@ import SafeDICore
             } expansion: {
                 """
                 public final class UserService: Instantiable {
-                public init(userID: String, userName: String) {
+                public init(
+                userID: String,
+                userName: String
+                ) {
                 self.userID = userID
                 self.userName = userName
                 }


### PR DESCRIPTION
I find myself avoiding utilizing the initializer fixits in SafeDI because I hate the formatting. Creating an initializer with multiple parameters on the same line is hard to read, and even more difficult to manually maintain.

This PR makes it such that when a fixit initializer has more than one parameter, each parameter is written on their own line. Xcode's multiline editing functionality makes it easy for consumers of SafeDI who like all parameters on the same line to update the fixit, meanwhile folk who prefer newline separation of multiple parameters are better supported.

Note for reviewers looking at the tests: Xcode automatically manages indenting for us when applying a fixit, so we don't need to manage leading whitespace.