### PR TITLE
Add publish workflow with artifact bundle support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,25 +1,42 @@
 name: Publish
 on:
-  push:
-    tags:
-      - '*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to create (e.g. 2.0.0)'
+        type: string
+        required: true
+      branch:
+        description: 'Branch to build from and commit to'
+        type: string
+        required: true
+        default: 'main'
+      prerelease:
+        description: 'Mark the GitHub release as a prerelease'
+        type: boolean
+        required: false
+        default: false
+      dry-run:
+        description: 'Build and assemble without publishing (no commit/tag/release)'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
-  build-release-cli:
-    name: Build Release CLI
+  build-macos:
+    name: Build macOS Universal Binary
     runs-on: macos-26
     strategy:
       matrix:
-        architecture: [
-          'x86_64',
-          'arm64',
-        ]
+        architecture: ['x86_64', 'arm64']
       fail-fast: false
     permissions:
       contents: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
       - name: Build SafeDITool
@@ -27,7 +44,7 @@ jobs:
       - name: Give SafeDITool executable permissions
         run: chmod +x .build/*/release/SafeDITool
       - name: Make codesigning folder
-        run:  |
+        run: |
           mkdir codesign
           cp .build/*/release/SafeDITool codesign/
       - name: Codesign
@@ -63,18 +80,170 @@ jobs:
       - name: Upload SafeDITool artifact
         uses: actions/upload-artifact@v4
         with:
-          name: SafeDITool-${{ matrix.architecture }}
+          name: SafeDITool-macos-${{ matrix.architecture }}
           path: codesign/SafeDITool
-      - name: Upload SafeDITool as release binary
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.RELEASE_UPLOADER }}
-          file: codesign/SafeDITool
-          tag: ${{ github.ref }}
-          asset_name: SafeDITool-${{ matrix.architecture }}
-          overwrite: false
       - name: Cleanup
-        if: always() # This ensures that the cleanup step runs even if earlier steps fail
+        if: always()
         run: |
           security delete-keychain build.keychain
           rm -rf codesign
+
+  build-linux-x86_64:
+    name: Build Linux x86_64
+    runs-on: ubuntu-latest
+    container: swift:6.3
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+      - name: Build SafeDITool
+        run: swift build -c release --product SafeDITool --static-swift-stdlib
+      - name: Upload SafeDITool artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SafeDITool-linux-x86_64
+          path: .build/release/SafeDITool
+
+  build-linux-arm64:
+    name: Build Linux arm64
+    runs-on: ubuntu-24.04-arm
+    container: swift:6.3
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+      - name: Build SafeDITool
+        run: swift build -c release --product SafeDITool --static-swift-stdlib
+      - name: Upload SafeDITool artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SafeDITool-linux-arm64
+          path: .build/release/SafeDITool
+
+  assemble-and-publish:
+    name: Assemble Artifact Bundle and Publish
+    needs: [build-macos, build-linux-x86_64, build-linux-arm64]
+    runs-on: macos-26
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.RELEASE_UPLOADER }}
+
+      - name: Select Xcode Version
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create macOS universal binary
+        run: |
+          lipo -create \
+            artifacts/SafeDITool-macos-arm64/SafeDITool \
+            artifacts/SafeDITool-macos-x86_64/SafeDITool \
+            -output SafeDITool-macos-universal
+          chmod +x SafeDITool-macos-universal
+
+      - name: Assemble artifact bundle
+        run: |
+          mkdir -p SafeDITool.artifactbundle/SafeDITool-macos/bin
+          mkdir -p SafeDITool.artifactbundle/SafeDITool-linux-x86_64/bin
+          mkdir -p SafeDITool.artifactbundle/SafeDITool-linux-arm64/bin
+
+          cp SafeDITool-macos-universal SafeDITool.artifactbundle/SafeDITool-macos/bin/SafeDITool
+          cp artifacts/SafeDITool-linux-x86_64/SafeDITool SafeDITool.artifactbundle/SafeDITool-linux-x86_64/bin/SafeDITool
+          cp artifacts/SafeDITool-linux-arm64/SafeDITool SafeDITool.artifactbundle/SafeDITool-linux-arm64/bin/SafeDITool
+
+          chmod +x SafeDITool.artifactbundle/SafeDITool-linux-x86_64/bin/SafeDITool
+          chmod +x SafeDITool.artifactbundle/SafeDITool-linux-arm64/bin/SafeDITool
+
+          cat > SafeDITool.artifactbundle/info.json << 'INFOJSON'
+          {
+            "schemaVersion": "1.0",
+            "artifacts": {
+              "SafeDITool": {
+                "version": "${{ inputs.version }}",
+                "type": "executable",
+                "variants": [
+                  {
+                    "path": "SafeDITool-macos/bin/SafeDITool",
+                    "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
+                  },
+                  {
+                    "path": "SafeDITool-linux-x86_64/bin/SafeDITool",
+                    "supportedTriples": ["x86_64-unknown-linux-gnu", "amd64-unknown-linux-gnu"]
+                  },
+                  {
+                    "path": "SafeDITool-linux-arm64/bin/SafeDITool",
+                    "supportedTriples": ["aarch64-unknown-linux-gnu", "arm64-unknown-linux-gnu"]
+                  }
+                ]
+              }
+            }
+          }
+          INFOJSON
+
+      - name: Zip artifact bundle
+        run: zip -r SafeDITool.artifactbundle.zip SafeDITool.artifactbundle/
+
+      - name: Compute checksum
+        id: checksum
+        run: |
+          CHECKSUM=$(swift package compute-checksum SafeDITool.artifactbundle.zip)
+          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
+          echo "Computed checksum: $CHECKSUM"
+
+      - name: Update version and checksum
+        run: ./Scripts/update-version.sh "${{ inputs.version }}" "${{ steps.checksum.outputs.checksum }}"
+
+      - name: Show changes
+        run: |
+          echo "=== Package.swift changes ==="
+          git diff Package.swift
+          echo "=== Version string changes ==="
+          git diff Sources/SafeDITool/SafeDITool.swift Plugins/Shared.swift
+          echo "=== Checksum: ${{ steps.checksum.outputs.checksum }} ==="
+
+      - name: Upload artifact bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: SafeDITool-artifactbundle
+          path: SafeDITool.artifactbundle.zip
+
+      - name: Commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Package.swift Sources/SafeDITool/SafeDITool.swift Plugins/Shared.swift
+          git commit -m "Release ${{ inputs.version }}"
+
+      - name: Tag and push
+        if: ${{ !inputs.dry-run }}
+        run: |
+          git tag "${{ inputs.version }}"
+          git push origin "${{ inputs.branch }}" --tags
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry-run }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_UPLOADER }}
+        run: |
+          gh release create "${{ inputs.version }}" \
+            --title "${{ inputs.version }}" \
+            --generate-notes \
+            ${{ inputs.prerelease && '--prerelease' || '' }} \
+            SafeDITool.artifactbundle.zip \
+            SafeDITool-macos-universal#SafeDITool-universal \
+            artifacts/SafeDITool-macos-arm64/SafeDITool#SafeDITool-arm64 \
+            artifacts/SafeDITool-macos-x86_64/SafeDITool#SafeDITool-x86_64

