### PR TITLE
Get compiling on Xcode 26

### DIFF
--- a/Sources/SafeDICore/Visitors/InstantiableVisitor.swift
+++ b/Sources/SafeDICore/Visitors/InstantiableVisitor.swift
@@ -295,6 +295,14 @@ public final class InstantiableVisitor: SyntaxVisitor {
 	public static let macroName = "Instantiable"
 	public static let instantiateMethodName = "instantiate"
 
+	public func walk(_ node: some ConcreteDeclSyntaxProtocol) {
+		super.walk(node)
+	}
+
+	public func walk(_ node: ExtensionDeclSyntax) {
+		super.walk(node)
+	}
+
 	// MARK: DeclarationType
 
 	public enum DeclarationType {


### PR DESCRIPTION
SafeDI is crashing when compiling on Xcode 26.0.0 RC, but not Swift 6.2 command line. This PR fixes it. This was not an issue on Xcode 26.0.0 Beta 7.

The crash we're fixing is:
```
SwiftCompile normal arm64 Compiling\ InstantiableMacro.swift /Users/dfed/source/SafeDI/Sources/SafeDIMacros/Macros/InstantiableMacro.swift (in target 'SafeDIMacros' from project 'SafeDI')

Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: /Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -frontend -c /Users/dfed/source/SafeDI/Sources/SafeDIMacros/Macros/InjectableMacro.swift -primary-file /Users/dfed/source/SafeDI/Sources/SafeDIMacros/Macros/InstantiableMacro.swift /Users/dfed/source/SafeDI/Sources/SafeDIMacros/SafeDIMacroPlugin.swift -emit-dependencies-path /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/InstantiableMacro.d -emit-const-values-path /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/InstantiableMacro.swiftconstvalues -emit-reference-dependencies-path /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/InstantiableMacro.swiftdeps -serialize-diagnostics-path /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/InstantiableMacro.dia -target arm64-apple-macos10.15 -load-resolved-plugin /Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/swift/host/plugins/libSwiftMacros.dylib#/Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/bin/swift-plugin-server#SwiftMacros -disable-implicit-swift-modules -Xcc -fno-implicit-modules -Xcc -fno-implicit-module-maps -explicit-swift-module-map-file /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/SafeDIMacros-dependencies-1.json -Xllvm -aarch64-use-tbi -enable-objc-interop -stack-check -sdk /Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk -I /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/SourcePackages/prebuilts/swift-syntax/601.0.1/swiftlang-6.2.0.19.9-MacroSupport-macos_aarch64/Modules -I /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/SourcePackages/checkouts/swift-syntax/Sources/_SwiftSyntaxCShims/include -I /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/SourcePackages/checkouts/swift-syntax/Sources/_SwiftLibraryPluginProviderCShims/include -I /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug -Isystem /Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug -F /Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -no-color-diagnostics -Xcc -fno-color-diagnostics -enable-testing -g -debug-info-format=dwarf -dwarf-version=4 -module-cache-path /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules -swift-version 6 -enforce-exclusivity=checked -Onone -D SWIFT_PACKAGE -D DEBUG -D Xcode -serialize-debugging-options -const-gather-protocols-file /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/SafeDIMacros_const_extract_protocols.json -enable-experimental-feature DebugDescriptionMacro -empty-abi-descriptor -validate-clang-modules-once -clang-build-session-file /Users/dfed/Library/Developer/Xcode/DerivedData/ModuleCache.noindex/Session.modulevalidation -Xcc -working-directory -Xcc /Users/dfed/source/SafeDI/.swiftpm/xcode -enable-anonymous-context-mangled-names -file-compilation-dir /Users/dfed/source/SafeDI/.swiftpm/xcode -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -Xcc -ivfsstatcache -Xcc /Users/dfed/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.0-25A352-3885c01c3e6b6a337905948deab2002ee29a30e712f399558590a593784cf700.sdkstatcache -Xcc -I/Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/SourcePackages/checkouts/swift-syntax/Sources/_SwiftSyntaxCShims/include -Xcc -I/Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/include -Xcc -I/Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/DerivedSources-normal/arm64 -Xcc -I/Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/DerivedSources/arm64 -Xcc -I/Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/DerivedSources -Xcc -DSWIFT_PACKAGE -Xcc -DDEBUG=1 -no-auto-bridging-header-chaining -module-name SafeDIMacros -package-name safedi -frontend-parseable-output -disable-clang-spi -target-sdk-version 26.0 -target-sdk-name macosx26.0 -clang-target arm64-apple-macos26.0 -in-process-plugin-server-path /Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/libSwiftInProcPluginServer.dylib -o /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/InstantiableMacro.o -index-unit-output-path /SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/InstantiableMacro.o -index-store-path /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Index.noindex/DataStore -index-system-modules
1.	Apple Swift version 6.2 (swiftlang-6.2.0.19.9 clang-1700.3.19.1)
2.	Compiling with the current language version
3.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { Mandatory Diagnostic Passes + Enabling Optimization Passes } on SIL for SafeDIMacros)
4.	While running pass #1686 SILModuleTransform "MandatoryInlining".
5.	While deserializing SIL vtable for 'InstantiableVisitor' (in module 'SafeDICore')
6.	*** DESERIALIZATION FAILURE ***
*** If any module named here was modified in the SDK, please delete the ***
*** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***
module 'SafeDICore', builder version '6.2(6.2)/Apple Swift version 6.2 (swiftlang-6.2.0.19.9 clang-1700.3.19.1)', built from source against SDK 25A352, non-resilient, loaded from '/Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/SafeDICore.swiftmodule/arm64-apple-macos.swiftmodule'
result not found (visitationFunc)
Cross-reference to module 'SwiftSyntax'
... SyntaxVisitor
... visitationFunc
... with type (SyntaxVisitor) -> (Syntax) -> (inout Syntax) -> ()


Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  swift-frontend           0x000000010946dbcc llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 56
1  swift-frontend           0x000000010946b55c llvm::sys::RunSignalHandlers() + 112
2  swift-frontend           0x000000010946e1f8 SignalHandler(int, __siginfo*, void*) + 344
3  libsystem_platform.dylib 0x0000000199e096a4 _sigtramp + 56
4  libsystem_pthread.dylib  0x0000000199dcf88c pthread_kill + 296
5  libsystem_c.dylib        0x0000000199cd8a3c abort + 124
6  swift-frontend           0x0000000104d5180c llvm::PrettyStackTraceString::PrettyStackTraceString(char const*) + 0
7  swift-frontend           0x00000001038bf6a8 swift::ModuleFileSharedCore::outputDiagnosticInfo(llvm::raw_ostream&) const + 0
8  swift-frontend           0x000000010384e190 swift::ModuleFile::getSourceLoc() const + 0
9  swift-frontend           0x000000010384dd10 swift::ModuleFile::fatal(llvm::Error) const + 44
10 swift-frontend           0x00000001038aa208 swift::SILDeserializer::readVTable(llvm::PointerEmbeddedInt<unsigned int, 31>) + 2232
11 swift-frontend           0x000000010394e8e0 swift::SerializedSILLoader::lookupVTable(swift::ClassDecl const*) + 412
12 swift-frontend           0x0000000103a09708 swift::SILModule::lookUpVTable(swift::ClassDecl const*, bool) + 220
13 swift-frontend           0x0000000104180a78 swift::getTargetClassMethod(swift::SILModule&, swift::FullApplySite, swift::ClassDecl*, swift::CanType, swift::MethodInst*) + 256
14 swift-frontend           0x0000000104180c28 swift::canDevirtualizeClassMethod(swift::FullApplySite, swift::ClassDecl*, swift::CanType, swift::OptRemark::Emitter*, bool) + 152
15 swift-frontend           0x0000000104185708 swift::tryDevirtualizeApply(swift::SILPassManager*, swift::ApplySite, swift::ClassHierarchyAnalysis*, swift::OptRemark::Emitter*, bool) + 748
16 swift-frontend           0x0000000103f5ae58 runOnFunctionRecursively(swift::SILOptFunctionBuilder&, swift::SILPassManager*, swift::SILFunction*, swift::FullApplySite, llvm::DenseSet<swift::SILFunction*, llvm::DenseMapInfo<swift::SILFunction*, void>>&, llvm::ImmutableSet<swift::SILFunction*, llvm::ImutContainerInfo<swift::SILFunction*>>::Factory&, llvm::ImmutableSet<swift::SILFunction*, llvm::ImutContainerInfo<swift::SILFunction*>>, swift::ClassHierarchyAnalysis*, llvm::DenseSet<swift::SILFunction*, llvm::DenseMapInfo<swift::SILFunction*, void>>&) + 2544
17 swift-frontend           0x0000000103f59fe8 (anonymous namespace)::MandatoryInlining::run() + 472
18 swift-frontend           0x0000000103ff4778 swift::SILPassManager::executePassPipelinePlan(swift::SILPassPipelinePlan const&) + 13328
19 swift-frontend           0x00000001040170a0 swift::SimpleRequest<swift::ExecuteSILPipelineRequest, std::__1::tuple<> (swift::SILPipelineExecutionDescriptor), (swift::RequestFlags)1>::evaluateRequest(swift::ExecuteSILPipelineRequest const&, swift::Evaluator&) + 52
20 swift-frontend           0x0000000103ffae5c swift::ExecuteSILPipelineRequest::OutputType swift::Evaluator::getResultUncached<swift::ExecuteSILPipelineRequest, swift::ExecuteSILPipelineRequest::OutputType swift::evaluateOrFatal<swift::ExecuteSILPipelineRequest>(swift::Evaluator&, swift::ExecuteSILPipelineRequest)::'lambda'()>(swift::ExecuteSILPipelineRequest const&, swift::ExecuteSILPipelineRequest::OutputType swift::evaluateOrFatal<swift::ExecuteSILPipelineRequest>(swift::Evaluator&, swift::ExecuteSILPipelineRequest)::'lambda'()) + 412
21 swift-frontend           0x0000000103ffd438 swift::runSILDiagnosticPasses(swift::SILModule&) + 416
22 swift-frontend           0x00000001034a3c68 swift::CompilerInstance::performSILProcessing(swift::SILModule*) + 656
23 swift-frontend           0x00000001030a8460 performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*) + 1360
24 swift-frontend           0x00000001030a774c swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 1032
25 swift-frontend           0x00000001030aaa7c performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 1764
26 swift-frontend           0x00000001030a968c swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3580
27 swift-frontend           0x000000010302ac6c swift::mainEntry(int, char const**) + 5412
28 dyld                     0x0000000199a2eb98 start + 6076
Failed frontend command:
/Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -frontend -c /Users/dfed/source/SafeDI/Sources/SafeDIMacros/Macros/InjectableMacro.swift -primary-file /Users/dfed/source/SafeDI/Sources/SafeDIMacros/Macros/InstantiableMacro.swift /Users/dfed/source/SafeDI/Sources/SafeDIMacros/SafeDIMacroPlugin.swift -emit-dependencies-path /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/InstantiableMacro.d -emit-const-values-path /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/InstantiableMacro.swiftconstvalues -emit-reference-dependencies-path /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/InstantiableMacro.swiftdeps -serialize-diagnostics-path /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/InstantiableMacro.dia -target arm64-apple-macos10.15 -load-resolved-plugin /Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/swift/host/plugins/libSwiftMacros.dylib\#/Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/bin/swift-plugin-server\#SwiftMacros -disable-implicit-swift-modules -Xcc -fno-implicit-modules -Xcc -fno-implicit-module-maps -explicit-swift-module-map-file /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/SafeDIMacros-dependencies-1.json -Xllvm -aarch64-use-tbi -enable-objc-interop -stack-check -sdk /Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk -I /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/SourcePackages/prebuilts/swift-syntax/601.0.1/swiftlang-6.2.0.19.9-MacroSupport-macos_aarch64/Modules -I /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/SourcePackages/checkouts/swift-syntax/Sources/_SwiftSyntaxCShims/include -I /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/SourcePackages/checkouts/swift-syntax/Sources/_SwiftLibraryPluginProviderCShims/include -I /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug -Isystem /Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/PackageFrameworks -F /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug -F /Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -no-color-diagnostics -Xcc -fno-color-diagnostics -enable-testing -g -debug-info-format\=dwarf -dwarf-version\=4 -module-cache-path /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules -swift-version 6 -enforce-exclusivity\=checked -Onone -D SWIFT_PACKAGE -D DEBUG -D Xcode -serialize-debugging-options -const-gather-protocols-file /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/SafeDIMacros_const_extract_protocols.json -enable-experimental-feature DebugDescriptionMacro -empty-abi-descriptor -validate-clang-modules-once -clang-build-session-file /Users/dfed/Library/Developer/Xcode/DerivedData/ModuleCache.noindex/Session.modulevalidation -Xcc -working-directory -Xcc /Users/dfed/source/SafeDI/.swiftpm/xcode -enable-anonymous-context-mangled-names -file-compilation-dir /Users/dfed/source/SafeDI/.swiftpm/xcode -Xcc -D_LIBCPP_HARDENING_MODE\=_LIBCPP_HARDENING_MODE_DEBUG -Xcc -ivfsstatcache -Xcc /Users/dfed/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.0-25A352-3885c01c3e6b6a337905948deab2002ee29a30e712f399558590a593784cf700.sdkstatcache -Xcc -I/Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/SourcePackages/checkouts/swift-syntax/Sources/_SwiftSyntaxCShims/include -Xcc -I/Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Products/Debug/include -Xcc -I/Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/DerivedSources-normal/arm64 -Xcc -I/Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/DerivedSources/arm64 -Xcc -I/Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/DerivedSources -Xcc -DSWIFT_PACKAGE -Xcc -DDEBUG\=1 -no-auto-bridging-header-chaining -module-name SafeDIMacros -package-name safedi -frontend-parseable-output -disable-clang-spi -target-sdk-version 26.0 -target-sdk-name macosx26.0 -clang-target arm64-apple-macos26.0 -in-process-plugin-server-path /Applications/Xcode-26.0.0-Release.Candidate.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/libSwiftInProcPluginServer.dylib -o /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Build/Intermediates.noindex/SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/InstantiableMacro.o -index-unit-output-path /SafeDI.build/Debug/SafeDIMacros.build/Objects-normal/arm64/InstantiableMacro.o -index-store-path /Users/dfed/Library/Developer/Xcode/DerivedData/SafeDI-djtbsyckgxfxuadzmudaduloxlzh/Index.noindex/DataStore -index-system-modules
```

For some reason, calling `func walk(_ node: some SyntaxProtocol)` on the `InstantiableVisitor` was causing issues until I made methods for the exact types being used.