### PR TITLE
Initializer fixit should not re-add conforming closure parameter

### DIFF
--- a/Sources/SafeDICore/Models/Initializer.swift
+++ b/Sources/SafeDICore/Models/Initializer.swift
@@ -319,46 +319,6 @@ extension ConcreteDeclType {
 
 extension TypeDescription {
 	fileprivate func isEqualToFunctionArgument(_ argument: TypeDescription) -> Bool {
-		switch argument {
-		case let .attributed(argumentTypeDescription, argumentSpecifiers, argumentAttributes):
-			switch self {
-			case .simple,
-			     .nested,
-			     .composition,
-			     .optional,
-			     .implicitlyUnwrappedOptional,
-			     .some,
-			     .any,
-			     .metatype,
-			     .array,
-			     .dictionary,
-			     .tuple,
-			     .closure,
-			     .unknown,
-			     .void:
-				self == argumentTypeDescription
-					&& argumentSpecifiers?.isEmpty ?? true
-					&& (argumentAttributes ?? []).contains("escaping")
-			case let .attributed(parameterTypeDescription, parameterSpecifiers, parameterAttributes):
-				parameterTypeDescription == argumentTypeDescription
-					&& Set(parameterSpecifiers ?? []) == Set(argumentSpecifiers ?? [])
-					&& Set(argumentAttributes ?? []).subtracting(parameterAttributes ?? []) == ["escaping"]
-			}
-		case .simple,
-		     .nested,
-		     .composition,
-		     .optional,
-		     .implicitlyUnwrappedOptional,
-		     .some,
-		     .any,
-		     .metatype,
-		     .closure,
-		     .array,
-		     .dictionary,
-		     .tuple,
-		     .unknown,
-		     .void:
-			self == argument
-		}
+		asFunctionParameter == argument
 	}
 }

--- a/Sources/SafeDICore/Models/TypeDescription.swift
+++ b/Sources/SafeDICore/Models/TypeDescription.swift
@@ -234,6 +234,37 @@ public enum TypeDescription: Codable, Hashable, Comparable, Sendable {
 		}
 	}
 
