### PR TITLE
Download platform simulator before linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,12 +168,11 @@ jobs:
           bundler-cache: true
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
-      - name: Download visionOS
-        if: matrix.platforms == 'visionos'
+      - name: Download Simulator
         run: |
           sudo xcodebuild -runFirstLaunch
           sudo xcrun simctl list
-          sudo xcodebuild -downloadPlatform visionOS
+          sudo xcodebuild -downloadPlatform ${{ matrix.platforms }}
           sudo xcodebuild -runFirstLaunch
       - name: Lint Podspec
         run: bundle exec pod lib lint --verbose --fail-fast --swift-version=6.0 --platforms=${{ matrix.platforms }}


### PR DESCRIPTION
We're seeing multiple failures linting our podspec because the simulator isn't installed. Let's fix that.