### PR TITLE
Delete existing file before moving file to same location

### DIFF
--- a/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
+++ b/Plugins/InstallSafeDITool/InstallCLIPluginCommand.swift
@@ -152,6 +152,9 @@ struct InstallSafeDITool: CommandPlugin {
 					at: expectedToolFolder,
 					withIntermediateDirectories: true
 				)
+				if FileManager.default.fileExists(atPath: expectedToolLocation.path()) {
+					try FileManager.default.removeItem(at: expectedToolLocation)
+				}
 				try FileManager.default.moveItem(
 					at: downloadedURL,
 					to: expectedToolLocation


### PR DESCRIPTION
Running `safedi-release-install` shouldn't error just because there's already a file in the expected destination location