### PR TITLE
Speed up CI with concurrency groups and targeted CodeQL builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     - cron: '0 0 * * 1'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   update-version-check:
     name: Update Version Script Check

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,7 @@ jobs:
 
     - if: matrix.language == 'swift'
       name: Build
-      run: xcrun swift build -c release
+      run: xcrun swift build --target SafeDI --target SafeDITool
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '35 2 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -40,13 +44,6 @@ jobs:
     - name: Select Xcode Version
       run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
 
-    # Pre-build so dependencies are compiled and cached before CodeQL
-    # starts tracing. This prevents CodeQL from analyzing swift-syntax
-    # and other third-party code.
-    - if: matrix.language == 'swift'
-      name: Pre-build dependencies
-      run: xcrun swift build -c release
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
@@ -54,13 +51,9 @@ jobs:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
-    # Touch only our source files so SPM recompiles them (but not
-    # cached dependencies) under CodeQL's compiler tracing.
     - if: matrix.language == 'swift'
-      name: Rebuild project source for CodeQL
-      run: |
-        find Sources -name '*.swift' -exec touch {} +
-        xcrun swift build -c release
+      name: Build
+      run: xcrun swift build -c release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,22 +40,26 @@ jobs:
     - name: Select Xcode Version
       run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
 
+    # Pre-build so dependencies are compiled and cached before CodeQL
+    # starts tracing. This prevents CodeQL from analyzing swift-syntax
+    # and other third-party code.
+    - if: matrix.language == 'swift'
+      name: Pre-build dependencies
+      run: xcrun swift build -c release
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
+    # Touch only our source files so SPM recompiles them (but not
+    # cached dependencies) under CodeQL's compiler tracing.
     - if: matrix.language == 'swift'
+      name: Rebuild project source for CodeQL
       run: |
-        sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
+        find Sources -name '*.swift' -exec touch {} +
         xcrun swift build -c release
 
     - name: Perform CodeQL Analysis


### PR DESCRIPTION
## Summary
- Add concurrency groups to both CI and CodeQL workflows so new pushes on a PR branch cancel in-progress runs
- Main branch and scheduled runs are never cancelled — each gets a unique group via `github.run_id`
- Build only `SafeDI` and `SafeDITool` targets in debug mode for CodeQL instead of a full release build of everything
- Clean up redundant `xcode-select` call and stale comments in CodeQL workflow

## Context
Investigated pre-building dependencies before CodeQL init to avoid tracing swift-syntax compilation. This doesn't work for Swift — CodeQL replaces the Swift compiler with a tracing wrapper, which invalidates SPM's entire build cache.

Instead, we reduce CodeQL build time by:
1. **Debug mode** (SPM default) — skips release optimizations that CodeQL doesn't need
2. **Targeted builds** — only `SafeDI` and `SafeDITool`, skipping test targets

## Test plan
- [x] Verify CodeQL workflow completes successfully with targeted debug build
- [x] Compare Swift analysis job duration against the ~57 min baseline on main
- [x] Push twice in quick succession on a PR to confirm stale runs get cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)