### PR TITLE
Add -internalize-at-link to SafeDITool release builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,8 @@ jobs:
         run: strip -rSTx .build/*/release/SafeDITool
       - name: Give SafeDITool executable permissions
         run: chmod +x .build/*/release/SafeDITool
+      - name: Smoke test
+        run: .build/*/release/SafeDITool --version
       - name: Make codesigning folder
         run: |
           mkdir codesign
@@ -92,6 +94,8 @@ jobs:
         run: swift build -c release --product SafeDITool --static-swift-stdlib -Xswiftc -Osize -Xswiftc -Xfrontend -Xswiftc -internalize-at-link
       - name: Strip binary
         run: strip -s .build/release/SafeDITool
+      - name: Smoke test
+        run: .build/release/SafeDITool --version
       - name: Upload SafeDITool artifact
         uses: actions/upload-artifact@v7
         with:
@@ -115,6 +119,8 @@ jobs:
         run: swift build -c release --product SafeDITool --static-swift-stdlib -Xswiftc -Osize -Xswiftc -Xfrontend -Xswiftc -internalize-at-link
       - name: Strip binary
         run: strip -s .build/release/SafeDITool
+      - name: Smoke test
+        run: .build/release/SafeDITool --version
       - name: Upload SafeDITool artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -236,8 +236,10 @@ jobs:
 
       - name: Prepare release assets
         run: |
-          cp artifacts/SafeDITool-macos-arm64/SafeDITool SafeDITool-arm64
-          cp artifacts/SafeDITool-macos-x86_64/SafeDITool SafeDITool-x86_64
+          cp artifacts/SafeDITool-macos-arm64/SafeDITool SafeDITool-macos-arm64
+          cp artifacts/SafeDITool-macos-x86_64/SafeDITool SafeDITool-macos-x86_64
+          cp artifacts/SafeDITool-linux-x86_64/SafeDITool SafeDITool-linux-x86_64
+          cp artifacts/SafeDITool-linux-arm64/SafeDITool SafeDITool-linux-arm64
 
       - name: Tag and push
         if: ${{ !inputs.dry-run }}
@@ -255,5 +257,7 @@ jobs:
             --generate-notes \
             ${{ inputs.prerelease && '--prerelease' || '' }} \
             SafeDITool.artifactbundle.zip \
-            SafeDITool-arm64 \
-            SafeDITool-x86_64
+            SafeDITool-macos-arm64 \
+            SafeDITool-macos-x86_64 \
+            SafeDITool-linux-x86_64 \
+            SafeDITool-linux-arm64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Stamp version
         run: sed -i 's|"0.0.0-development"|"${{ inputs.version }}"|' Sources/SafeDITool/SafeDITool.swift
       - name: Build SafeDITool
-        run: swift build -c release --product SafeDITool --static-swift-stdlib -Xswiftc -Osize -Xswiftc -Xfrontend -Xswiftc -internalize-at-link
+        run: swift build -c release --product SafeDITool --static-swift-stdlib -Xswiftc -Osize
       - name: Strip binary
         run: strip -s .build/release/SafeDITool
       - name: Smoke test
@@ -116,7 +116,7 @@ jobs:
       - name: Stamp version
         run: sed -i 's|"0.0.0-development"|"${{ inputs.version }}"|' Sources/SafeDITool/SafeDITool.swift
       - name: Build SafeDITool
-        run: swift build -c release --product SafeDITool --static-swift-stdlib -Xswiftc -Osize -Xswiftc -Xfrontend -Xswiftc -internalize-at-link
+        run: swift build -c release --product SafeDITool --static-swift-stdlib -Xswiftc -Osize
       - name: Strip binary
         run: strip -s .build/release/SafeDITool
       - name: Smoke test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Stamp version
         run: sed -i '' 's|"0.0.0-development"|"${{ inputs.version }}"|' Sources/SafeDITool/SafeDITool.swift
       - name: Build SafeDITool
-        run: xcrun swift build -c release --product SafeDITool --arch ${{ matrix.architecture }} -Xswiftc -Osize -Xlinker -dead_strip
+        run: xcrun swift build -c release --product SafeDITool --arch ${{ matrix.architecture }} -Xswiftc -Osize -Xswiftc -Xfrontend -Xswiftc -internalize-at-link -Xlinker -dead_strip
       - name: Strip binary
         run: strip -rSTx .build/*/release/SafeDITool
       - name: Give SafeDITool executable permissions
@@ -89,7 +89,7 @@ jobs:
       - name: Stamp version
         run: sed -i 's|"0.0.0-development"|"${{ inputs.version }}"|' Sources/SafeDITool/SafeDITool.swift
       - name: Build SafeDITool
-        run: swift build -c release --product SafeDITool --static-swift-stdlib -Xswiftc -Osize
+        run: swift build -c release --product SafeDITool --static-swift-stdlib -Xswiftc -Osize -Xswiftc -Xfrontend -Xswiftc -internalize-at-link
       - name: Strip binary
         run: strip -s .build/release/SafeDITool
       - name: Upload SafeDITool artifact
@@ -112,7 +112,7 @@ jobs:
       - name: Stamp version
         run: sed -i 's|"0.0.0-development"|"${{ inputs.version }}"|' Sources/SafeDITool/SafeDITool.swift
       - name: Build SafeDITool
-        run: swift build -c release --product SafeDITool --static-swift-stdlib -Xswiftc -Osize
+        run: swift build -c release --product SafeDITool --static-swift-stdlib -Xswiftc -Osize -Xswiftc -Xfrontend -Xswiftc -internalize-at-link
       - name: Strip binary
         run: strip -s .build/release/SafeDITool
       - name: Upload SafeDITool artifact


### PR DESCRIPTION
## Summary
- Adds `-Xswiftc -Xfrontend -Xswiftc -internalize-at-link` to macOS release builds. This flag marks all `public`/`open` symbols as `internal` at link time, allowing the linker to strip unused code from dependencies (primarily SwiftSyntax). Not added to Linux builds — the static Swift stdlib dominates binary size there and the flag had zero effect.
- Adds `SafeDITool --version` smoke test after strip on each platform to catch runtime issues early.
- Uploads Linux binaries to the GitHub release alongside macOS binaries and the artifact bundle.

## Size comparison vs 2.0.0-alpha-14

| Platform | Before | After | Change |
|---|---|---|---|
| macOS arm64 | 6.4 MB | 5.1 MB | **-20.2%** |
| macOS x86_64 | 7.2 MB | 5.7 MB | **-20.4%** |
| Linux arm64 | 67 MB | 67 MB | 0% (unchanged) |
| Linux x86_64 | 69 MB | 69 MB | 0% (unchanged) |
| Bundle zip | 54 MB | 53 MB | -1.9% |

## Test plan
- [x] Dry-run publish succeeded on all platforms (macOS x86_64, macOS arm64, Linux x86_64, Linux arm64)
- [x] Smoke tests (`SafeDITool --version`) passed on all platforms
- [x] Compared artifact sizes against 2.0.0-alpha-14

🤖 Generated with [Claude Code](https://claude.com/claude-code)