+	public var asFunctionParameter: TypeDescription {
+		switch self {
+		case .any,
+			 .array,
+			 .composition,
+			 .dictionary,
+			 .implicitlyUnwrappedOptional,
+			 .metatype,
+			 .nested,
+			 .optional,
+			 .simple,
+			 .some,
+			 .tuple,
+			 .unknown,
+			 .void:
+			self
+		case .closure:
+			.attributed(self, specifiers: nil, attributes: ["escaping"])
+		case let .attributed(type, specifiers: specifiers, attributes: attributes):
+			if let attributes {
+				if attributes.contains(where: { $0 == "escaping" }) {
+					.attributed(type, specifiers: specifiers, attributes: attributes)
+				} else {
+					.attributed(type, specifiers: specifiers, attributes: ["escaping"] + attributes)
+				}
+			} else {
+				.attributed(type, specifiers: specifiers, attributes: ["escaping"])
+			}
+		}
+	}
+
 	public var isOptional: Bool {
 		switch self {
 		case .any,

--- a/Sources/SafeDICore/Models/TypeDescription.swift
+++ b/Sources/SafeDICore/Models/TypeDescription.swift
@@ -237,18 +237,18 @@ public enum TypeDescription: Codable, Hashable, Comparable, Sendable {
 	public var asFunctionParameter: TypeDescription {
 		switch self {
 		case .any,
-			 .array,
-			 .composition,
-			 .dictionary,
-			 .implicitlyUnwrappedOptional,
-			 .metatype,
-			 .nested,
-			 .optional,
-			 .simple,
-			 .some,
-			 .tuple,
-			 .unknown,
-			 .void:
+		     .array,
+		     .composition,
+		     .dictionary,
+		     .implicitlyUnwrappedOptional,
+		     .metatype,
+		     .nested,
+		     .optional,
+		     .simple,
+		     .some,
+		     .tuple,
+		     .unknown,
+		     .void:
 			self
 		case .closure:
 			.attributed(self, specifiers: nil, attributes: ["escaping"])

--- a/Sources/SafeDICore/Models/TypeDescription.swift
+++ b/Sources/SafeDICore/Models/TypeDescription.swift
@@ -253,7 +253,15 @@ public enum TypeDescription: Codable, Hashable, Comparable, Sendable {
 		case .closure:
 			.attributed(self, specifiers: nil, attributes: ["escaping"])
 		case let .attributed(type, specifiers: specifiers, attributes: attributes):
-			.attributed(type, specifiers: specifiers, attributes: ["escaping"] + (attributes ?? []).filter { $0 != "escaping" })
+			if let attributes {
+				if attributes.contains(where: { $0 == "escaping" }) {
+					.attributed(type, specifiers: specifiers, attributes: attributes)
+				} else {
+					.attributed(type, specifiers: specifiers, attributes: ["escaping"] + attributes)
+				}
+			} else {
+				.attributed(type, specifiers: specifiers, attributes: ["escaping"])
+			}
 		}
 	}
 

--- a/Sources/SafeDICore/Models/TypeDescription.swift
+++ b/Sources/SafeDICore/Models/TypeDescription.swift
@@ -253,15 +253,7 @@ public enum TypeDescription: Codable, Hashable, Comparable, Sendable {
 		case .closure:
 			.attributed(self, specifiers: nil, attributes: ["escaping"])
 		case let .attributed(type, specifiers: specifiers, attributes: attributes):
-			if let attributes {
-				if attributes.contains(where: { $0 == "escaping" }) {
-					.attributed(type, specifiers: specifiers, attributes: attributes)
-				} else {
-					.attributed(type, specifiers: specifiers, attributes: ["escaping"] + attributes)
-				}
-			} else {
-				.attributed(type, specifiers: specifiers, attributes: ["escaping"])
-			}
+			.attributed(type, specifiers: specifiers, attributes: ["escaping"] + (attributes ?? []).filter { $0 != "escaping" })
 		}
 	}
 

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -197,16 +197,20 @@ public struct InstantiableMacro: MemberMacro {
 							return parameter
 						}
 						for property in properties {
-							if let existingParameter = existingParameters[property] {
+							let functionArgumentProperty = Property(
+								label: property.label,
+								typeDescription: property.typeDescription.asFunctionParameter
+							)
+							if let existingParameter = existingParameters[functionArgumentProperty] {
 								fixedSyntax.signature.parameterClause.parameters.append(
-									normalizeFunctionParameter(existingParameter, for: property)
+									normalizeFunctionParameter(existingParameter, for: functionArgumentProperty)
 								)
 							} else {
 								fixedSyntax.signature.parameterClause.parameters.append(
-									normalizeFunctionParameter(property.asFunctionParamter, for: property)
+									normalizeFunctionParameter(property.asFunctionParamter, for: functionArgumentProperty)
 								)
 							}
-							existingParameters[property] = nil
+							existingParameters[functionArgumentProperty] = nil
 						}
 
 						for existingParameter in existingParameters.map(\.value) {

--- a/Tests/SafeDICoreTests/TypeDescriptionTests.swift
+++ b/Tests/SafeDICoreTests/TypeDescriptionTests.swift
@@ -730,6 +730,75 @@ struct TypeDescriptionTests {
 		]))
 	}
 
+	@Test
+	func asFunctionParameter_doesNotChangeOrderingOfEscapingWhenEscapingIsLast() {
+		#expect(TypeDescription.attributed(
+			.closure(
+				arguments: [.void(.tuple)],
+				isAsync: false,
+				doesThrow: false,
+				returnType: .void(.identifier)
+			),
+			specifiers: nil,
+			attributes: ["autoclosure", "escaping"]
+		).asFunctionParameter == TypeDescription.attributed(
+			.closure(
+				arguments: [.void(.tuple)],
+				isAsync: false,
+				doesThrow: false,
+				returnType: .void(.identifier)
+			),
+			specifiers: nil,
+			attributes: ["autoclosure", "escaping"]
+		))
+	}
+
+	@Test
+	func asFunctionParameter_doesNotChangeOrderingOfEscapingWhenEscapingIsFirst() {
+		#expect(TypeDescription.attributed(
+			.closure(
+				arguments: [.void(.tuple)],
+				isAsync: false,
+				doesThrow: false,
+				returnType: .void(.identifier)
+			),
+			specifiers: nil,
+			attributes: ["escaping", "autoclosure"]
+		).asFunctionParameter == TypeDescription.attributed(
+			.closure(
+				arguments: [.void(.tuple)],
+				isAsync: false,
+				doesThrow: false,
+				returnType: .void(.identifier)
+			),
+			specifiers: nil,
+			attributes: ["escaping", "autoclosure"]
+		))
+	}
+
+	@Test
+	func asFunctionParameter_addsEscapingWhenNoAttributesFound() {
+		#expect(TypeDescription.attributed(
+			.closure(
+				arguments: [.void(.tuple)],
+				isAsync: false,
+				doesThrow: false,
+				returnType: .void(.identifier)
+			),
+			specifiers: nil,
+			attributes: nil
+		).asFunctionParameter == TypeDescription.attributed(
+			.closure(
+				arguments: [.void(.tuple)],
+				isAsync: false,
+				doesThrow: false,
+				returnType: .void(.identifier)
+			),
+			specifiers: nil,
+			attributes: ["escaping"]
+		))
+	}
+
 	// MARK: - Visitors
 
 	private final class TypeIdentifierSyntaxVisitor: SyntaxVisitor {

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -1860,6 +1860,80 @@ import Testing
 		}
 
 		@Test
