### PR TITLE
Only write the dependency tree output file if it has changed

### DIFF
--- a/SafeDI.podspec
+++ b/SafeDI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'SafeDI'
-  s.version  = '1.2.0'
+  s.version  = '1.2.1'
   s.summary  = 'Compile-time-safe dependency injection'
   s.homepage = 'https://github.com/dfed/SafeDI'
   s.license  = 'MIT'

--- a/Sources/SafeDITool/SafeDITool.swift
+++ b/Sources/SafeDITool/SafeDITool.swift
@@ -59,6 +59,7 @@ struct SafeDITool: AsyncParsableCommand, Sendable {
 				nil
 			}
 		}.value
+
 		let (dependentModuleInfo, module) = try await (
 			loadSafeDIModuleInfo(),
 			parsedModule()


### PR DESCRIPTION
@ahmdmhasn had a great idea to not touch the output file if the output file's content hasn't changed. Looks like modern Xcode seems to support having a package plugin that does supports this, so let's do it.

I believe earlier SPM implementations required the output file to be touched as part of the build plugin run, so we _needed_ to write the file. This does not seem to be the case in Xcode 16+.