### PR TITLE
Instantiable must be conformed to in all isolation contexts

### DIFF
--- a/Sources/SafeDI/Decorators/Instantiable.swift
+++ b/Sources/SafeDI/Decorators/Instantiable.swift
@@ -60,9 +60,22 @@ public macro Instantiable(
 	conformsElsewhere: Bool = false
 ) = #externalMacro(module: "SafeDIMacros", type: "InstantiableMacro")
 
-/// A type that can be instantiated with runtime-injected properties.
-public protocol Instantiable {
-	/// The forwarded properties required to instantiate the type.
-	/// Defaults to `Void`.
-	associatedtype ForwardedProperties = Void
-}
+#if swift(>=6.2)
+
+	/// A type that can be instantiated with runtime-injected properties.
+	public protocol Instantiable: SendableMetatype {
+		/// The forwarded properties required to instantiate the type.
+		/// Defaults to `Void`.
+		associatedtype ForwardedProperties = Void
+	}
+
+#else
+
+	/// A type that can be instantiated with runtime-injected properties.
+	public protocol Instantiable {
+		/// The forwarded properties required to instantiate the type.
+		/// Defaults to `Void`.
+		associatedtype ForwardedProperties = Void
+	}
+
+#endif

--- a/Sources/SafeDI/DelayedInstantiation/SendableInstantiator.swift
+++ b/Sources/SafeDI/DelayedInstantiation/SendableInstantiator.swift
@@ -36,7 +36,7 @@ public final class SendableInstantiator<T: Instantiable>: Sendable {
 
 	/// - Parameter instantiator: A closure that returns an instance of `Instantiable`.
 	public init(_ instantiator: @escaping @Sendable () -> T) where T.ForwardedProperties == Void {
-		self.instantiator = Self.createInstantiator(from: instantiator)
+		self.instantiator = { _ in instantiator() }
 	}
 
 	/// Instantiates and returns a new instance of the `@Instantiable` type.
@@ -52,9 +52,4 @@ public final class SendableInstantiator<T: Instantiable>: Sendable {
 	}
 
 	private let instantiator: @Sendable (T.ForwardedProperties) -> T
-
-	// This shouldn't be necessary. We're working around https://github.com/swiftlang/swift/issues/82133
-	private static func createInstantiator(from instantiator: @escaping @Sendable (T.ForwardedProperties) -> T) -> @Sendable (T.ForwardedProperties) -> T {
-		instantiator
-	}
 }


### PR DESCRIPTION
@mattmassicotte convinced me that it does not make sense for the `Instantiable` protocol to be conformed to within a single isolation context. `Instantiable` declares only that a type has a `ForwardedProperties` type, and this type cannot be scoped to a particular isolation context, and therefore `Instantiable` _is_ a `SendableMetatype`.

This PR makes `Instantiable` required to be a `SendableMetatype` in Swift versions 6.2 and above. I may not be able to merge this PR (due to code coverage requirements) until a Swift 6.2 linux container is added to CI. TBD.