### PR TITLE
Stop using CODECOV_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,6 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           os: macos
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   pod-lint:
     name: Pod Lint
@@ -167,8 +165,6 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           os: linux
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   readme-validation:
     name: Check Markdown links


### PR DESCRIPTION
Forked repos should be able to contribute and have CI succeed. Example failure: https://github.com/dfed/SafeDI/actions/runs/12676458517/job/35331202575

I have made the token not required in Codecov