### PR TITLE
Share SafeDICore between Macros and Plugins again

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f458ca5a995b05838a802374587025b86fea2c32bd46b009ce45c3f7bfa75910",
+  "originHash" : "383be4df4f51649e38db062316442c857d18dff613b5b670ef68dbfc6848d247",
   "pins" : [
     {
       "identity" : "swift-argument-parser",

--- a/Package.swift
+++ b/Package.swift
@@ -63,10 +63,7 @@ let package = Package(
 		.macro(
 			name: "SafeDIMacros",
 			dependencies: [
-				// We need to have the same dependencies as SafeDICore, since we simlink to SafeDICore's code.
-				// We simlink to SafeDICore becuase as of Xcode 16.4 and Swift 6.1.1, Xcode fails to build with IDEPackageEnablePrebuilts enabled when a module (like SafeDICore) with a SwiftSyntax dependency is shared between a Macro and a Plugin.
-				// See https://forums.swift.org/t/preview-swift-syntax-prebuilts-for-macros/80202/14
-				.product(name: "Collections", package: "swift-collections"),
+				"SafeDICore",
 				.product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
 				.product(name: "SwiftDiagnostics", package: "swift-syntax"),
 				.product(name: "SwiftSyntax", package: "swift-syntax"),
@@ -81,6 +78,7 @@ let package = Package(
 			name: "SafeDIMacrosTests",
 			dependencies: [
 				"SafeDIMacros",
+				"SafeDICore",
 				.product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
 				.product(name: "MacroTesting", package: "swift-macro-testing"),
 			],

--- a/Sources/SafeDIMacros/Macros/InjectableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InjectableMacro.swift
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import SafeDICore
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import SafeDICore
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxBuilder

--- a/Sources/SafeDIMacros/SafeDIMacroCore
+++ b/Sources/SafeDIMacros/SafeDIMacroCore
@@ -1,1 +1,0 @@
-../SafeDICore

--- a/Tests/SafeDIMacrosTests/InjectableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InjectableMacroTests.swift
@@ -23,6 +23,8 @@ import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import Testing
 
+import SafeDICore
+
 #if canImport(SafeDIMacros)
 	@testable import SafeDIMacros
 

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -23,6 +23,8 @@ import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import Testing
 
+import SafeDICore
+
 #if canImport(SafeDIMacros)
 	@testable import SafeDIMacros
 


### PR DESCRIPTION
Undoes some of hacked support for prebuilt SwiftSyntax binaries in Xcode 16.4 using Swift 6.1.1 added in #161. We should not merge this until there is an Xcode version that supports Swift 6.2.