### PR TITLE
Stop detecting longform Optional expression types.

### DIFF
--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -122,7 +122,7 @@ import SafeDICore
             }
         }
 
-        func test_declaration_throwsErrorWhenFulfillingAdditionalTypesIncludesAShortformOptional() {
+        func test_declaration_throwsErrorWhenFulfillingAdditionalTypesIncludesAnOptional() {
             assertMacro {
                 """
                 @Instantiable(fulfillingAdditionalTypes: [AnyObject?.self])
@@ -132,22 +132,6 @@ import SafeDICore
                 """
                 @Instantiable(fulfillingAdditionalTypes: [AnyObject?.self])
                 ┬──────────────────────────────────────────────────────────
-                ╰─ 🛑 The argument `fulfillingAdditionalTypes` must not include optionals
-                public final class ExampleService: Instantiable {}
-                """
-            }
-        }
-
-        func test_declaration_throwsErrorWhenFulfillingAdditionalTypesIncludesALongformOptional() {
-            assertMacro {
-                """
-                @Instantiable(fulfillingAdditionalTypes: [Optional<AnyObject>.self])
-                public final class ExampleService: Instantiable {}
-                """
-            } diagnostics: {
-                """
-                @Instantiable(fulfillingAdditionalTypes: [Optional<AnyObject>.self])
-                ┬───────────────────────────────────────────────────────────────────
                 ╰─ 🛑 The argument `fulfillingAdditionalTypes` must not include optionals
                 public final class ExampleService: Instantiable {}
                 """


### PR DESCRIPTION
In #77, I added code to find `Optional<Generic>.self` and treat the reference as `Generic?.self`. This detection was added so that we could throw an error when `fulfillingAdditionalTypes` was written as a longform optional (`Optional<Generic>`) rather than a shortform optional (`Generic?`).

However, this detection can be wrong. If someone were to define a nested `Optional` type and then refer to it in `fulfillingAdditionalTypes` **without qualification**, we'd parse it incorrectly. Fixing this issue would require having locally defined type context at the `var typeDescription: TypeDescription` scope, which isn't feasible.

While this particular issue is likely quite rare, it's not worth introducing this kind of trap door in order to protect consumers from trying to `fulfillingAdditionalTypes` with a longform optional: there are all kinds of potential `fulfillingAdditionalTypes` failures—like fulfilling non-subclassable concrete types—that we do not error on because we do not have enough information to detect it.

I also updated placement of `return` while I was here.