### PR TITLE
Schedule CI to run every week

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_16.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
       - name: Download visionOS
         if: matrix.platforms == 'generic/platform=visionos'
         run: |
@@ -101,11 +101,11 @@ jobs:
           ruby-version: '3.3.5'
           bundler-cache: true
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_16.2.0.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.0.app/Contents/Developer
       - name: Install Pod
         run: bundle exec pod install --project-directory=Examples/ExampleCocoaPodsIntegration
       - name: Build CocoaPods Integration
-        run: xcrun xcodebuild build -scheme ExampleCocoaPodsIntegration -configuration Debug -workspace Examples/ExampleCocoaPodsIntegration/ExampleCocoaPodsIntegration.xcworkspace -destination 'platform=iOS Simulator,OS=18.2,name=iPad (10th generation)' # Explicitly test the Debug build. Our pod lint jobs are already testing the Release build.
+        run: xcrun xcodebuild build -scheme ExampleCocoaPodsIntegration -configuration Debug -workspace Examples/ExampleCocoaPodsIntegration/ExampleCocoaPodsIntegration.xcworkspace -destination 'platform=iOS Simulator,OS=18.4,name=iPad (10th generation)' # Explicitly test the Debug build. Our pod lint jobs are already testing the Release build.
 
   spm:
     name: Build and Test on Xcode 16
@@ -151,7 +151,7 @@ jobs:
           ruby-version: '3.3.5'
           bundler-cache: true
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_16.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
       - name: Download visionOS
         if: matrix.platforms == 'visionos'
         run: |


### PR DESCRIPTION
Let's keep CI from bit-rotting

Additionally, Github Actions has [an issue](https://github.com/actions/runner-images/issues/12758) running on older Xcode versions. Let's work around it by bumping our versions.