+		func declaration_fixit_updatesRequiredInitializerWhenLastDependencyMissingFromInitAndEscapingDependencyParameterExists() {
+			assertMacro {
+				"""
+				@Instantiable
+				public struct ExampleService: Instantiable {
+					public init(customizable: @escaping (String) -> Void, forwardedA: ForwardedA, receivedA: ReceivedA) {
+						self.customizable = customizable
+						self.forwardedA = forwardedA
+						self.receivedA = receivedA
+					}
+
+					@Forwarded let customizable: (String) -> Void
+					@Forwarded let forwardedA: ForwardedA
+					@Received let receivedA: ReceivedA
+					@Received let receivedB: ReceivedB
+				}
+				"""
+			} diagnostics: {
+				"""
+				@Instantiable
+				public struct ExampleService: Instantiable {
+					public init(customizable: @escaping (String) -> Void, forwardedA: ForwardedA, receivedA: ReceivedA) {
+				 ╰─ 🛑 @Instantiable-decorated type must have a `public` or `open` initializer with a parameter for each @Instantiated, @Received, or @Forwarded-decorated property.
+				    ✏️ Add arguments for receivedB: ReceivedB
+						self.customizable = customizable
+						self.forwardedA = forwardedA
+						self.receivedA = receivedA
+					}
+
+					@Forwarded let customizable: (String) -> Void
+					@Forwarded let forwardedA: ForwardedA
+					@Received let receivedA: ReceivedA
+					@Received let receivedB: ReceivedB
+				}
+				"""
+			} fixes: {
+				"""
+				@Instantiable
+				public struct ExampleService: Instantiable {
+					public init(customizable: @escaping (String) -> Void, forwardedA: ForwardedA, receivedA: ReceivedA, receivedB: ReceivedB) {
+						self.customizable = customizable
+						self.forwardedA = forwardedA
+						self.receivedA = receivedA
+						self.receivedB = receivedB
+					}
+
+					@Forwarded let customizable: (String) -> Void
+					@Forwarded let forwardedA: ForwardedA
+					@Received let receivedA: ReceivedA
+					@Received let receivedB: ReceivedB
+				}
+				"""
+			} expansion: {
+				"""
+				public struct ExampleService: Instantiable {
+					public init(customizable: @escaping (String) -> Void, forwardedA: ForwardedA, receivedA: ReceivedA, receivedB: ReceivedB) {
+						self.customizable = customizable
+						self.forwardedA = forwardedA
+						self.receivedA = receivedA
+						self.receivedB = receivedB
+					}
+
+					let customizable: (String) -> Void
+					let forwardedA: ForwardedA
+					let receivedA: ReceivedA
+					let receivedB: ReceivedB
+
+					public typealias ForwardedProperties = (customizable: (String) -> Void, forwardedA: ForwardedA)
+				}
+				"""
+			}
+		}
+
+		@Test
 		func declaration_fixit_updatesRequiredInitializerWhenIncorrectAccessibilityOnInitAndOtherNonConformingInitializersExist() {
 			assertMacro {
 				"""

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -756,7 +756,7 @@ import Testing
 				    public init(closure: @escaping @Sendable () -> Void) {
 				        self.closure = closure
 				    }
-				    @Forwarded let closure: (() -> Void)
+				    @Forwarded let closure: (@Sendable () -> Void)
 				}
 				"""
 			} expansion: {
@@ -765,9 +765,9 @@ import Testing
 				    public init(closure: @escaping @Sendable () -> Void) {
 				        self.closure = closure
 				    }
-				    let closure: (() -> Void)
+				    let closure: (@Sendable () -> Void)
 
-				    public typealias ForwardedProperties = () -> Void
+				    public typealias ForwardedProperties = @Sendable () -> Void
 				}
 				"""
 			}


### PR DESCRIPTION
#164 introduced an issue where a fixit to add new parameters to an initializer would repeat any closure parameters in the list. This PR addresses that issue.