--- a/Scripts/check-version-consistency.sh
+++ b/Scripts/check-version-consistency.sh
@@ -13,7 +13,7 @@ extract_version() {
     local quote_char="$4"
 
     local version
-    version=$(grep -A"$context_lines" "$pattern" "$file" | grep -o "${quote_char}[0-9]*\.[0-9]*\.[0-9]*${quote_char}" | tr -d "$quote_char")
+    version=$(grep -A"$context_lines" "$pattern" "$file" | grep -o "${quote_char}[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*[^${quote_char}]*${quote_char}" | tr -d "$quote_char")
 
     local count
     count=$(echo "$version" | grep -c . || true)

--- a/Scripts/update-version.sh
+++ b/Scripts/update-version.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Updates version strings, artifact bundle URL, and checksum across the repository.
+# Used by the publish workflow and tested in CI.
+#
+# Usage: ./Scripts/update-version.sh <version> <checksum>
+# Example: ./Scripts/update-version.sh 2.0.0 abc123def456
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <version> <checksum>" >&2
+    exit 1
+fi
+
+VERSION="$1"
+CHECKSUM="$2"
+
+echo "Updating to version $VERSION with checksum $CHECKSUM..."
+
+# Update the binary target URL in Package.swift.
+sed -i '' "s|https://github.com/dfed/SafeDI/releases/download/[^\"]*|https://github.com/dfed/SafeDI/releases/download/${VERSION}/SafeDITool.artifactbundle.zip|" Package.swift
+
+# Update the checksum in Package.swift.
+sed -i '' "s|checksum: \"[^\"]*\"|checksum: \"${CHECKSUM}\"|" Package.swift
+
+# Update SafeDITool.currentVersion.
+sed -i '' "s|\"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*[^\"]*\"|\"${VERSION}\"|" Sources/SafeDITool/SafeDITool.swift
+
+# Update Plugins/Shared.swift Xcode version.
+sed -i '' "/var safeDIVersion: String/,/}/{s|\"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*[^\"]*\"|\"${VERSION}\"|;}" Plugins/Shared.swift
+
+echo "  Package.swift: URL and checksum updated"
+echo "  SafeDITool.swift: version updated"
+echo "  Plugins/Shared.swift: version updated"
+echo "Done."


### PR DESCRIPTION
## Summary

- Replace tag-triggered publish workflow with `workflow_dispatch` (version, branch, prerelease, dry-run inputs)
- Add Linux x86_64 and arm64 build jobs
- Create macOS universal binary via `lipo`
- Assemble artifact bundle with `info.json` for all platforms
- Extract `Scripts/update-version.sh` for version/checksum updates
- Always upload artifact bundle as workflow artifact (recoverable if release step fails)
- Commit always happens (validates sed); push/release only on non-dry-run
- Use `RELEASE_UPLOADER` PAT for checkout to bypass branch protection
- Fix `check-version-consistency.sh` to handle pre-release version suffixes

## Motivation

Needed to publish releases with artifact bundles for the unified plugin architecture (PR #231). This workflow must land first so we can publish a release that #231 can point to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)