### PR TITLE
Rename SafeDIParameters to SafeDIOverrides and add doc comments to generated mock types

### DIFF
--- a/Documentation/Manual.md
+++ b/Documentation/Manual.md
@@ -554,30 +554,42 @@ Your user-defined `mock()` method must be `public` (or `open`) and must accept p
 
 ### Overriding dependencies
 
-When a type has `@Instantiated` dependencies with their own subtrees, the generated `mock()` accepts a `safeDIParameters` argument that provides tree-structured control over every dependency in the graph:
+When a type has `@Instantiated` dependencies with their own subtrees, the generated `mock()` accepts a `safeDIOverrides` argument that provides tree-structured control over every dependency in the graph:
 
 ```swift
 // Override a child’s default-valued parameter:
-Root.mock(safeDIParameters: .init(
+Root.mock(safeDIOverrides: .init(
     child: .init(theme: .dark)
 ))
 
 // Replace an entire type’s construction with a trailing closure:
-Root.mock(safeDIParameters: .init(
+Root.mock(safeDIOverrides: .init(
     child: .init { service, theme in
         CustomChild(service: service, theme: theme)
     }
 ))
 
-// Override a leaf dependency:
-Root.mock(safeDIParameters: .init(
-    service: .init { MockService() }
+// Override a leaf dependency (leaves are simple closures, not config objects):
+Root.mock(safeDIOverrides: .init(
+    service: { MockService() }
 ))
 ```
 
-Each child dependency in the tree has a configuration type that accepts optional overrides for its own children and a trailing `safeDIBuilder` closure to replace its construction entirely. When no overrides are provided, the generated mock uses the type’s real initializer (or custom mock method).
+Each child dependency in the tree that has its own subtree generates a `SafeDIMockConfiguration` struct. This struct accepts optional overrides for the child’s own dependencies and a trailing `safeDIBuilder` closure. The `safeDIBuilder` closure is how you override or customize how the type is constructed within the generated mock tree. Its parameters match the type’s `customMockName` method signature if one is defined, or its `init` parameters otherwise. When no `safeDIBuilder` is provided, the generated mock calls the type’s `customMockName` method or `init` directly.
 
-Types with no `@Instantiated` subtree — for example, types with only `@Received` dependencies — do not generate a `SafeDIParameters` struct. Their `mock()` method uses flat parameters instead.
+For example, given a `Child` type with `init(service: Service, theme: Theme)`, the `safeDIBuilder` closure has the signature `(Service, Theme) -> Child`:
+
+```swift
+Root.mock(safeDIOverrides: .init(
+    child: .init { service, theme in
+        // `service` and `theme` are the resolved values from the mock tree.
+        // Return a customized Child instance.
+        Child(service: service, theme: theme)
+    }
+))
+```
+
+Types with no `@Instantiated` subtree — for example, types with only `@Received` dependencies — do not generate a `SafeDIOverrides` struct. Their `mock()` method uses flat parameters instead.
 
 ### Mock visibility
 
@@ -610,7 +622,7 @@ public struct ProfileView: Instantiable {
 Override the default:
 
 ```swift
-Root.mock(safeDIParameters: .init(
+Root.mock(safeDIOverrides: .init(
     profileView: .init(showDebugInfo: true)
 ))
 ```
@@ -621,7 +633,7 @@ Default-valued parameters do **not** bubble through `Instantiator`, `SendableIns
 
 ### `@Received(onlyIfAvailable: true)` properties in mocks
 
-When a type has a `@Received(onlyIfAvailable: true)` dependency, the generated mock places that dependency inside the `SafeDIParameters` struct as a plain optional property (defaulting to `nil`) rather than exposing it as a top-level `mock()` parameter. When `nil`, the dependency is absent. When provided (e.g., `.mock()`), the value is used.
+When a type has a `@Received(onlyIfAvailable: true)` dependency, the generated mock places that dependency inside the `SafeDIOverrides` struct as a plain optional property (defaulting to `nil`) rather than exposing it as a top-level `mock()` parameter. When `nil`, the dependency is absent. When provided (e.g., `.mock()`), the value is used.
 
 ```swift
 @Instantiable(generateMock: true)
@@ -633,10 +645,10 @@ public struct ImageService: Instantiable {
 }
 ```
 
-Provide the dependency via `SafeDIParameters`:
+Provide the dependency via `SafeDIOverrides`:
 
 ```swift
-ImageService.mock(safeDIParameters: .init(
+ImageService.mock(safeDIOverrides: .init(
     cacheService: .mock()
 ))
 ```

--- a/Sources/SafeDI/Decorators/SafeDIConfiguration.swift
+++ b/Sources/SafeDI/Decorators/SafeDIConfiguration.swift
@@ -30,6 +30,7 @@
 /// - Parameters:
 ///   - additionalImportedModules: Module names to import in the generated dependency tree, in addition to the import statements found in files that declare `@Instantiable` types.
 ///   - additionalDirectoriesToInclude: Directories containing Swift files to include, relative to the executing directory. This property only applies to SafeDI repos that utilize the SPM plugin via an Xcode project.
+///   - additionalMocksToGenerate: Type names from dependent modules to generate `mock()` methods for in this module. The types must be decorated with `@Instantiable` in their home module. See the "Cross-module mock generation" section of the manual.
 ///   - mockConditionalCompilation: The conditional compilation flag to wrap generated mock code in (e.g. `"DEBUG"`). Set to `nil` to generate mocks without conditional compilation.
 ///
 /// Example:

--- a/Sources/SafeDICore/Generators/ScopeGenerator.swift
+++ b/Sources/SafeDICore/Generators/ScopeGenerator.swift
@@ -662,7 +662,7 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 		// Disambiguate flat received parameter labels when collisions exist.
 		// Include onlyIfAvailable labels so flat params with the same label
 		// get disambiguated (onlyIfAvailable entries are accessed via
-		// safeDIParameters.label, so they don't need disambiguation).
+		// safeDIOverrides.label, so they don't need disambiguation).
 		// Forwarded parameters keep their original labels (must match init signature).
 		let allFlatLabels = forwardedDependencies.map(\.property.label)
 			+ rootDefaultParameters.map(\.label)
@@ -715,7 +715,7 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 		lines.append("extension \(typeName) {")
 
 		if hasTree {
-			lines.append(Self.generateSafeDIParametersStruct(
+			lines.append(Self.generateSafeDIOverridesStruct(
 				rootChildren: parameterTree,
 				onlyIfAvailableEntries: onlyIfAvailableSafeDIParameterEntries,
 				indent: indent,
@@ -755,7 +755,7 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 			mockParameters.append("\(bodyIndent)\(flatUncovered.label): \(flatUncovered.typeSource)")
 		}
 		if hasTree {
-			mockParameters.append("\(bodyIndent)safeDIParameters: SafeDIParameters = .init()")
+			mockParameters.append("\(bodyIndent)safeDIOverrides: SafeDIOverrides = .init()")
 		}
 
 		lines.append("\(indent)\(mockAttributesPrefix)static func mock(")
@@ -766,11 +766,11 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 		if hasTree {
 			// Bind onlyIfAvailable entries first — tree bindings may reference them.
 			for entry in onlyIfAvailableSafeDIParameterEntries {
-				lines.append("\(bodyIndent)let \(entry.label): \(entry.typeSource) = safeDIParameters.\(entry.label)")
+				lines.append("\(bodyIndent)let \(entry.label): \(entry.typeSource) = safeDIOverrides.\(entry.label)")
 			}
 			let bodyBindings = Self.generateMockBodyBindings(
 				nodes: parameterTree,
-				parentPath: "safeDIParameters",
+				parentPath: "safeDIOverrides",
 				indent: bodyIndent,
 			)
 			lines.append(contentsOf: bodyBindings)
@@ -1058,7 +1058,7 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 		}
 	}
 
-	// MARK: SafeDIParameters Generation
+	// MARK: SafeDIOverrides Generation
 
 	/// Computes disambiguated property labels for a list of nodes at the same scope level.
 	/// When two nodes share a `propertyLabel`, appends `_TypeName` to make them unique.
@@ -1151,10 +1151,10 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 		return result
 	}
 
-	/// Generates the `SafeDIParameters` struct. Configuration type references
+	/// Generates the `SafeDIOverrides` struct. Configuration type references
 	/// use qualified names (e.g., `ChildA.SafeDIMockConfiguration`).
 	/// Returns the struct source code, or `nil` if the tree has no children.
-	private static func generateSafeDIParametersStruct(
+	private static func generateSafeDIOverridesStruct(
 		rootChildren: [MockParameterNode],
 		onlyIfAvailableEntries: [(label: String, typeSource: String)],
 		indent: String,
@@ -1163,12 +1163,13 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 		let memberIndent = "\(innerIndent)\(standardIndent)"
 
 		var lines = [String]()
-		lines.append("\(indent)struct SafeDIParameters {")
+		lines.append("\(indent)/// Overrides for the mock dependency tree.")
+		lines.append("\(indent)struct SafeDIOverrides {")
 
 		// Disambiguate root-level children property labels.
 		let rootLabelMap = disambiguatePropertyLabels(for: rootChildren)
 
-		// Generate SafeDIParameters init with root-level children and onlyIfAvailable entries.
+		// Generate SafeDIOverrides init with root-level children and onlyIfAvailable entries.
 		lines.append("\(innerIndent)init(")
 		var initParameters = rootChildren.map { child in
 			let label = disambiguatedLabel(for: child, labelMap: rootLabelMap)
@@ -1223,6 +1224,7 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 		let sendableAnnotation = node.requiresSendable ? "@Sendable " : ""
 		var lines = [String]()
 
+		lines.append("\(indent)/// Configuration for how this type is constructed within a mock tree.")
 		lines.append("\(indent)struct \(MockParameterNode.configurationStructName) {")
 
 		// Build init parameters in order: children, defaults, builder (last).
@@ -1271,6 +1273,7 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 		let closureType = node.builderClosureType
 		initParameters.append("\(innerIndent)\(standardIndent)_ safeDIBuilder: (\(sendableAnnotation)\(closureType))? = nil")
 		assignments.append("\(innerIndent)\(standardIndent)self.safeDIBuilder = safeDIBuilder")
+		storedProperties.append("\(innerIndent)/// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.")
 		storedProperties.append("\(innerIndent)let safeDIBuilder: (\(sendableAnnotation)\(closureType))?")
 
 		// Emit init.
@@ -1291,11 +1294,11 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 	// MARK: Mock Body Generation
 
 	/// Generates the mock body bindings for the tree. Walks depth-first (children before
-	/// parent), emitting `let` bindings that call through `safeDIParameters.path.safeDIBuilder(...)`.
+	/// parent), emitting `let` bindings that call through `safeDIOverrides.path.safeDIBuilder(...)`.
 	///
-	/// For constant nodes: `let {label} = safeDIParameters.{path}.safeDIBuilder({arguments})`
+	/// For constant nodes: `let {label} = safeDIOverrides.{path}.safeDIBuilder({arguments})`
 	/// For Instantiator nodes: inner builder function + `Instantiator<T>` wrapping.
-	/// Collects all `safeDIParameters` references that would appear inside a
+	/// Collects all `safeDIOverrides` references that would appear inside a
 	/// `@Sendable func`, so they can be extracted and resolved outside the function.
 	/// Each extraction is a `(localName, optionalPath, defaultExpression)` tuple.
 	/// When `optionalPath` is non-nil, the extraction resolves an optional builder via nil-coalescing.
@@ -1314,9 +1317,9 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 			let disambiguated = disambiguatedLabel(for: node, labelMap: labelMap)
 			let nodePath = "\(parentPath).\(disambiguated)"
 			// Convert nodePath to a local name: replace dots with underscores,
-			// strip the "safeDIParameters." prefix.
+			// strip the "safeDIOverrides." prefix.
 			let relativePath = nodePath
-				.replacingOccurrences(of: "safeDIParameters.", with: "")
+				.replacingOccurrences(of: "safeDIOverrides.", with: "")
 				.replacingOccurrences(of: ".", with: "_")
 
 			if !isCycleNode {
@@ -1385,11 +1388,11 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 
 			let defaultBuilder = node.defaultBuilderExpression
 			let relativePath = nodePath
-				.replacingOccurrences(of: "safeDIParameters.", with: "")
+				.replacingOccurrences(of: "safeDIOverrides.", with: "")
 				.replacingOccurrences(of: ".", with: "_")
 
 			// When inside a sendable extraction, use extracted locals instead of
-			// safeDIParameters paths.
+			// safeDIOverrides paths.
 			let builderExpression: String
 			let optionalBuilderPath: String?
 			let argumentNodePath: String
@@ -1497,7 +1500,7 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 	/// Resolves the positional arguments for a builder call.
 	/// Each argument comes from one of:
 	/// - A local variable (previously built dep or flat mock param)
-	/// - A stored default on SafeDIParameters (`{nodePath}.{label}`)
+	/// - A stored default on SafeDIOverrides (`{nodePath}.{label}`)
 	private static func resolveBuilderArguments(
 		for node: MockParameterNode,
 		nodePath: String,
@@ -1507,7 +1510,7 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 		let defaultParameterLabels = Set(node.defaultParameters.map(\.label))
 
 		let relativePath = nodePath
-			.replacingOccurrences(of: "safeDIParameters.", with: "")
+			.replacingOccurrences(of: "safeDIOverrides.", with: "")
 			.replacingOccurrences(of: ".", with: "_")
 
 		return node.constructionArguments.compactMap { argument in
@@ -1586,10 +1589,10 @@ actor ScopeGenerator: CustomStringConvertible, Sendable {
 		// depend on forwarded properties that are only available as parameters.
 		if !node.isPropertyCycle {
 			if propertyType.isSendable {
-				// For @Sendable functions, extract all safeDIParameters references
+				// For @Sendable functions, extract all safeDIOverrides references
 				// OUTSIDE the function and resolve nil-coalescing here (in the
 				// @MainActor mock() context). This avoids capturing the non-Sendable
-				// SafeDIParameters struct inside the @Sendable function.
+				// SafeDIOverrides struct inside the @Sendable function.
 				var extractions = [(localName: String, optionalPath: String?, defaultExpression: String)]()
 				collectSendableExtractions(
 					nodes: node.children,
@@ -1744,7 +1747,7 @@ extension Instantiable {
 		}
 		if forMockGeneration {
 			// In the simple mock case (no dependencies, no tree), the initializer is always present
-			// and covers all dependencies. The SafeDIParameters pipeline handles complex cases.
+			// and covers all dependencies. The SafeDIOverrides pipeline handles complex cases.
 			guard let initializerToUse else { return "" }
 			return initializerToUse
 				.createMockInitializerArgumentList(

--- a/Tests/SafeDIToolTests/SafeDIToolMockGenerationConfigurationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockGenerationConfigurationTests.swift
@@ -159,7 +159,8 @@ struct SafeDIToolMockGenerationConfigurationTests: ~Copyable {
 		// Please refrain from editing this file directly.
 
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            dependency: (() -> Dependency)? = nil
 		        ) {
@@ -170,9 +171,9 @@ struct SafeDIToolMockGenerationConfigurationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let dependency = (safeDIParameters.dependency ?? Dependency.init)()
+		        let dependency = (safeDIOverrides.dependency ?? Dependency.init)()
 		        return Root(dependency: dependency)
 		    }
 		}
@@ -476,7 +477,8 @@ struct SafeDIToolMockGenerationConfigurationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            crossModuleService: (() -> CrossModuleService)? = nil
 		        ) {
@@ -487,9 +489,9 @@ struct SafeDIToolMockGenerationConfigurationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let crossModuleService = (safeDIParameters.crossModuleService ?? CrossModuleService.init)()
+		        let crossModuleService = (safeDIOverrides.crossModuleService ?? CrossModuleService.init)()
 		        return Root(crossModuleService: crossModuleService)
 		    }
 		}
@@ -547,7 +549,8 @@ struct SafeDIToolMockGenerationConfigurationTests: ~Copyable {
 		// Please refrain from editing this file directly.
 
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -558,11 +561,11 @@ struct SafeDIToolMockGenerationConfigurationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            let leaf = (safeDIParameters.child.leaf ?? Leaf.init)()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(leaf:))(leaf)
+		            let leaf = (safeDIOverrides.child.leaf ?? Leaf.init)()
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(leaf:))(leaf)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -637,7 +640,8 @@ struct SafeDIToolMockGenerationConfigurationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            crossModuleService: (() -> CrossModuleService)? = nil
 		        ) {
@@ -648,9 +652,9 @@ struct SafeDIToolMockGenerationConfigurationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let crossModuleService = (safeDIParameters.crossModuleService ?? CrossModuleService.init)()
+		        let crossModuleService = (safeDIOverrides.crossModuleService ?? CrossModuleService.init)()
 		        return Root(crossModuleService: crossModuleService)
 		    }
 		}

--- a/Tests/SafeDIToolTests/SafeDIToolMockGenerationCustomMockTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockGenerationCustomMockTests.swift
@@ -112,7 +112,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension TypeWithCustomMock {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            dependency: (() -> Dependency)? = nil
 		        ) {
@@ -123,9 +124,9 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> TypeWithCustomMock {
-		        let dependency = (safeDIParameters.dependency ?? Dependency.init)()
+		        let dependency = (safeDIOverrides.dependency ?? Dependency.init)()
 		        return TypeWithCustomMock.customMock(dependency: dependency)
 		    }
 		}
@@ -232,7 +233,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            dependency: (() -> Dependency)? = nil,
 		            child: ((Dependency) -> Child)? = nil
@@ -246,10 +248,10 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let dependency = (safeDIParameters.dependency ?? Dependency.init)()
-		        let child = (safeDIParameters.child ?? Child.customMock(dependency:))(dependency)
+		        let dependency = (safeDIOverrides.dependency ?? Dependency.init)()
+		        let child = (safeDIOverrides.child ?? Child.customMock(dependency:))(dependency)
 		        return Parent(child: child)
 		    }
 		}
@@ -264,7 +266,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            dependency: (() -> Dependency)? = nil
 		        ) {
@@ -275,9 +278,9 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
-		        let dependency = (safeDIParameters.dependency ?? Dependency.init)()
+		        let dependency = (safeDIOverrides.dependency ?? Dependency.init)()
 		        return Child.customMock(dependency: dependency)
 		    }
 		}
@@ -333,7 +336,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            serviceA: (() -> ServiceA)? = nil,
 		            serviceB: (() -> ServiceB)? = nil
@@ -347,10 +351,10 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let serviceA = (safeDIParameters.serviceA ?? ServiceA.customMock)()
-		        let serviceB = (safeDIParameters.serviceB ?? ServiceB.init)()
+		        let serviceA = (safeDIOverrides.serviceA ?? ServiceA.customMock)()
+		        let serviceB = (safeDIOverrides.serviceB ?? ServiceB.init)()
 		        return Parent(serviceA: serviceA, serviceB: serviceB)
 		    }
 		}
@@ -415,7 +419,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil,
 		            child: Child.SafeDIMockConfiguration = .init()
@@ -429,12 +434,12 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let service = (safeDIParameters.service ?? Service.init)()
+		        let service = (safeDIOverrides.service ?? Service.init)()
 		        func __safeDI_child() -> Child {
-		            let grandchild = (safeDIParameters.child.grandchild ?? Grandchild.customMock(service:))(service)
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(grandchild:))(grandchild)
+		            let grandchild = (safeDIOverrides.child.grandchild ?? Grandchild.customMock(service:))(service)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(grandchild:))(grandchild)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Parent(child: child)
@@ -498,7 +503,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil,
 		            child: ((Service) -> Child)? = nil
@@ -512,10 +518,10 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let service = (safeDIParameters.service ?? Service.init)()
-		        let child = (safeDIParameters.child ?? Child.customMock(service:))(service)
+		        let service = (safeDIOverrides.service ?? Service.init)()
+		        let child = (safeDIOverrides.child ?? Child.customMock(service:))(service)
 		        return Parent(child: child)
 		    }
 		}
@@ -575,7 +581,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil,
 		            child: ((Service) -> Child)? = nil
@@ -589,10 +596,10 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let service = (safeDIParameters.service ?? Service.init)()
-		        let child = (safeDIParameters.child ?? Child.customMock(service:))(service)
+		        let service = (safeDIOverrides.service ?? Service.init)()
+		        let child = (safeDIOverrides.child ?? Child.customMock(service:))(service)
 		        return Parent(child: child)
 		    }
 		}
@@ -656,7 +663,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            serviceA: (() -> ServiceA)? = nil,
 		            serviceB: (() -> ServiceB)? = nil,
@@ -673,11 +681,11 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let serviceA = (safeDIParameters.serviceA ?? ServiceA.init)()
-		        let serviceB = (safeDIParameters.serviceB ?? ServiceB.init)()
-		        let child = (safeDIParameters.child ?? Child.customMock(serviceA:serviceB:))(serviceA, serviceB)
+		        let serviceA = (safeDIOverrides.serviceA ?? ServiceA.init)()
+		        let serviceB = (safeDIOverrides.serviceB ?? ServiceB.init)()
+		        let child = (safeDIOverrides.child ?? Child.customMock(serviceA:serviceB:))(serviceA, serviceB)
 		        return Parent(child: child)
 		    }
 		}
@@ -733,7 +741,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            serviceA: (() -> ServiceA)? = nil,
 		            serviceB: (() -> ServiceB)? = nil
@@ -747,10 +756,10 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
-		        let serviceA = (safeDIParameters.serviceA ?? ServiceA.init)()
-		        let serviceB = (safeDIParameters.serviceB ?? ServiceB.init)()
+		        let serviceA = (safeDIOverrides.serviceA ?? ServiceA.init)()
+		        let serviceB = (safeDIOverrides.serviceB ?? ServiceB.init)()
 		        return Child.customMock(serviceB: serviceB, serviceA: serviceA)
 		    }
 		}
@@ -817,7 +826,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: ((String) -> Child)? = nil
 		        ) {
@@ -829,9 +839,9 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		    static func mock(
 		        name: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let child = (safeDIParameters.child ?? Child.customMock(name:))(name)
+		        let child = (safeDIOverrides.child ?? Child.customMock(name:))(name)
 		        return Parent(child: child)
 		    }
 		}
@@ -885,7 +895,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -896,11 +907,11 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            let dependency = (safeDIParameters.child.dependency ?? Dependency.init)()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.customMock(dependency:extra:))(dependency, safeDIParameters.child.extra)
+		            let dependency = (safeDIOverrides.child.dependency ?? Dependency.init)()
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.customMock(dependency:extra:))(dependency, safeDIOverrides.child.extra)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -963,7 +974,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childService: ChildService.SafeDIMockConfiguration = .init()
 		        ) {
@@ -974,11 +986,11 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childService() -> ChildService {
-		            let engine = (safeDIParameters.childService.engine ?? Engine.init)()
-		            return (safeDIParameters.childService.safeDIBuilder ?? ChildService.customMock(engine:))(engine)
+		            let engine = (safeDIOverrides.childService.engine ?? Engine.init)()
+		            return (safeDIOverrides.childService.safeDIBuilder ?? ChildService.customMock(engine:))(engine)
 		        }
 		        let childService: ChildService = __safeDI_childService()
 		        return Root(childService: childService)
@@ -1046,7 +1058,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: ((@escaping @MainActor (String) -> Void, @escaping @MainActor (String) throws -> Void) -> Service)? = nil
 		        ) {
@@ -1057,9 +1070,9 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service = (safeDIParameters.service ?? Service.customMock(onCancel:onSubmit:))({ _ in }, { _ in })
+		        let service = (safeDIOverrides.service ?? Service.customMock(onCancel:onSubmit:))({ _ in }, { _ in })
 		        return Root(service: service)
 		    }
 		}
@@ -1109,7 +1122,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -1120,11 +1134,11 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            let service = (safeDIParameters.child.service ?? Service.init)()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.customMock(service:))(service)
+		            let service = (safeDIOverrides.child.service ?? Service.init)()
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.customMock(service:))(service)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -1186,7 +1200,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -1197,11 +1212,11 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            let externalService = (safeDIParameters.child.externalService ?? ExternalService.init)()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.customMock(externalService:))(externalService)
+		            let externalService = (safeDIOverrides.child.externalService ?? ExternalService.init)()
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.customMock(externalService:))(externalService)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -1255,7 +1270,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: ((Service?) -> Child)? = nil,
 		            service: Service? = nil
@@ -1269,10 +1285,10 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service: Service? = safeDIParameters.service
-		        let child = (safeDIParameters.child ?? Child.customMock(service:))(service)
+		        let service: Service? = safeDIOverrides.service
+		        let child = (safeDIOverrides.child ?? Child.customMock(service:))(service)
 		        return Root(child: child)
 		    }
 		}
@@ -1327,7 +1343,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            engine: (() -> Engine)? = nil,
 		            childService: ((Engine) -> ChildService)? = nil
@@ -1341,10 +1358,10 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let engine = (safeDIParameters.engine ?? Engine.init)()
-		        let childService = (safeDIParameters.childService ?? ChildService.customMock(engine:))(engine)
+		        let engine = (safeDIOverrides.engine ?? Engine.init)()
+		        let childService = (safeDIOverrides.childService ?? ChildService.customMock(engine:))(engine)
 		        return Root(childService: childService, engine: engine)
 		    }
 		}
@@ -1400,7 +1417,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            engine: (() -> Engine)? = nil,
 		            childService: ((Engine) -> ChildService)? = nil
@@ -1414,10 +1432,10 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let engine = (safeDIParameters.engine ?? Engine.init)()
-		        let childService = (safeDIParameters.childService ?? ChildService.init(engine:))(engine)
+		        let engine = (safeDIOverrides.engine ?? Engine.init)()
+		        let childService = (safeDIOverrides.childService ?? ChildService.init(engine:))(engine)
 		        return Root(childService: childService, engine: engine)
 		    }
 		}
@@ -1471,7 +1489,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            engine: (() -> Engine)? = nil,
 		            childService: ((Engine) -> ChildService)? = nil
@@ -1485,10 +1504,10 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let engine = (safeDIParameters.engine ?? Engine.init)()
-		        let childService = (safeDIParameters.childService ?? ChildService.customMock(engine:))(engine)
+		        let engine = (safeDIOverrides.engine ?? Engine.init)()
+		        let childService = (safeDIOverrides.childService ?? ChildService.customMock(engine:))(engine)
 		        return Root(childService: childService, engine: engine)
 		    }
 		}
@@ -1543,7 +1562,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            engine: (() -> Engine)? = nil,
 		            childService: ((Engine) -> ChildService)? = nil
@@ -1557,10 +1577,10 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let engine = (safeDIParameters.engine ?? Engine.init)()
-		        let childService = (safeDIParameters.childService ?? ChildService.instantiate(engine:))(engine)
+		        let engine = (safeDIOverrides.engine ?? Engine.init)()
+		        let childService = (safeDIOverrides.childService ?? ChildService.instantiate(engine:))(engine)
 		        return Root(childService: childService, engine: engine)
 		    }
 		}
@@ -1610,7 +1630,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Service {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            engine: (() -> Engine)? = nil
 		        ) {
@@ -1621,9 +1642,9 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Service {
-		        let engine = (safeDIParameters.engine ?? Engine.init)()
+		        let engine = (safeDIOverrides.engine ?? Engine.init)()
 		        return Service.customMock(engine: engine)
 		    }
 		}
@@ -1631,6 +1652,7 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Service {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            engine: (() -> Engine)? = nil,
@@ -1641,6 +1663,7 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		        }
 
 		        let engine: (() -> Engine)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((Engine) -> Service)?
 		    }
 		}
@@ -1695,7 +1718,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Service {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            engine: (() -> Engine)? = nil
 		        ) {
@@ -1706,9 +1730,9 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Service {
-		        let engine = (safeDIParameters.engine ?? Engine.init)()
+		        let engine = (safeDIOverrides.engine ?? Engine.init)()
 		        return Service.customMock(engine: engine)
 		    }
 		}
@@ -1716,6 +1740,7 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Service {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            engine: (() -> Engine)? = nil,
@@ -1726,6 +1751,7 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		        }
 
 		        let engine: (() -> Engine)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((Engine) -> Service)?
 		    }
 		}
@@ -1741,7 +1767,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: Service.SafeDIMockConfiguration = .init()
 		        ) {
@@ -1752,11 +1779,11 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_service() -> Service {
-		            let engine = (safeDIParameters.service.engine ?? Engine.init)()
-		            return (safeDIParameters.service.safeDIBuilder ?? Service.customMock(engine:))(engine)
+		            let engine = (safeDIOverrides.service.engine ?? Engine.init)()
+		            return (safeDIOverrides.service.safeDIBuilder ?? Service.customMock(engine:))(engine)
 		        }
 		        let service: Service = __safeDI_service()
 		        return Root(service: service)
@@ -1814,7 +1841,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Service {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            engine: (() -> Engine)? = nil
 		        ) {
@@ -1826,9 +1854,9 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		    static func mock(
 		        showDebugInfo: Bool = false,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Service {
-		        let engine = (safeDIParameters.engine ?? Engine.init)()
+		        let engine = (safeDIOverrides.engine ?? Engine.init)()
 		        return Service.customMock(engine: engine, showDebugInfo: showDebugInfo)
 		    }
 		}
@@ -1836,6 +1864,7 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Service {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            engine: (() -> Engine)? = nil,
@@ -1849,6 +1878,7 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		        let engine: (() -> Engine)?
 		        let showDebugInfo: Bool
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((Engine, Bool) -> Service)?
 		    }
 		}
@@ -1903,7 +1933,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Service {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            engine: (() -> Engine)? = nil
 		        ) {
@@ -1914,9 +1945,9 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Service {
-		        let engine = (safeDIParameters.engine ?? Engine.init)()
+		        let engine = (safeDIOverrides.engine ?? Engine.init)()
 		        return Service.customMock(engine: engine)
 		    }
 		}
@@ -1966,7 +1997,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: ((String) -> Child)? = nil
 		        ) {
@@ -1978,9 +2010,9 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		    static func mock(
 		        name: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let child = (safeDIParameters.child ?? Child.customMock(name:))(name)
+		        let child = (safeDIOverrides.child ?? Child.customMock(name:))(name)
 		        return Root(child: child, name: name)
 		    }
 		}
@@ -2054,7 +2086,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ((String) -> ChildA)? = nil,
 		            childB: ((String) -> ChildB)? = nil
@@ -2069,10 +2102,10 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		    static func mock(
 		        name: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let childA = (safeDIParameters.childA ?? ChildA.customMock(name:))(name)
-		        let childB = (safeDIParameters.childB ?? ChildB.customMock(name:))(name)
+		        let childA = (safeDIOverrides.childA ?? ChildA.customMock(name:))(name)
+		        let childB = (safeDIOverrides.childB ?? ChildB.customMock(name:))(name)
 		        return Root(childA: childA, childB: childB, name: name)
 		    }
 		}
@@ -2145,7 +2178,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
 		            childB: ((String) -> ChildB)? = nil
@@ -2160,14 +2194,14 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		    static func mock(
 		        name: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childA() -> ChildA {
-		            let grandchild = (safeDIParameters.childA.grandchild ?? Grandchild.customMock(name:))(name)
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.customMock(grandchild:name:))(grandchild, name)
+		            let grandchild = (safeDIOverrides.childA.grandchild ?? Grandchild.customMock(name:))(name)
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.customMock(grandchild:name:))(grandchild, name)
 		        }
 		        let childA: ChildA = __safeDI_childA()
-		        let childB = (safeDIParameters.childB ?? ChildB.customMock(name:))(name)
+		        let childB = (safeDIOverrides.childB ?? ChildB.customMock(name:))(name)
 		        return Root(childA: childA, childB: childB, name: name)
 		    }
 		}
@@ -2213,7 +2247,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: ((String) -> Child)? = nil
 		        ) {
@@ -2225,9 +2260,9 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		    static func mock(
 		        name: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let child = (safeDIParameters.child ?? Child.init(name:))(name)
+		        let child = (safeDIOverrides.child ?? Child.init(name:))(name)
 		        return Root(child: child, name: name)
 		    }
 		}
@@ -2299,7 +2334,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
 		            childB: ChildB.SafeDIMockConfiguration = .init()
@@ -2313,16 +2349,16 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childA() -> ChildA {
-		            let value = (safeDIParameters.childA.value ?? String.init)()
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.customMock(value:))(value)
+		            let value = (safeDIOverrides.childA.value ?? String.init)()
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.customMock(value:))(value)
 		        }
 		        let childA: ChildA = __safeDI_childA()
 		        func __safeDI_childB() -> ChildB {
-		            let value = (safeDIParameters.childB.value ?? Int.init)()
-		            return (safeDIParameters.childB.safeDIBuilder ?? ChildB.init(value:))(value)
+		            let value = (safeDIOverrides.childB.value ?? Int.init)()
+		            return (safeDIOverrides.childB.safeDIBuilder ?? ChildB.init(value:))(value)
 		        }
 		        let childB: ChildB = __safeDI_childB()
 		        return Root(childA: childA, childB: childB)
@@ -2380,7 +2416,8 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -2392,10 +2429,10 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 
 		    static func mock(
 		        engine: Engine,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.mock(engine:name:))(engine, safeDIParameters.child.name)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.mock(engine:name:))(engine, safeDIOverrides.child.name)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)

--- a/Tests/SafeDIToolTests/SafeDIToolMockGenerationDefaultValueTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockGenerationDefaultValueTests.swift
@@ -82,7 +82,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil
 		        ) {
@@ -94,9 +95,9 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		    static func mock(
 		        flag: Bool = false,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        return Child(shared: shared, flag: flag)
 		    }
 		}
@@ -104,6 +105,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            flag: Bool = false,
@@ -114,6 +116,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		        }
 
 		        let flag: Bool
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((Shared, Bool) -> Child)?
 		    }
 		}
@@ -127,7 +130,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil,
 		            child: Child.SafeDIMockConfiguration = .init()
@@ -141,11 +145,11 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        func __safeDI_child() -> Child {
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(shared:flag:))(shared, safeDIParameters.child.flag)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(shared:flag:))(shared, safeDIOverrides.child.flag)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child, shared: shared)
@@ -211,6 +215,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            config: String = "hello",
@@ -221,6 +226,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		        }
 
 		        let config: String
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((String) -> Child)?
 		    }
 		}
@@ -234,7 +240,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -245,10 +252,10 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(config:))(safeDIParameters.child.config)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(config:))(safeDIOverrides.child.config)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -291,7 +298,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -302,10 +310,10 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childBuilder(name: String) -> Child {
-		            (safeDIParameters.childBuilder.safeDIBuilder ?? Child.init(name:flag:))(name, safeDIParameters.childBuilder.flag)
+		            (safeDIOverrides.childBuilder.safeDIBuilder ?? Child.init(name:flag:))(name, safeDIOverrides.childBuilder.flag)
 		        }
 		        let childBuilder = Instantiator<Child> {
 		            __safeDI_childBuilder(name: $0)
@@ -334,6 +342,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            flag: Bool = false,
@@ -344,6 +353,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		        }
 
 		        let flag: Bool
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((String, Bool) -> Child)?
 		    }
 		}
@@ -388,7 +398,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -399,14 +410,14 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
 		            func __safeDI_grandchild() -> Grandchild {
-		                return (safeDIParameters.child.grandchild.safeDIBuilder ?? Grandchild.init(viewModel:))(safeDIParameters.child.grandchild.viewModel)
+		                return (safeDIOverrides.child.grandchild.safeDIBuilder ?? Grandchild.init(viewModel:))(safeDIOverrides.child.grandchild.viewModel)
 		            }
 		            let grandchild: Grandchild = __safeDI_grandchild()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(grandchild:))(grandchild)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(grandchild:))(grandchild)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -422,7 +433,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            grandchild: Grandchild.SafeDIMockConfiguration = .init()
 		        ) {
@@ -433,10 +445,10 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
 		        func __safeDI_grandchild() -> Grandchild {
-		            return (safeDIParameters.grandchild.safeDIBuilder ?? Grandchild.init(viewModel:))(safeDIParameters.grandchild.viewModel)
+		            return (safeDIOverrides.grandchild.safeDIBuilder ?? Grandchild.init(viewModel:))(safeDIOverrides.grandchild.viewModel)
 		        }
 		        let grandchild: Grandchild = __safeDI_grandchild()
 		        return Child(grandchild: grandchild)
@@ -446,6 +458,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            grandchild: Grandchild.SafeDIMockConfiguration = .init(),
@@ -456,6 +469,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		        }
 
 		        let grandchild: Grandchild.SafeDIMockConfiguration
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((Grandchild) -> Child)?
 		    }
 		}
@@ -481,6 +495,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Grandchild {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            viewModel: String = "default",
@@ -491,6 +506,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		        }
 
 		        let viewModel: String
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((String) -> Grandchild)?
 		    }
 		}
@@ -530,7 +546,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: (() -> Child)? = nil
 		        ) {
@@ -542,9 +559,9 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		    static func mock(
 		        debug: Bool = false,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let child = (safeDIParameters.child ?? Child.init)()
+		        let child = (safeDIOverrides.child ?? Child.init)()
 		        return Root(child: child, debug: debug)
 		    }
 		}
@@ -583,7 +600,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -594,11 +612,11 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let __safeDI_childBuilder__safeDIBuilder = safeDIParameters.childBuilder.safeDIBuilder ?? Child.init(name:flag:)
+		        let __safeDI_childBuilder__safeDIBuilder = safeDIOverrides.childBuilder.safeDIBuilder ?? Child.init(name:flag:)
 		        @Sendable func __safeDI_childBuilder(name: String) -> Child {
-		            __safeDI_childBuilder__safeDIBuilder(name, safeDIParameters.childBuilder.flag)
+		            __safeDI_childBuilder__safeDIBuilder(name, safeDIOverrides.childBuilder.flag)
 		        }
 		        let childBuilder = SendableInstantiator<Child> {
 		            __safeDI_childBuilder(name: $0)
@@ -650,7 +668,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
 		            childB: ChildB.SafeDIMockConfiguration = .init()
@@ -664,14 +683,14 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childA() -> ChildA {
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.init(flagA:))(safeDIParameters.childA.flagA)
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.init(flagA:))(safeDIOverrides.childA.flagA)
 		        }
 		        let childA: ChildA = __safeDI_childA()
 		        func __safeDI_childB() -> ChildB {
-		            return (safeDIParameters.childB.safeDIBuilder ?? ChildB.init(flagB:))(safeDIParameters.childB.flagB)
+		            return (safeDIOverrides.childB.safeDIBuilder ?? ChildB.init(flagB:))(safeDIOverrides.childB.flagB)
 		        }
 		        let childB: ChildB = __safeDI_childB()
 		        return Root(childA: childA, childB: childB)
@@ -713,7 +732,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -724,10 +744,10 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(viewModel:))(safeDIParameters.child.viewModel)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(viewModel:))(safeDIOverrides.child.viewModel)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -753,6 +773,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            viewModel: String? = nil,
@@ -763,6 +784,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		        }
 
 		        let viewModel: String?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((String?) -> Child)?
 		    }
 		}
@@ -813,7 +835,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
 		            childB: ChildB.SafeDIMockConfiguration = .init()
@@ -827,14 +850,14 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childA() -> ChildA {
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.init(flag:))(safeDIParameters.childA.flag)
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.init(flag:))(safeDIOverrides.childA.flag)
 		        }
 		        let childA: ChildA = __safeDI_childA()
 		        func __safeDI_childB() -> ChildB {
-		            return (safeDIParameters.childB.safeDIBuilder ?? ChildB.init(flag:))(safeDIParameters.childB.flag)
+		            return (safeDIOverrides.childB.safeDIBuilder ?? ChildB.init(flag:))(safeDIOverrides.childB.flag)
 		        }
 		        let childB: ChildB = __safeDI_childB()
 		        return Root(childA: childA, childB: childB)
@@ -882,7 +905,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -893,10 +917,10 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childBuilder(name: String) -> Child {
-		            (safeDIParameters.childBuilder.safeDIBuilder ?? Child.init(name:flag:))(name, safeDIParameters.childBuilder.flag)
+		            (safeDIOverrides.childBuilder.safeDIBuilder ?? Child.init(name:flag:))(name, safeDIOverrides.childBuilder.flag)
 		        }
 		        let childBuilder = ErasedInstantiator<String, Child> {
 		            __safeDI_childBuilder(name: $0)
@@ -944,7 +968,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -955,11 +980,11 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let __safeDI_childBuilder__safeDIBuilder = safeDIParameters.childBuilder.safeDIBuilder ?? Child.init(name:flag:)
+		        let __safeDI_childBuilder__safeDIBuilder = safeDIOverrides.childBuilder.safeDIBuilder ?? Child.init(name:flag:)
 		        @Sendable func __safeDI_childBuilder(name: String) -> Child {
-		            __safeDI_childBuilder__safeDIBuilder(name, safeDIParameters.childBuilder.flag)
+		            __safeDI_childBuilder__safeDIBuilder(name, safeDIOverrides.childBuilder.flag)
 		        }
 		        let childBuilder = SendableErasedInstantiator<String, Child> {
 		            __safeDI_childBuilder(name: $0)
@@ -1002,7 +1027,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -1013,10 +1039,10 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(values:))(safeDIParameters.child.values)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(values:))(safeDIOverrides.child.values)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -1066,7 +1092,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -1078,10 +1105,10 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		    static func mock(
 		        clientId: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
 		        func __safeDI_child() -> Child {
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(clientId:))(safeDIParameters.child.clientId)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(clientId:))(safeDIOverrides.child.clientId)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Parent(clientId: clientId, child: child)
@@ -1144,7 +1171,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
 		            childB: ChildB.SafeDIMockConfiguration = .init()
@@ -1158,14 +1186,14 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childA() -> ChildA {
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.init(viewModel:))(safeDIParameters.childA.viewModel)
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.init(viewModel:))(safeDIOverrides.childA.viewModel)
 		        }
 		        let childA: ChildA = __safeDI_childA()
 		        func __safeDI_childB() -> ChildB {
-		            return (safeDIParameters.childB.safeDIBuilder ?? ChildB.init(viewModel:))(safeDIParameters.childB.viewModel)
+		            return (safeDIOverrides.childB.safeDIBuilder ?? ChildB.init(viewModel:))(safeDIOverrides.childB.viewModel)
 		        }
 		        let childB: ChildB = __safeDI_childB()
 		        return Root(childA: childA, childB: childB)
@@ -1217,7 +1245,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -1228,14 +1257,14 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
 		            func __safeDI_grandchild() -> Grandchild {
-		                return (safeDIParameters.child.grandchild.safeDIBuilder ?? Grandchild.init(viewModel:))(safeDIParameters.child.grandchild.viewModel)
+		                return (safeDIOverrides.child.grandchild.safeDIBuilder ?? Grandchild.init(viewModel:))(safeDIOverrides.child.grandchild.viewModel)
 		            }
 		            let grandchild: Grandchild = __safeDI_grandchild()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(grandchild:config:))(grandchild, safeDIParameters.child.config)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(grandchild:config:))(grandchild, safeDIOverrides.child.config)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -1290,7 +1319,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -1301,16 +1331,16 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
 		            func __safeDI_grandchildBuilder(name: String) -> Grandchild {
-		                (safeDIParameters.child.grandchildBuilder.safeDIBuilder ?? Grandchild.init(name:viewModel:))(name, safeDIParameters.child.grandchildBuilder.viewModel)
+		                (safeDIOverrides.child.grandchildBuilder.safeDIBuilder ?? Grandchild.init(name:viewModel:))(name, safeDIOverrides.child.grandchildBuilder.viewModel)
 		            }
 		            let grandchildBuilder = Instantiator<Grandchild> {
 		                __safeDI_grandchildBuilder(name: $0)
 		            }
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(grandchildBuilder:))(grandchildBuilder)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(grandchildBuilder:))(grandchildBuilder)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -1353,7 +1383,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -1364,10 +1395,10 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(onDismiss:))(safeDIParameters.child.onDismiss)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(onDismiss:))(safeDIOverrides.child.onDismiss)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -1424,6 +1455,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            onCancel: @escaping @MainActor (String) -> Void = { _ in },
@@ -1437,6 +1469,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		        let onCancel: @MainActor (String) -> Void
 		        let onSubmit: @MainActor (String) throws -> Void
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((@escaping @MainActor (String) -> Void, @escaping @MainActor (String) throws -> Void) -> Child)?
 		    }
 		}
@@ -1475,7 +1508,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -1486,10 +1520,10 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(onComplete:))(safeDIParameters.child.onComplete)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(onComplete:))(safeDIOverrides.child.onComplete)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -1547,7 +1581,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		)
 
 		// ChildA receives `service` (onlyIfAvailable). ChildB has `service` as a
-		// default-valued param. The root-level binding for `service` from SafeDIParameters
+		// default-valued param. The root-level binding for `service` from SafeDIOverrides
 		// must exist so ChildA's construction can reference the resolved value.
 		#expect(output.mockFiles["Root+SafeDIMock.swift"] == """
 		// This file was generated by the SafeDIGenerateDependencyTree build tool plugin.
@@ -1556,7 +1590,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ((Service?) -> ChildA)? = nil,
 		            childB: ChildB.SafeDIMockConfiguration = .init(),
@@ -1573,12 +1608,12 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service: Service? = safeDIParameters.service
-		        let childA = (safeDIParameters.childA ?? ChildA.init(service:))(service)
+		        let service: Service? = safeDIOverrides.service
+		        let childA = (safeDIOverrides.childA ?? ChildA.init(service:))(service)
 		        func __safeDI_childB() -> ChildB {
-		            return (safeDIParameters.childB.safeDIBuilder ?? ChildB.init(service:))(safeDIParameters.childB.service)
+		            return (safeDIOverrides.childB.safeDIBuilder ?? ChildB.init(service:))(safeDIOverrides.childB.service)
 		        }
 		        let childB: ChildB = __safeDI_childB()
 		        return Root(childA: childA, childB: childB)
@@ -1627,7 +1662,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -1639,10 +1675,10 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		    static func mock(
 		        name: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(name:))(safeDIParameters.child.name)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(name:))(safeDIOverrides.child.name)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(name: name, child: child)
@@ -1685,7 +1721,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -1696,10 +1733,10 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(isLoggingEnabled:))(safeDIParameters.child.isLoggingEnabled)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(isLoggingEnabled:))(safeDIOverrides.child.isLoggingEnabled)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -1724,6 +1761,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            isLoggingEnabled: Bool = false,
@@ -1734,6 +1772,7 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		        }
 
 		        let isLoggingEnabled: Bool
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((Bool) -> Child)?
 		    }
 		}
@@ -1774,7 +1813,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: ((Bool) -> Child)? = nil
 		        ) {
@@ -1785,9 +1825,9 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let child = (safeDIParameters.child ?? Child.init(_:))(isLoggingEnabled)
+		        let child = (safeDIOverrides.child ?? Child.init(_:))(isLoggingEnabled)
 		        return Root(child: child)
 		    }
 		}
@@ -1839,7 +1879,8 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: ((Bool) -> Child)? = nil
 		        ) {
@@ -1850,9 +1891,9 @@ struct SafeDIToolMockGenerationDefaultValueTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let child = (safeDIParameters.child ?? Child.init(_:))(_)
+		        let child = (safeDIOverrides.child ?? Child.init(_:))(_)
 		        return Root(child: child)
 		    }
 		}

--- a/Tests/SafeDIToolTests/SafeDIToolMockGenerationDisambiguationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockGenerationDisambiguationTests.swift
@@ -92,7 +92,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension ChildA {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childB: (() -> Other)? = nil
 		        ) {
@@ -103,10 +104,10 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> ChildA {
 		        func __safeDI_childB() -> Other {
-		            (safeDIParameters.childB ?? Other.init)()
+		            (safeDIOverrides.childB ?? Other.init)()
 		        }
 		        let childB = Instantiator<Other>(__safeDI_childB)
 		        return ChildA(childB: childB)
@@ -116,6 +117,7 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension ChildA {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            childB: (() -> Other)? = nil,
@@ -126,6 +128,7 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		        }
 
 		        let childB: (() -> Other)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((Instantiator<Other>) -> ChildA)?
 		    }
 		}
@@ -167,7 +170,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
 		            childB: (() -> ChildB)? = nil
@@ -181,17 +185,17 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childA() -> ChildA {
 		            func __safeDI_childB() -> Other {
-		                (safeDIParameters.childA.childB ?? Other.init)()
+		                (safeDIOverrides.childA.childB ?? Other.init)()
 		            }
 		            let childB = Instantiator<Other>(__safeDI_childB)
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.init(childB:))(childB)
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.init(childB:))(childB)
 		        }
 		        let childA: ChildA = __safeDI_childA()
-		        let childB = (safeDIParameters.childB ?? ChildB.init)()
+		        let childB = (safeDIOverrides.childB ?? ChildB.init)()
 		        return Root(childA: childA, childB: childB)
 		    }
 		}
@@ -261,7 +265,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
 		            childB: ChildB.SafeDIMockConfiguration = .init()
@@ -275,16 +280,16 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childA() -> ChildA {
-		            let service = (safeDIParameters.childA.service ?? ServiceA.init)()
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.init(service:))(service)
+		            let service = (safeDIOverrides.childA.service ?? ServiceA.init)()
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.init(service:))(service)
 		        }
 		        let childA: ChildA = __safeDI_childA()
 		        func __safeDI_childB() -> ChildB {
-		            let service = (safeDIParameters.childB.service ?? ServiceB.init)()
-		            return (safeDIParameters.childB.safeDIBuilder ?? ChildB.init(service:))(service)
+		            let service = (safeDIOverrides.childB.service ?? ServiceB.init)()
+		            return (safeDIOverrides.childB.safeDIBuilder ?? ChildB.init(service:))(service)
 		        }
 		        let childB: ChildB = __safeDI_childB()
 		        return Root(childA: childA, childB: childB)
@@ -301,7 +306,7 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 	mutating func mock_disambiguationUsesSimplifiedSuffixWhenUnique() async throws {
 		// Two children have `service` with different types. One is optional.
 		// The required ExternalService stays as a disambiguated flat param.
-		// The onlyIfAvailable LocalService? moves into SafeDIParameters.
+		// The onlyIfAvailable LocalService? moves into SafeDIOverrides.
 		let output = try await executeSafeDIToolTest(
 			swiftFileContent: [
 				"""
@@ -347,7 +352,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ((ExternalService) -> ChildA)? = nil,
 		            childB: ((LocalService?) -> ChildB)? = nil,
@@ -365,11 +371,11 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		    static func mock(
 		        service_ExternalService: ExternalService,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service: LocalService? = safeDIParameters.service
-		        let childA = (safeDIParameters.childA ?? ChildA.init(service:))(service)
-		        let childB = (safeDIParameters.childB ?? ChildB.init(service:))(service)
+		        let service: LocalService? = safeDIOverrides.service
+		        let childA = (safeDIOverrides.childA ?? ChildA.init(service:))(service)
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(service:))(service)
 		        return Root(childA: childA, childB: childB)
 		    }
 		}
@@ -382,7 +388,7 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 	mutating func mock_disambiguationFallsBackToFullSuffixWhenSimplifiedCollides() async throws {
 		// Two children have `service` — one is `Service` (non-optional, @Instantiated in ChildA),
 		// one is `Service?` (optional, onlyIfAvailable in ChildB).
-		// The onlyIfAvailable version moves into SafeDIParameters.
+		// The onlyIfAvailable version moves into SafeDIOverrides.
 		// No flat param disambiguation needed since there's no flat `service` param.
 		let output = try await executeSafeDIToolTest(
 			swiftFileContent: [
@@ -429,7 +435,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
 		            childB: ((Service?) -> ChildB)? = nil,
@@ -446,15 +453,15 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service: Service? = safeDIParameters.service
+		        let service: Service? = safeDIOverrides.service
 		        func __safeDI_childA() -> ChildA {
-		            let service = (safeDIParameters.childA.service ?? Service.init)()
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.init(service:))(service)
+		            let service = (safeDIOverrides.childA.service ?? Service.init)()
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.init(service:))(service)
 		        }
 		        let childA: ChildA = __safeDI_childA()
-		        let childB = (safeDIParameters.childB ?? ChildB.init(service:))(service)
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(service:))(service)
 		        return Root(childA: childA, childB: childB)
 		    }
 		}
@@ -522,7 +529,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childABuilder: ((String, PresenterA) -> ChildA)? = nil,
 		            childB: ((PresenterB) -> ChildB)? = nil
@@ -538,15 +546,15 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    static func mock(
 		        presenter_PresenterA: PresenterA,
 		        presenter_PresenterB: PresenterB,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childABuilder(name: String) -> ChildA {
-		            (safeDIParameters.childABuilder ?? ChildA.init(name:presenter:))(name, presenter)
+		            (safeDIOverrides.childABuilder ?? ChildA.init(name:presenter:))(name, presenter)
 		        }
 		        let childABuilder = Instantiator<ChildA> {
 		            __safeDI_childABuilder(name: $0)
 		        }
-		        let childB = (safeDIParameters.childB ?? ChildB.init(presenter:))(presenter)
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(presenter:))(presenter)
 		        return Root(childABuilder: childABuilder, childB: childB)
 		    }
 		}
@@ -607,7 +615,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            parent: Parent.SafeDIMockConfiguration = .init(),
 		            childBuilder: ((String) -> ChildA)? = nil
@@ -621,20 +630,20 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_parent() -> Parent {
 		            func __safeDI_childBuilder(name: String) -> ChildB {
-		                (safeDIParameters.parent.childBuilder ?? ChildB.init(name:))(name)
+		                (safeDIOverrides.parent.childBuilder ?? ChildB.init(name:))(name)
 		            }
 		            let childBuilder = Instantiator<ChildB> {
 		                __safeDI_childBuilder(name: $0)
 		            }
-		            return (safeDIParameters.parent.safeDIBuilder ?? Parent.init(childBuilder:))(childBuilder)
+		            return (safeDIOverrides.parent.safeDIBuilder ?? Parent.init(childBuilder:))(childBuilder)
 		        }
 		        let parent: Parent = __safeDI_parent()
 		        func __safeDI_childBuilder(name: String) -> ChildA {
-		            (safeDIParameters.childBuilder ?? ChildA.init(name:))(name)
+		            (safeDIOverrides.childBuilder ?? ChildA.init(name:))(name)
 		        }
 		        let childBuilder = Instantiator<ChildA> {
 		            __safeDI_childBuilder(name: $0)
@@ -711,7 +720,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder_ChildA: ((String) -> ChildA)? = nil,
 		            childC: ((Instantiator<ChildA>) -> ChildC)? = nil,
@@ -731,22 +741,22 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childBuilder(name: String) -> ChildA {
-		            (safeDIParameters.childBuilder_ChildA ?? ChildA.init(name:))(name)
+		            (safeDIOverrides.childBuilder_ChildA ?? ChildA.init(name:))(name)
 		        }
 		        let childBuilder = Instantiator<ChildA> {
 		            __safeDI_childBuilder(name: $0)
 		        }
-		        let childC = (safeDIParameters.childC ?? ChildC.init(childBuilder:))(childBuilder)
+		        let childC = (safeDIOverrides.childC ?? ChildC.init(childBuilder:))(childBuilder)
 		        func __safeDI_childBuilder(name: String) -> ChildB {
-		            (safeDIParameters.childBuilder_ChildB ?? ChildB.init(name:))(name)
+		            (safeDIOverrides.childBuilder_ChildB ?? ChildB.init(name:))(name)
 		        }
 		        let childBuilder = Instantiator<ChildB> {
 		            __safeDI_childBuilder(name: $0)
 		        }
-		        let childD = (safeDIParameters.childD ?? ChildD.init(childBuilder:))(childBuilder)
+		        let childD = (safeDIOverrides.childD ?? ChildD.init(childBuilder:))(childBuilder)
 		        return Root(childC: childC, childD: childD)
 		    }
 		}
@@ -812,7 +822,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: ((String) -> ChildA)? = nil,
 		            parentBuilder: Parent.SafeDIMockConfiguration = .init()
@@ -826,22 +837,22 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childBuilder(name: String) -> ChildA {
-		            (safeDIParameters.childBuilder ?? ChildA.init(name:))(name)
+		            (safeDIOverrides.childBuilder ?? ChildA.init(name:))(name)
 		        }
 		        let childBuilder = Instantiator<ChildA> {
 		            __safeDI_childBuilder(name: $0)
 		        }
 		        func __safeDI_parentBuilder() -> Parent {
 		            func __safeDI_otherBuilder(name: String) -> ChildB {
-		                (safeDIParameters.parentBuilder.otherBuilder ?? ChildB.init(name:))(name)
+		                (safeDIOverrides.parentBuilder.otherBuilder ?? ChildB.init(name:))(name)
 		            }
 		            let otherBuilder = Instantiator<ChildB> {
 		                __safeDI_otherBuilder(name: $0)
 		            }
-		            return (safeDIParameters.parentBuilder.safeDIBuilder ?? Parent.init(childBuilder:otherBuilder:))(childBuilder, otherBuilder)
+		            return (safeDIOverrides.parentBuilder.safeDIBuilder ?? Parent.init(childBuilder:otherBuilder:))(childBuilder, otherBuilder)
 		        }
 		        let parentBuilder = Instantiator<Parent>(__safeDI_parentBuilder)
 		        return Root(parentBuilder: parentBuilder, childBuilder: childBuilder)
@@ -928,7 +939,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            builder_TypeA: ((String) -> TypeA)? = nil,
 		            childA: ((Instantiator<TypeA>) -> ChildA)? = nil,
@@ -948,24 +960,24 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_builder(name: String) -> TypeA {
-		            (safeDIParameters.builder_TypeA ?? TypeA.init(name:))(name)
+		            (safeDIOverrides.builder_TypeA ?? TypeA.init(name:))(name)
 		        }
 		        let builder = Instantiator<TypeA> {
 		            __safeDI_builder(name: $0)
 		        }
-		        let childA = (safeDIParameters.childA ?? ChildA.init(builder:))(builder)
+		        let childA = (safeDIOverrides.childA ?? ChildA.init(builder:))(builder)
 		        func __safeDI_builder(name: String) -> TypeB {
-		            (safeDIParameters.builder_TypeB ?? TypeB.init(name:))(name)
+		            (safeDIOverrides.builder_TypeB ?? TypeB.init(name:))(name)
 		        }
 		        let builder = Instantiator<TypeB> {
 		            __safeDI_builder(name: $0)
 		        }
 		        func __safeDI_childBBuilder() -> ChildB {
-		            let subChild = (safeDIParameters.childBBuilder.subChild ?? SubChild.init(builder:))(builder)
-		            return (safeDIParameters.childBBuilder.safeDIBuilder ?? ChildB.init(subChild:))(subChild)
+		            let subChild = (safeDIOverrides.childBBuilder.subChild ?? SubChild.init(builder:))(builder)
+		            return (safeDIOverrides.childBBuilder.safeDIBuilder ?? ChildB.init(subChild:))(subChild)
 		        }
 		        let childBBuilder = Instantiator<ChildB>(__safeDI_childBBuilder)
 		        return Root(childA: childA, childBBuilder: childBBuilder)
@@ -1033,7 +1045,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            parentBuilder: ((String, ConfigA) -> Parent)? = nil,
 		            childB: ((ConfigB) -> ChildB)? = nil
@@ -1049,15 +1062,15 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    static func mock(
 		        config_ConfigA: ConfigA,
 		        config_ConfigB: ConfigB,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_parentBuilder(name: String) -> Parent {
-		            (safeDIParameters.parentBuilder ?? Parent.init(name:config:))(name, config)
+		            (safeDIOverrides.parentBuilder ?? Parent.init(name:config:))(name, config)
 		        }
 		        let parentBuilder = Instantiator<Parent> {
 		            __safeDI_parentBuilder(name: $0)
 		        }
-		        let childB = (safeDIParameters.childB ?? ChildB.init(config:))(config)
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(config:))(config)
 		        return Root(parentBuilder: parentBuilder, childB: childB)
 		    }
 		}
@@ -1117,7 +1130,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            parent: ((EngineA) -> Parent)? = nil,
 		            child: ((EngineB) -> Child)? = nil
@@ -1133,10 +1147,10 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    static func mock(
 		        engine_EngineA: EngineA,
 		        engine_EngineB: EngineB,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let parent = (safeDIParameters.parent ?? Parent.init(engine:))(engine)
-		        let child = (safeDIParameters.child ?? Child.init(engine:))(engine)
+		        let parent = (safeDIOverrides.parent ?? Parent.init(engine:))(engine)
+		        let child = (safeDIOverrides.child ?? Child.init(engine:))(engine)
 		        return Root(parent: parent, child: child)
 		    }
 		}
@@ -1149,7 +1163,7 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 	mutating func mock_onlyIfAvailableDisambiguatedSimplifiedUnique() async throws {
 		// ChildA @Receives service: ExternalService. ChildB @Receives(onlyIfAvailable: true) service: LocalService?.
 		// The required ExternalService stays as a disambiguated flat param.
-		// The onlyIfAvailable LocalService? moves into SafeDIParameters.
+		// The onlyIfAvailable LocalService? moves into SafeDIOverrides.
 		let output = try await executeSafeDIToolTest(
 			swiftFileContent: [
 				"""
@@ -1195,7 +1209,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ((ExternalService) -> ChildA)? = nil,
 		            childB: ((LocalService?) -> ChildB)? = nil,
@@ -1213,11 +1228,11 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		    static func mock(
 		        service_ExternalService: ExternalService,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service: LocalService? = safeDIParameters.service
-		        let childA = (safeDIParameters.childA ?? ChildA.init(service:))(service)
-		        let childB = (safeDIParameters.childB ?? ChildB.init(service:))(service)
+		        let service: LocalService? = safeDIOverrides.service
+		        let childA = (safeDIOverrides.childA ?? ChildA.init(service:))(service)
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(service:))(service)
 		        return Root(childA: childA, childB: childB)
 		    }
 		}
@@ -1269,7 +1284,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
 		            childB: ChildB.SafeDIMockConfiguration = .init()
@@ -1283,14 +1299,14 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childA() -> ChildA {
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.init(onAction:))(safeDIParameters.childA.onAction)
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.init(onAction:))(safeDIOverrides.childA.onAction)
 		        }
 		        let childA: ChildA = __safeDI_childA()
 		        func __safeDI_childB() -> ChildB {
-		            return (safeDIParameters.childB.safeDIBuilder ?? ChildB.init(onAction:))(safeDIParameters.childB.onAction)
+		            return (safeDIOverrides.childB.safeDIBuilder ?? ChildB.init(onAction:))(safeDIOverrides.childB.onAction)
 		        }
 		        let childB: ChildB = __safeDI_childB()
 		        return Root(childA: childA, childB: childB)
@@ -1364,7 +1380,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ((ServiceA) -> ChildA)? = nil,
 		            childB: ((ServiceB) -> ChildB)? = nil,
@@ -1384,11 +1401,11 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		        service_ServiceA: ServiceA,
 		        service_ServiceB: ServiceB,
 		        service_ServiceC: ServiceC,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let childA = (safeDIParameters.childA ?? ChildA.init(service:))(service)
-		        let childB = (safeDIParameters.childB ?? ChildB.init(service:))(service)
-		        let childC = (safeDIParameters.childC ?? ChildC.init(service:))(service)
+		        let childA = (safeDIOverrides.childA ?? ChildA.init(service:))(service)
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(service:))(service)
+		        let childC = (safeDIOverrides.childC ?? ChildC.init(service:))(service)
 		        return Root(childA: childA, childB: childB, childC: childC)
 		    }
 		}
@@ -1469,7 +1486,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: ((String) -> ChildA)? = nil,
 		            parentBuilder: Parent.SafeDIMockConfiguration = .init(),
@@ -1486,32 +1504,32 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childBuilder(name: String) -> ChildA {
-		            (safeDIParameters.childBuilder ?? ChildA.init(name:))(name)
+		            (safeDIOverrides.childBuilder ?? ChildA.init(name:))(name)
 		        }
 		        let childBuilder = Instantiator<ChildA> {
 		            __safeDI_childBuilder(name: $0)
 		        }
 		        func __safeDI_parentBuilder() -> Parent {
 		            func __safeDI_childBuilder(name: String) -> ChildA {
-		                (safeDIParameters.parentBuilder.childBuilder ?? ChildA.init(name:))(name)
+		                (safeDIOverrides.parentBuilder.childBuilder ?? ChildA.init(name:))(name)
 		            }
 		            let childBuilder = Instantiator<ChildA> {
 		                __safeDI_childBuilder(name: $0)
 		            }
-		            return (safeDIParameters.parentBuilder.safeDIBuilder ?? Parent.init(childBuilder:))(childBuilder)
+		            return (safeDIOverrides.parentBuilder.safeDIBuilder ?? Parent.init(childBuilder:))(childBuilder)
 		        }
 		        let parentBuilder = Instantiator<Parent>(__safeDI_parentBuilder)
 		        func __safeDI_other() -> Other {
 		            func __safeDI_childBuilder(name: String) -> ChildB {
-		                (safeDIParameters.other.childBuilder ?? ChildB.init(name:))(name)
+		                (safeDIOverrides.other.childBuilder ?? ChildB.init(name:))(name)
 		            }
 		            let childBuilder = Instantiator<ChildB> {
 		                __safeDI_childBuilder(name: $0)
 		            }
-		            return (safeDIParameters.other.safeDIBuilder ?? Other.init(childBuilder:))(childBuilder)
+		            return (safeDIOverrides.other.safeDIBuilder ?? Other.init(childBuilder:))(childBuilder)
 		        }
 		        let other: Other = __safeDI_other()
 		        return Root(childBuilder: childBuilder, parentBuilder: parentBuilder, other: other)
@@ -1601,7 +1619,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service_UserService_: (() -> UserService)? = nil,
 		            childA: ((UserService) -> ChildA)? = nil,
@@ -1627,14 +1646,14 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service = (safeDIParameters.service_UserService_ ?? UserService.init)()
-		        let childA = (safeDIParameters.childA ?? ChildA.init(service:))(service)
-		        let service = (safeDIParameters.service_AdminService ?? AdminService.init)()
-		        let childB = (safeDIParameters.childB ?? ChildB.init(service:))(service)
-		        let service_UserService = (safeDIParameters.service_UserService ?? OtherType.init)()
-		        let childC = (safeDIParameters.childC ?? ChildC.init(service_UserService:))(service_UserService)
+		        let service = (safeDIOverrides.service_UserService_ ?? UserService.init)()
+		        let childA = (safeDIOverrides.childA ?? ChildA.init(service:))(service)
+		        let service = (safeDIOverrides.service_AdminService ?? AdminService.init)()
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(service:))(service)
+		        let service_UserService = (safeDIOverrides.service_UserService ?? OtherType.init)()
+		        let childC = (safeDIOverrides.childC ?? ChildC.init(service_UserService:))(service_UserService)
 		        return Root(childA: childA, childB: childB, childC: childC)
 		    }
 		}
@@ -1697,7 +1716,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service_TypeB: (() -> TypeB)? = nil,
 		            child: Child.SafeDIMockConfiguration = .init(),
@@ -1714,15 +1734,15 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service = (safeDIParameters.service_TypeB ?? TypeB.init)()
+		        let service = (safeDIOverrides.service_TypeB ?? TypeB.init)()
 		        func __safeDI_child() -> Child {
-		            let service = (safeDIParameters.child.service ?? TypeB.init)()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(service:serviceAlias:))(service, serviceAlias)
+		            let service = (safeDIOverrides.child.service ?? TypeB.init)()
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(service:serviceAlias:))(service, serviceAlias)
 		        }
 		        let child: Child = __safeDI_child()
-		        let service = (safeDIParameters.service_TypeA ?? TypeA.init)()
+		        let service = (safeDIOverrides.service_TypeA ?? TypeA.init)()
 		        return Root(child: child, service: service)
 		    }
 		}
@@ -1800,7 +1820,8 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
 		            childB: ChildB.SafeDIMockConfiguration = .init(),
@@ -1817,18 +1838,18 @@ struct SafeDIToolMockGenerationDisambiguationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childA() -> ChildA {
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.init(value:))(safeDIParameters.childA.value)
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.init(value:))(safeDIOverrides.childA.value)
 		        }
 		        let childA: ChildA = __safeDI_childA()
 		        func __safeDI_childB() -> ChildB {
-		            return (safeDIParameters.childB.safeDIBuilder ?? ChildB.init(value:))(safeDIParameters.childB.value)
+		            return (safeDIOverrides.childB.safeDIBuilder ?? ChildB.init(value:))(safeDIOverrides.childB.value)
 		        }
 		        let childB: ChildB = __safeDI_childB()
 		        func __safeDI_childC() -> ChildC {
-		            return (safeDIParameters.childC.safeDIBuilder ?? ChildC.init(value:))(safeDIParameters.childC.value)
+		            return (safeDIOverrides.childC.safeDIBuilder ?? ChildC.init(value:))(safeDIOverrides.childC.value)
 		        }
 		        let childC: ChildC = __safeDI_childC()
 		        return Root(childA: childA, childB: childB, childC: childC)

--- a/Tests/SafeDIToolTests/SafeDIToolMockGenerationErrorTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockGenerationErrorTests.swift
@@ -389,7 +389,8 @@ struct SafeDIToolMockGenerationErrorTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: ((Unrelated?, Shared?) -> Child)? = nil,
 		            shared: Shared? = nil,
@@ -406,11 +407,11 @@ struct SafeDIToolMockGenerationErrorTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let shared: Shared? = safeDIParameters.shared
-		        let unrelated: Unrelated? = safeDIParameters.unrelated
-		        let child = (safeDIParameters.child ?? Child.mock(unrelated:shared:))(unrelated, shared)
+		        let shared: Shared? = safeDIOverrides.shared
+		        let unrelated: Unrelated? = safeDIOverrides.unrelated
+		        let child = (safeDIOverrides.child ?? Child.mock(unrelated:shared:))(unrelated, shared)
 		        return Parent(child: child, shared: shared)
 		    }
 		}

--- a/Tests/SafeDIToolTests/SafeDIToolMockGenerationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockGenerationTests.swift
@@ -141,7 +141,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            dependency: (() -> Dependency)? = nil
 		        ) {
@@ -152,9 +153,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let dependency = (safeDIParameters.dependency ?? Dependency.init)()
+		        let dependency = (safeDIOverrides.dependency ?? Dependency.init)()
 		        return Root(dependency: dependency)
 		    }
 		}
@@ -220,7 +221,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> SharedThing)? = nil
 		        ) {
@@ -231,9 +233,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
-		        let shared = (safeDIParameters.shared ?? SharedThing.init)()
+		        let shared = (safeDIOverrides.shared ?? SharedThing.init)()
 		        return Child(shared: shared)
 		    }
 		}
@@ -247,7 +249,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> SharedThing)? = nil,
 		            child: ((SharedThing) -> Child)? = nil
@@ -261,10 +264,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let shared = (safeDIParameters.shared ?? SharedThing.init)()
-		        let child = (safeDIParameters.child ?? Child.init(shared:))(shared)
+		        let shared = (safeDIOverrides.shared ?? SharedThing.init)()
+		        let child = (safeDIOverrides.child ?? Child.init(shared:))(shared)
 		        return Root(child: child, shared: shared)
 		    }
 		}
@@ -341,7 +344,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension ChildA {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> SharedThing)? = nil,
 		            grandchild: ((SharedThing) -> Grandchild)? = nil
@@ -355,10 +359,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> ChildA {
-		        let shared = (safeDIParameters.shared ?? SharedThing.init)()
-		        let grandchild = (safeDIParameters.grandchild ?? Grandchild.init(shared:))(shared)
+		        let shared = (safeDIOverrides.shared ?? SharedThing.init)()
+		        let grandchild = (safeDIOverrides.grandchild ?? Grandchild.init(shared:))(shared)
 		        return ChildA(shared: shared, grandchild: grandchild)
 		    }
 		}
@@ -366,6 +370,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension ChildA {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            grandchild: ((SharedThing) -> Grandchild)? = nil,
@@ -376,6 +381,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let grandchild: ((SharedThing) -> Grandchild)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((SharedThing, Grandchild) -> ChildA)?
 		    }
 		}
@@ -389,7 +395,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Grandchild {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> SharedThing)? = nil
 		        ) {
@@ -400,9 +407,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Grandchild {
-		        let shared = (safeDIParameters.shared ?? SharedThing.init)()
+		        let shared = (safeDIOverrides.shared ?? SharedThing.init)()
 		        return Grandchild(shared: shared)
 		    }
 		}
@@ -416,7 +423,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> SharedThing)? = nil,
 		            childA: ChildA.SafeDIMockConfiguration = .init()
@@ -430,12 +438,12 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let shared = (safeDIParameters.shared ?? SharedThing.init)()
+		        let shared = (safeDIOverrides.shared ?? SharedThing.init)()
 		        func __safeDI_childA() -> ChildA {
-		            let grandchild = (safeDIParameters.childA.grandchild ?? Grandchild.init(shared:))(shared)
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.init(shared:grandchild:))(shared, grandchild)
+		            let grandchild = (safeDIOverrides.childA.grandchild ?? Grandchild.init(shared:))(shared)
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.init(shared:grandchild:))(shared, grandchild)
 		        }
 		        let childA: ChildA = __safeDI_childA()
 		        return Root(childA: childA, shared: shared)
@@ -551,7 +559,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            myService: (() -> ConcreteService)? = nil
 		        ) {
@@ -562,9 +571,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
-		        let myService = AnyService((safeDIParameters.myService ?? ConcreteService.init)())
+		        let myService = AnyService((safeDIOverrides.myService ?? ConcreteService.init)())
 		        return Child(myService: myService)
 		    }
 		}
@@ -592,7 +601,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            myService: (() -> ConcreteService)? = nil,
 		            child: ((AnyService) -> Child)? = nil
@@ -606,10 +616,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let myService = AnyService((safeDIParameters.myService ?? ConcreteService.init)())
-		        let child = (safeDIParameters.child ?? Child.init(myService:))(myService)
+		        let myService = AnyService((safeDIOverrides.myService ?? ConcreteService.init)())
+		        let child = (safeDIOverrides.child ?? Child.init(myService:))(myService)
 		        return Root(child: child, myService: myService)
 		    }
 		}
@@ -670,7 +680,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            myService: (() -> DefaultMyService)? = nil
 		        ) {
@@ -681,9 +692,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let myService = AnyMyService((safeDIParameters.myService ?? DefaultMyService.init)())
+		        let myService = AnyMyService((safeDIOverrides.myService ?? DefaultMyService.init)())
 		        return Root(myService: myService)
 		    }
 		}
@@ -768,7 +779,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension ChildA {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil,
 		            grandchildAA: ((Shared) -> GrandchildAA)? = nil,
@@ -785,11 +797,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> ChildA {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
-		        let grandchildAA = (safeDIParameters.grandchildAA ?? GrandchildAA.init(shared:))(shared)
-		        let grandchildAB = (safeDIParameters.grandchildAB ?? GrandchildAB.init(shared:))(shared)
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
+		        let grandchildAA = (safeDIOverrides.grandchildAA ?? GrandchildAA.init(shared:))(shared)
+		        let grandchildAB = (safeDIOverrides.grandchildAB ?? GrandchildAB.init(shared:))(shared)
 		        return ChildA(grandchildAA: grandchildAA, grandchildAB: grandchildAB)
 		    }
 		}
@@ -797,6 +809,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension ChildA {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            grandchildAA: ((Shared) -> GrandchildAA)? = nil,
@@ -810,6 +823,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		        let grandchildAA: ((Shared) -> GrandchildAA)?
 		        let grandchildAB: ((Shared) -> GrandchildAB)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((GrandchildAA, GrandchildAB) -> ChildA)?
 		    }
 		}
@@ -823,7 +837,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension ChildB {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil
 		        ) {
@@ -834,9 +849,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> ChildB {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        return ChildB(shared: shared)
 		    }
 		}
@@ -850,7 +865,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension GrandchildAA {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil
 		        ) {
@@ -861,9 +877,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> GrandchildAA {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        return GrandchildAA(shared: shared)
 		    }
 		}
@@ -877,7 +893,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension GrandchildAB {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil
 		        ) {
@@ -888,9 +905,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> GrandchildAB {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        return GrandchildAB(shared: shared)
 		    }
 		}
@@ -904,7 +921,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil,
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
@@ -921,16 +939,16 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        func __safeDI_childA() -> ChildA {
-		            let grandchildAA = (safeDIParameters.childA.grandchildAA ?? GrandchildAA.init(shared:))(shared)
-		            let grandchildAB = (safeDIParameters.childA.grandchildAB ?? GrandchildAB.init(shared:))(shared)
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.init(grandchildAA:grandchildAB:))(grandchildAA, grandchildAB)
+		            let grandchildAA = (safeDIOverrides.childA.grandchildAA ?? GrandchildAA.init(shared:))(shared)
+		            let grandchildAB = (safeDIOverrides.childA.grandchildAB ?? GrandchildAB.init(shared:))(shared)
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.init(grandchildAA:grandchildAB:))(grandchildAA, grandchildAB)
 		        }
 		        let childA: ChildA = __safeDI_childA()
-		        let childB = (safeDIParameters.childB ?? ChildB.init(shared:))(shared)
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(shared:))(shared)
 		        return Root(childA: childA, childB: childB, shared: shared)
 		    }
 		}
@@ -1003,7 +1021,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            networkService: (() -> DefaultNetworkService)? = nil
 		        ) {
@@ -1014,9 +1033,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let networkService = (safeDIParameters.networkService ?? DefaultNetworkService.init)()
+		        let networkService = (safeDIOverrides.networkService ?? DefaultNetworkService.init)()
 		        return Root(networkService: networkService)
 		    }
 		}
@@ -1067,7 +1086,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension RootA {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            dependency: (() -> Dependency)? = nil
 		        ) {
@@ -1078,9 +1098,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> RootA {
-		        let dependency = (safeDIParameters.dependency ?? Dependency.init)()
+		        let dependency = (safeDIOverrides.dependency ?? Dependency.init)()
 		        return RootA(dependency: dependency)
 		    }
 		}
@@ -1093,7 +1113,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension RootB {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            dependency: (() -> Dependency)? = nil
 		        ) {
@@ -1104,9 +1125,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> RootB {
-		        let dependency = (safeDIParameters.dependency ?? Dependency.init)()
+		        let dependency = (safeDIOverrides.dependency ?? Dependency.init)()
 		        return RootB(dependency: dependency)
 		    }
 		}
@@ -1180,7 +1201,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension ChildA {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil
 		        ) {
@@ -1191,9 +1213,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> ChildA {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        return ChildA(shared: shared)
 		    }
 		}
@@ -1221,7 +1243,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil,
 		            childA: ((Shared) -> ChildA)? = nil,
@@ -1238,11 +1261,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
-		        let childA = (safeDIParameters.childA ?? ChildA.init(shared:))(shared)
-		        let childB = (safeDIParameters.childB ?? ChildB.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
+		        let childA = (safeDIOverrides.childA ?? ChildA.init(shared:))(shared)
+		        let childB = (safeDIOverrides.childB ?? ChildB.init)()
 		        return Root(childA: childA, childB: childB, shared: shared)
 		    }
 		}
@@ -1330,7 +1353,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            leaf: (() -> Leaf)? = nil,
 		            grandchild: Grandchild.SafeDIMockConfiguration = .init()
@@ -1344,12 +1368,12 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
-		        let leaf = (safeDIParameters.leaf ?? Leaf.init)()
+		        let leaf = (safeDIOverrides.leaf ?? Leaf.init)()
 		        func __safeDI_grandchild() -> Grandchild {
-		            let greatGrandchild = (safeDIParameters.grandchild.greatGrandchild ?? GreatGrandchild.init(leaf:))(leaf)
-		            return (safeDIParameters.grandchild.safeDIBuilder ?? Grandchild.init(greatGrandchild:leaf:))(greatGrandchild, leaf)
+		            let greatGrandchild = (safeDIOverrides.grandchild.greatGrandchild ?? GreatGrandchild.init(leaf:))(leaf)
+		            return (safeDIOverrides.grandchild.safeDIBuilder ?? Grandchild.init(greatGrandchild:leaf:))(greatGrandchild, leaf)
 		        }
 		        let grandchild: Grandchild = __safeDI_grandchild()
 		        return Child(grandchild: grandchild, leaf: leaf)
@@ -1359,6 +1383,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            grandchild: Grandchild.SafeDIMockConfiguration = .init(),
@@ -1369,6 +1394,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let grandchild: Grandchild.SafeDIMockConfiguration
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((Grandchild, Leaf) -> Child)?
 		    }
 		}
@@ -1382,7 +1408,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Grandchild {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            leaf: (() -> Leaf)? = nil,
 		            greatGrandchild: ((Leaf) -> GreatGrandchild)? = nil
@@ -1396,10 +1423,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Grandchild {
-		        let leaf = (safeDIParameters.leaf ?? Leaf.init)()
-		        let greatGrandchild = (safeDIParameters.greatGrandchild ?? GreatGrandchild.init(leaf:))(leaf)
+		        let leaf = (safeDIOverrides.leaf ?? Leaf.init)()
+		        let greatGrandchild = (safeDIOverrides.greatGrandchild ?? GreatGrandchild.init(leaf:))(leaf)
 		        return Grandchild(greatGrandchild: greatGrandchild, leaf: leaf)
 		    }
 		}
@@ -1407,6 +1434,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Grandchild {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            greatGrandchild: ((Leaf) -> GreatGrandchild)? = nil,
@@ -1417,6 +1445,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let greatGrandchild: ((Leaf) -> GreatGrandchild)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((GreatGrandchild, Leaf) -> Grandchild)?
 		    }
 		}
@@ -1430,7 +1459,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension GreatGrandchild {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            leaf: (() -> Leaf)? = nil
 		        ) {
@@ -1441,9 +1471,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> GreatGrandchild {
-		        let leaf = (safeDIParameters.leaf ?? Leaf.init)()
+		        let leaf = (safeDIOverrides.leaf ?? Leaf.init)()
 		        return GreatGrandchild(leaf: leaf)
 		    }
 		}
@@ -1471,7 +1501,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            leaf: (() -> Leaf)? = nil,
 		            child: Child.SafeDIMockConfiguration = .init()
@@ -1485,16 +1516,16 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let leaf = (safeDIParameters.leaf ?? Leaf.init)()
+		        let leaf = (safeDIOverrides.leaf ?? Leaf.init)()
 		        func __safeDI_child() -> Child {
 		            func __safeDI_grandchild() -> Grandchild {
-		                let greatGrandchild = (safeDIParameters.child.grandchild.greatGrandchild ?? GreatGrandchild.init(leaf:))(leaf)
-		                return (safeDIParameters.child.grandchild.safeDIBuilder ?? Grandchild.init(greatGrandchild:leaf:))(greatGrandchild, leaf)
+		                let greatGrandchild = (safeDIOverrides.child.grandchild.greatGrandchild ?? GreatGrandchild.init(leaf:))(leaf)
+		                return (safeDIOverrides.child.grandchild.safeDIBuilder ?? Grandchild.init(greatGrandchild:leaf:))(greatGrandchild, leaf)
 		            }
 		            let grandchild: Grandchild = __safeDI_grandchild()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(grandchild:leaf:))(grandchild, leaf)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(grandchild:leaf:))(grandchild, leaf)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child, leaf: leaf)
@@ -1552,7 +1583,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil
 		        ) {
@@ -1564,9 +1596,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        name: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        return Child(name: name, shared: shared)
 		    }
 		}
@@ -1580,7 +1612,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil,
 		            childBuilder: ((String, Shared) -> Child)? = nil
@@ -1594,11 +1627,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        func __safeDI_childBuilder(name: String) -> Child {
-		            (safeDIParameters.childBuilder ?? Child.init(name:shared:))(name, shared)
+		            (safeDIOverrides.childBuilder ?? Child.init(name:shared:))(name, shared)
 		        }
 		        let childBuilder = Instantiator<Child> {
 		            __safeDI_childBuilder(name: $0)
@@ -1657,7 +1690,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            viewBuilder: (() -> SimpleView)? = nil
 		        ) {
@@ -1668,10 +1702,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_viewBuilder() -> SimpleView {
-		            (safeDIParameters.viewBuilder ?? SimpleView.init)()
+		            (safeDIOverrides.viewBuilder ?? SimpleView.init)()
 		        }
 		        let viewBuilder = Instantiator<SimpleView>(__safeDI_viewBuilder)
 		        return Root(viewBuilder: viewBuilder)
@@ -1750,7 +1784,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: ((String, Int) -> Child)? = nil
 		        ) {
@@ -1761,10 +1796,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childBuilder(age: Int, name: String) -> Child {
-		            (safeDIParameters.childBuilder ?? Child.init(name:age:))(name, age)
+		            (safeDIOverrides.childBuilder ?? Child.init(name:age:))(name, age)
 		        }
 		        let childBuilder = Instantiator<Child> {
 		            __safeDI_childBuilder(age: $0.age, name: $0.name)
@@ -1817,7 +1852,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension DefaultUserService {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            stringStorage: (() -> UserDefaults)? = nil
 		        ) {
@@ -1828,9 +1864,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> DefaultUserService {
-		        let stringStorage = (safeDIParameters.stringStorage ?? UserDefaults.instantiate)()
+		        let stringStorage = (safeDIOverrides.stringStorage ?? UserDefaults.instantiate)()
 		        return DefaultUserService(stringStorage: stringStorage)
 		    }
 		}
@@ -1918,7 +1954,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            helper: (() -> Helper)? = nil,
 		            thirdParty: ((Helper) -> ThirdParty)? = nil
@@ -1932,10 +1969,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let helper = (safeDIParameters.helper ?? Helper.init)()
-		        let thirdParty = (safeDIParameters.thirdParty ?? ThirdParty.instantiate(helper:))(helper)
+		        let helper = (safeDIOverrides.helper ?? Helper.init)()
+		        let thirdParty = (safeDIOverrides.thirdParty ?? ThirdParty.instantiate(helper:))(helper)
 		        return Root(thirdParty: thirdParty, helper: helper)
 		    }
 		}
@@ -1949,7 +1986,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension ThirdParty {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            helper: (() -> Helper)? = nil
 		        ) {
@@ -1960,9 +1998,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> ThirdParty {
-		        let helper = (safeDIParameters.helper ?? Helper.init)()
+		        let helper = (safeDIOverrides.helper ?? Helper.init)()
 		        return ThirdParty.instantiate(helper: helper)
 		    }
 		}
@@ -2018,7 +2056,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            dep: (() -> ThirdPartyDep)? = nil
 		        ) {
@@ -2029,9 +2068,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
-		        let dep = (safeDIParameters.dep ?? ThirdPartyDep.instantiate)()
+		        let dep = (safeDIOverrides.dep ?? ThirdPartyDep.instantiate)()
 		        return Child(dep: dep)
 		    }
 		}
@@ -2045,7 +2084,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            dep: (() -> ThirdPartyDep)? = nil,
 		            child: ((ThirdPartyDep) -> Child)? = nil
@@ -2059,10 +2099,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let dep = (safeDIParameters.dep ?? ThirdPartyDep.instantiate)()
-		        let child = (safeDIParameters.child ?? Child.init(dep:))(dep)
+		        let dep = (safeDIOverrides.dep ?? ThirdPartyDep.instantiate)()
+		        let child = (safeDIOverrides.child ?? Child.init(dep:))(dep)
 		        return Root(child: child, dep: dep)
 		    }
 		}
@@ -2130,7 +2170,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil
 		        ) {
@@ -2143,9 +2184,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    static func mock(
 		        name: String,
 		        flag: Bool = false,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        return Child(name: name, shared: shared, flag: flag)
 		    }
 		}
@@ -2153,6 +2194,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            flag: Bool = false,
@@ -2163,6 +2205,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let flag: Bool
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((String, Shared, Bool) -> Child)?
 		    }
 		}
@@ -2176,7 +2219,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil,
 		            childBuilder: Child.SafeDIMockConfiguration = .init()
@@ -2190,11 +2234,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        func __safeDI_childBuilder(name: String) -> Child {
-		            (safeDIParameters.childBuilder.safeDIBuilder ?? Child.init(name:shared:flag:))(name, shared, safeDIParameters.childBuilder.flag)
+		            (safeDIOverrides.childBuilder.safeDIBuilder ?? Child.init(name:shared:flag:))(name, shared, safeDIOverrides.childBuilder.flag)
 		        }
 		        let childBuilder = Instantiator<Child> {
 		            __safeDI_childBuilder(name: $0)
@@ -2266,7 +2310,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil,
 		            thirdPartyBuilder: ((Shared) -> ThirdParty)? = nil
@@ -2280,11 +2325,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        func __safeDI_thirdPartyBuilder() -> ThirdParty {
-		            (safeDIParameters.thirdPartyBuilder ?? ThirdParty.instantiate(shared:))(shared)
+		            (safeDIOverrides.thirdPartyBuilder ?? ThirdParty.instantiate(shared:))(shared)
 		        }
 		        let thirdPartyBuilder = Instantiator<ThirdParty>(__safeDI_thirdPartyBuilder)
 		        return Root(shared: shared, thirdPartyBuilder: thirdPartyBuilder)
@@ -2314,7 +2359,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension ThirdParty {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil
 		        ) {
@@ -2325,9 +2371,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> ThirdParty {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        return ThirdParty.instantiate(shared: shared)
 		    }
 		}
@@ -2366,7 +2412,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            selfBuilder: Root.SafeDIMockConfiguration = .init()
 		        ) {
@@ -2377,11 +2424,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_selfBuilder() -> Root {
 		            let selfBuilder = Instantiator<Root>(__safeDI_selfBuilder)
-		            return (safeDIParameters.selfBuilder.safeDIBuilder ?? Root.init(selfBuilder:))(selfBuilder)
+		            return (safeDIOverrides.selfBuilder.safeDIBuilder ?? Root.init(selfBuilder:))(selfBuilder)
 		        }
 		        let selfBuilder = Instantiator<Root>(__safeDI_selfBuilder)
 		        return Root(selfBuilder: selfBuilder)
@@ -2391,6 +2438,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            _ safeDIBuilder: ((Instantiator<Root>) -> Root)? = nil
@@ -2398,6 +2446,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		            self.safeDIBuilder = safeDIBuilder
 		        }
 
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((Instantiator<Root>) -> Root)?
 		    }
 		}
@@ -2455,7 +2504,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil,
 		            child: Child.SafeDIMockConfiguration = .init()
@@ -2469,16 +2519,16 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service = (safeDIParameters.service ?? Service.init)()
+		        let service = (safeDIOverrides.service ?? Service.init)()
 		        func __safeDI_child() -> Child {
 		            func __safeDI_selfBuilder() -> Child {
 		                let selfBuilder = Instantiator<Child>(__safeDI_selfBuilder)
 		                return Child.init(service:selfBuilder:)(service, selfBuilder)
 		            }
 		            let selfBuilder = Instantiator<Child>(__safeDI_selfBuilder)
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(service:selfBuilder:))(service, selfBuilder)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(service:selfBuilder:))(service, selfBuilder)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child, service: service)
@@ -2544,7 +2594,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            presenter: (() -> RootPresenter)? = nil,
 		            child: Child.SafeDIMockConfiguration = .init()
@@ -2558,12 +2609,12 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let presenter = (safeDIParameters.presenter ?? RootPresenter.init)()
+		        let presenter = (safeDIOverrides.presenter ?? RootPresenter.init)()
 		        func __safeDI_child() -> Child {
-		            let presenter = (safeDIParameters.child.presenter ?? ChildPresenter.init)()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(presenter:))(presenter)
+		            let presenter = (safeDIOverrides.child.presenter ?? ChildPresenter.init)()
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(presenter:))(presenter)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(presenter: presenter, child: child)
@@ -2635,7 +2686,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension B {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            a: A? = nil
 		        ) {
@@ -2646,9 +2698,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> B {
-		        let a: A? = safeDIParameters.a
+		        let a: A? = safeDIOverrides.a
 		        return B(a: a)
 		    }
 		}
@@ -2662,7 +2714,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            a: (() -> A)? = nil,
 		            b: ((A?) -> B)? = nil
@@ -2676,10 +2729,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let a = (safeDIParameters.a ?? A.init)()
-		        let b = (safeDIParameters.b ?? B.init(a:))(a)
+		        let a = (safeDIOverrides.a ?? A.init)()
+		        let b = (safeDIOverrides.b ?? B.init(a:))(a)
 		        return Root(a: a, b: b)
 		    }
 		}
@@ -2733,7 +2786,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            user: (() -> User)? = nil
 		        ) {
@@ -2744,9 +2798,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
-		        let user = (safeDIParameters.user ?? User.init)()
+		        let user = (safeDIOverrides.user ?? User.init)()
 		        return Child(userType: userType)
 		    }
 		}
@@ -2760,7 +2814,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            user: (() -> User)? = nil,
 		            child: ((UserType) -> Child)? = nil
@@ -2774,10 +2829,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let user = (safeDIParameters.user ?? User.init)()
-		        let child = (safeDIParameters.child ?? Child.init(userType:))(userType)
+		        let user = (safeDIOverrides.user ?? User.init)()
+		        let child = (safeDIOverrides.child ?? Child.init(userType:))(userType)
 		        return Root(child: child, user: user)
 		    }
 		}
@@ -2861,7 +2916,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension B {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            a: A? = nil
 		        ) {
@@ -2872,9 +2928,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> B {
-		        let a: A? = safeDIParameters.a
+		        let a: A? = safeDIOverrides.a
 		        return B(a: a)
 		    }
 		}
@@ -2888,7 +2944,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            a: (() -> A)? = nil,
 		            b: ((A?) -> B)? = nil
@@ -2902,10 +2959,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let a = (safeDIParameters.a ?? A.init)()
-		        let b = (safeDIParameters.b ?? B.init(a:))(a)
+		        let a = (safeDIOverrides.a ?? A.init)()
+		        let b = (safeDIOverrides.b ?? B.init(a:))(a)
 		        return Root(a: a, b: b)
 		    }
 		}
@@ -2970,7 +3027,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            defaultUserService: (() -> DefaultUserService)? = nil
 		        ) {
@@ -2981,9 +3039,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let defaultUserService = (safeDIParameters.defaultUserService ?? DefaultUserService.init)()
+		        let defaultUserService = (safeDIOverrides.defaultUserService ?? DefaultUserService.init)()
 		        return Root(defaultUserService: defaultUserService, userService: userService)
 		    }
 		}
@@ -3075,7 +3133,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension DefaultAuthService {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            networkService: (() -> DefaultNetworkService)? = nil
 		        ) {
@@ -3086,9 +3145,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> DefaultAuthService {
-		        let networkService = (safeDIParameters.networkService ?? DefaultNetworkService.init)()
+		        let networkService = (safeDIOverrides.networkService ?? DefaultNetworkService.init)()
 		        return DefaultAuthService(networkService: networkService)
 		    }
 		}
@@ -3124,7 +3183,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension LoggedInViewController {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            networkService: (() -> DefaultNetworkService)? = nil
 		        ) {
@@ -3136,9 +3196,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        user: User,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> LoggedInViewController {
-		        let networkService = (safeDIParameters.networkService ?? DefaultNetworkService.init)()
+		        let networkService = (safeDIOverrides.networkService ?? DefaultNetworkService.init)()
 		        return LoggedInViewController(user: user, networkService: networkService)
 		    }
 		}
@@ -3156,7 +3216,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension RootViewController {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            networkService: (() -> DefaultNetworkService)? = nil,
 		            authService: ((NetworkService) -> DefaultAuthService)? = nil,
@@ -3173,12 +3234,12 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> RootViewController {
-		        let networkService = (safeDIParameters.networkService ?? DefaultNetworkService.init)()
-		        let authService = (safeDIParameters.authService ?? DefaultAuthService.init(networkService:))(networkService)
+		        let networkService = (safeDIOverrides.networkService ?? DefaultNetworkService.init)()
+		        let authService = (safeDIOverrides.authService ?? DefaultAuthService.init(networkService:))(networkService)
 		        func __safeDI_loggedInViewControllerBuilder(user: User) -> LoggedInViewController {
-		            (safeDIParameters.loggedInViewControllerBuilder ?? LoggedInViewController.init(user:networkService:))(user, networkService)
+		            (safeDIOverrides.loggedInViewControllerBuilder ?? LoggedInViewController.init(user:networkService:))(user, networkService)
 		        }
 		        let loggedInViewControllerBuilder = ErasedInstantiator<User, UIViewController> {
 		            __safeDI_loggedInViewControllerBuilder(user: $0)
@@ -3242,7 +3303,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: (@Sendable (String) -> Child)? = nil
 		        ) {
@@ -3253,9 +3315,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let __safeDI_childBuilder__safeDIBuilder = safeDIParameters.childBuilder ?? Child.init(name:)
+		        let __safeDI_childBuilder__safeDIBuilder = safeDIOverrides.childBuilder ?? Child.init(name:)
 		        @Sendable func __safeDI_childBuilder(name: String) -> Child {
 		            __safeDI_childBuilder__safeDIBuilder(name)
 		        }
@@ -3316,7 +3378,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            grandchildBuilder: ((Int) -> Grandchild)? = nil
 		        ) {
@@ -3328,10 +3391,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        name: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
 		        func __safeDI_grandchildBuilder(age: Int) -> Grandchild {
-		            (safeDIParameters.grandchildBuilder ?? Grandchild.init(age:))(age)
+		            (safeDIOverrides.grandchildBuilder ?? Grandchild.init(age:))(age)
 		        }
 		        let grandchildBuilder = Instantiator<Grandchild> {
 		            __safeDI_grandchildBuilder(age: $0)
@@ -3343,6 +3406,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            grandchildBuilder: ((Int) -> Grandchild)? = nil,
@@ -3353,6 +3417,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let grandchildBuilder: ((Int) -> Grandchild)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((String, Instantiator<Grandchild>) -> Child)?
 		    }
 		}
@@ -3382,7 +3447,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -3393,16 +3459,16 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childBuilder(name: String) -> Child {
 		            func __safeDI_grandchildBuilder(age: Int) -> Grandchild {
-		                (safeDIParameters.childBuilder.grandchildBuilder ?? Grandchild.init(age:))(age)
+		                (safeDIOverrides.childBuilder.grandchildBuilder ?? Grandchild.init(age:))(age)
 		            }
 		            let grandchildBuilder = Instantiator<Grandchild> {
 		                __safeDI_grandchildBuilder(age: $0)
 		            }
-		            return (safeDIParameters.childBuilder.safeDIBuilder ?? Child.init(name:grandchildBuilder:))(name, grandchildBuilder)
+		            return (safeDIOverrides.childBuilder.safeDIBuilder ?? Child.init(name:grandchildBuilder:))(name, grandchildBuilder)
 		        }
 		        let childBuilder = Instantiator<Child> {
 		            __safeDI_childBuilder(name: $0)
@@ -3519,7 +3585,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension DefaultAuthService {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            networkService: (() -> DefaultNetworkService)? = nil
 		        ) {
@@ -3530,9 +3597,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> DefaultAuthService {
-		        let networkService = (safeDIParameters.networkService ?? DefaultNetworkService.init)()
+		        let networkService = (safeDIOverrides.networkService ?? DefaultNetworkService.init)()
 		        return DefaultAuthService(networkService: networkService)
 		    }
 		}
@@ -3560,7 +3627,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension EditProfileViewController {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            userManager: (() -> UserManager)? = nil,
 		            userNetworkService: (() -> DefaultNetworkService)? = nil,
@@ -3577,11 +3645,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> EditProfileViewController {
-		        let userManager = (safeDIParameters.userManager ?? UserManager.init)()
-		        let userNetworkService = (safeDIParameters.userNetworkService ?? DefaultNetworkService.init)()
-		        let userVendor = (safeDIParameters.userVendor ?? UserManager.init)()
+		        let userManager = (safeDIOverrides.userManager ?? UserManager.init)()
+		        let userNetworkService = (safeDIOverrides.userNetworkService ?? DefaultNetworkService.init)()
+		        let userVendor = (safeDIOverrides.userVendor ?? UserManager.init)()
 		        return EditProfileViewController(userVendor: userVendor, userManager: userManager, userNetworkService: userNetworkService)
 		    }
 		}
@@ -3595,7 +3663,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension LoggedInViewController {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            networkService: (() -> DefaultNetworkService)? = nil,
 		            profileViewControllerBuilder: ProfileViewController.SafeDIMockConfiguration = .init()
@@ -3610,15 +3679,15 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        userManager: UserManager,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> LoggedInViewController {
-		        let networkService = (safeDIParameters.networkService ?? DefaultNetworkService.init)()
+		        let networkService = (safeDIOverrides.networkService ?? DefaultNetworkService.init)()
 		        func __safeDI_profileViewControllerBuilder() -> ProfileViewController {
 		            func __safeDI_editProfileViewControllerBuilder() -> EditProfileViewController {
-		                (safeDIParameters.profileViewControllerBuilder.editProfileViewControllerBuilder ?? EditProfileViewController.init(userVendor:userManager:userNetworkService:))(userVendor, userManager, userNetworkService)
+		                (safeDIOverrides.profileViewControllerBuilder.editProfileViewControllerBuilder ?? EditProfileViewController.init(userVendor:userManager:userNetworkService:))(userVendor, userManager, userNetworkService)
 		            }
 		            let editProfileViewControllerBuilder = Instantiator<EditProfileViewController>(__safeDI_editProfileViewControllerBuilder)
-		            return (safeDIParameters.profileViewControllerBuilder.safeDIBuilder ?? ProfileViewController.init(userVendor:editProfileViewControllerBuilder:))(userVendor, editProfileViewControllerBuilder)
+		            return (safeDIOverrides.profileViewControllerBuilder.safeDIBuilder ?? ProfileViewController.init(userVendor:editProfileViewControllerBuilder:))(userVendor, editProfileViewControllerBuilder)
 		        }
 		        let profileViewControllerBuilder = Instantiator<ProfileViewController>(__safeDI_profileViewControllerBuilder)
 		        return LoggedInViewController(userManager: userManager, userNetworkService: userNetworkService, profileViewControllerBuilder: profileViewControllerBuilder)
@@ -3628,6 +3697,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension LoggedInViewController {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            profileViewControllerBuilder: ProfileViewController.SafeDIMockConfiguration = .init(),
@@ -3638,6 +3708,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let profileViewControllerBuilder: ProfileViewController.SafeDIMockConfiguration
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((UserManager, NetworkService, Instantiator<ProfileViewController>) -> LoggedInViewController)?
 		    }
 		}
@@ -3651,7 +3722,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension ProfileViewController {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            userManager: (() -> UserManager)? = nil,
 		            userNetworkService: (() -> DefaultNetworkService)? = nil,
@@ -3668,12 +3740,12 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> ProfileViewController {
-		        let userManager = (safeDIParameters.userManager ?? UserManager.init)()
-		        let userNetworkService = (safeDIParameters.userNetworkService ?? DefaultNetworkService.init)()
+		        let userManager = (safeDIOverrides.userManager ?? UserManager.init)()
+		        let userNetworkService = (safeDIOverrides.userNetworkService ?? DefaultNetworkService.init)()
 		        func __safeDI_editProfileViewControllerBuilder() -> EditProfileViewController {
-		            (safeDIParameters.editProfileViewControllerBuilder ?? EditProfileViewController.init(userVendor:userManager:userNetworkService:))(userVendor, userManager, userNetworkService)
+		            (safeDIOverrides.editProfileViewControllerBuilder ?? EditProfileViewController.init(userVendor:userManager:userNetworkService:))(userVendor, userManager, userNetworkService)
 		        }
 		        let editProfileViewControllerBuilder = Instantiator<EditProfileViewController>(__safeDI_editProfileViewControllerBuilder)
 		        return ProfileViewController(userVendor: userVendor, editProfileViewControllerBuilder: editProfileViewControllerBuilder)
@@ -3683,6 +3755,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension ProfileViewController {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            editProfileViewControllerBuilder: ((UserVendor, UserManager, NetworkService) -> EditProfileViewController)? = nil,
@@ -3693,6 +3766,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let editProfileViewControllerBuilder: ((UserVendor, UserManager, NetworkService) -> EditProfileViewController)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((UserVendor, Instantiator<EditProfileViewController>) -> ProfileViewController)?
 		    }
 		}
@@ -3706,7 +3780,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension RootViewController {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            networkService: (() -> DefaultNetworkService)? = nil,
 		            authService: ((NetworkService) -> DefaultAuthService)? = nil,
@@ -3723,20 +3798,20 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> RootViewController {
-		        let networkService = (safeDIParameters.networkService ?? DefaultNetworkService.init)()
-		        let authService = (safeDIParameters.authService ?? DefaultAuthService.init(networkService:))(networkService)
+		        let networkService = (safeDIOverrides.networkService ?? DefaultNetworkService.init)()
+		        let authService = (safeDIOverrides.authService ?? DefaultAuthService.init(networkService:))(networkService)
 		        func __safeDI_loggedInViewControllerBuilder(userManager: UserManager) -> LoggedInViewController {
 		            func __safeDI_profileViewControllerBuilder() -> ProfileViewController {
 		                func __safeDI_editProfileViewControllerBuilder() -> EditProfileViewController {
-		                    (safeDIParameters.loggedInViewControllerBuilder.profileViewControllerBuilder.editProfileViewControllerBuilder ?? EditProfileViewController.init(userVendor:userManager:userNetworkService:))(userVendor, userManager, userNetworkService)
+		                    (safeDIOverrides.loggedInViewControllerBuilder.profileViewControllerBuilder.editProfileViewControllerBuilder ?? EditProfileViewController.init(userVendor:userManager:userNetworkService:))(userVendor, userManager, userNetworkService)
 		                }
 		                let editProfileViewControllerBuilder = Instantiator<EditProfileViewController>(__safeDI_editProfileViewControllerBuilder)
-		                return (safeDIParameters.loggedInViewControllerBuilder.profileViewControllerBuilder.safeDIBuilder ?? ProfileViewController.init(userVendor:editProfileViewControllerBuilder:))(userVendor, editProfileViewControllerBuilder)
+		                return (safeDIOverrides.loggedInViewControllerBuilder.profileViewControllerBuilder.safeDIBuilder ?? ProfileViewController.init(userVendor:editProfileViewControllerBuilder:))(userVendor, editProfileViewControllerBuilder)
 		            }
 		            let profileViewControllerBuilder = Instantiator<ProfileViewController>(__safeDI_profileViewControllerBuilder)
-		            return (safeDIParameters.loggedInViewControllerBuilder.safeDIBuilder ?? LoggedInViewController.init(userManager:userNetworkService:profileViewControllerBuilder:))(userManager, userNetworkService, profileViewControllerBuilder)
+		            return (safeDIOverrides.loggedInViewControllerBuilder.safeDIBuilder ?? LoggedInViewController.init(userManager:userNetworkService:profileViewControllerBuilder:))(userManager, userNetworkService, profileViewControllerBuilder)
 		        }
 		        let loggedInViewControllerBuilder = Instantiator<LoggedInViewController> {
 		            __safeDI_loggedInViewControllerBuilder(userManager: $0)
@@ -3813,7 +3888,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            grandchildBuilder: ((AnyIterator) -> Grandchild)? = nil
 		        ) {
@@ -3825,10 +3901,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        iterator: IndexingIterator<Array<Element>>,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
 		        func __safeDI_grandchildBuilder() -> Grandchild {
-		            (safeDIParameters.grandchildBuilder ?? Grandchild.init(anyIterator:))(anyIterator)
+		            (safeDIOverrides.grandchildBuilder ?? Grandchild.init(anyIterator:))(anyIterator)
 		        }
 		        let grandchildBuilder = Instantiator<Grandchild>(__safeDI_grandchildBuilder)
 		        return Child(iterator: iterator, grandchildBuilder: grandchildBuilder)
@@ -3838,6 +3914,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            grandchildBuilder: ((AnyIterator) -> Grandchild)? = nil,
@@ -3848,6 +3925,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let grandchildBuilder: ((AnyIterator) -> Grandchild)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((IndexingIterator<Array<Element>>, Instantiator<Grandchild>) -> Child)?
 		    }
 		}
@@ -3877,7 +3955,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -3888,14 +3967,14 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childBuilder(iterator: IndexingIterator<Array<Element>>) -> Child {
 		            func __safeDI_grandchildBuilder() -> Grandchild {
-		                (safeDIParameters.childBuilder.grandchildBuilder ?? Grandchild.init(anyIterator:))(anyIterator)
+		                (safeDIOverrides.childBuilder.grandchildBuilder ?? Grandchild.init(anyIterator:))(anyIterator)
 		            }
 		            let grandchildBuilder = Instantiator<Grandchild>(__safeDI_grandchildBuilder)
-		            return (safeDIParameters.childBuilder.safeDIBuilder ?? Child.init(iterator:grandchildBuilder:))(iterator, grandchildBuilder)
+		            return (safeDIOverrides.childBuilder.safeDIBuilder ?? Child.init(iterator:grandchildBuilder:))(iterator, grandchildBuilder)
 		        }
 		        let childBuilder = Instantiator<Child> {
 		            __safeDI_childBuilder(iterator: $0)
@@ -3981,7 +4060,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension ChildB {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            recreated: (() -> Recreated)? = nil
 		        ) {
@@ -3992,9 +4072,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> ChildB {
-		        let recreated = (safeDIParameters.recreated ?? Recreated.init)()
+		        let recreated = (safeDIOverrides.recreated ?? Recreated.init)()
 		        return ChildB(recreated: recreated)
 		    }
 		}
@@ -4022,7 +4102,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childABuilder: (@Sendable (Recreated) -> ChildA)? = nil,
 		            recreated: (() -> Recreated)? = nil,
@@ -4039,17 +4120,17 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let __safeDI_childABuilder__safeDIBuilder = safeDIParameters.childABuilder ?? ChildA.init(recreated:)
+		        let __safeDI_childABuilder__safeDIBuilder = safeDIOverrides.childABuilder ?? ChildA.init(recreated:)
 		        @Sendable func __safeDI_childABuilder(recreated: Recreated) -> ChildA {
 		            __safeDI_childABuilder__safeDIBuilder(recreated)
 		        }
 		        let childABuilder = SendableErasedInstantiator<Recreated, ChildAProtocol> {
 		            __safeDI_childABuilder(recreated: $0)
 		        }
-		        let recreated = (safeDIParameters.recreated ?? Recreated.init)()
-		        let childB = (safeDIParameters.childB ?? ChildB.init(recreated:))(recreated)
+		        let recreated = (safeDIOverrides.recreated ?? Recreated.init)()
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(recreated:))(recreated)
 		        return Root(childABuilder: childABuilder, childB: childB, recreated: recreated)
 		    }
 		}
@@ -4110,7 +4191,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension DefaultAuthService {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            networkService: (() -> DefaultNetworkService)? = nil
 		        ) {
@@ -4121,9 +4203,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> DefaultAuthService {
-		        let networkService = (safeDIParameters.networkService ?? DefaultNetworkService.init)()
+		        let networkService = (safeDIOverrides.networkService ?? DefaultNetworkService.init)()
 		        return DefaultAuthService(networkService: networkService, renamedNetworkService: renamedNetworkService)
 		    }
 		}
@@ -4131,6 +4213,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension DefaultAuthService {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            networkService: (() -> DefaultNetworkService)? = nil,
@@ -4141,6 +4224,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let networkService: (() -> DefaultNetworkService)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((NetworkService, NetworkService) -> DefaultAuthService)?
 		    }
 		}
@@ -4168,7 +4252,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension RootViewController {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            networkService: (() -> DefaultNetworkService)? = nil,
 		            authService: DefaultAuthService.SafeDIMockConfiguration = .init()
@@ -4182,12 +4267,12 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> RootViewController {
-		        let networkService = (safeDIParameters.networkService ?? DefaultNetworkService.init)()
+		        let networkService = (safeDIOverrides.networkService ?? DefaultNetworkService.init)()
 		        func __safeDI_authService() -> DefaultAuthService {
-		            let networkService = (safeDIParameters.authService.networkService ?? DefaultNetworkService.init)()
-		            return (safeDIParameters.authService.safeDIBuilder ?? DefaultAuthService.init(networkService:renamedNetworkService:))(networkService, renamedNetworkService)
+		            let networkService = (safeDIOverrides.authService.networkService ?? DefaultNetworkService.init)()
+		            return (safeDIOverrides.authService.safeDIBuilder ?? DefaultAuthService.init(networkService:renamedNetworkService:))(networkService, renamedNetworkService)
 		        }
 		        let authService: DefaultAuthService = __safeDI_authService()
 		        return RootViewController(authService: authService)
@@ -4259,7 +4344,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            externalType: (() -> ExternalType)? = nil
 		        ) {
@@ -4270,9 +4356,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let externalType = (safeDIParameters.externalType ?? ExternalType.instantiate)()
+		        let externalType = (safeDIOverrides.externalType ?? ExternalType.instantiate)()
 		        return Root(externalType: externalType)
 		    }
 		}
@@ -4335,7 +4421,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            parentBuilder: Parent.SafeDIMockConfiguration = .init()
 		        ) {
@@ -4346,14 +4433,14 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_parentBuilder(config: Config) -> Parent {
 		            func __safeDI_childBuilder() -> Child {
-		                (safeDIParameters.parentBuilder.childBuilder ?? Child.init(config:))(config)
+		                (safeDIOverrides.parentBuilder.childBuilder ?? Child.init(config:))(config)
 		            }
 		            let childBuilder = Instantiator<Child>(__safeDI_childBuilder)
-		            return (safeDIParameters.parentBuilder.safeDIBuilder ?? Parent.init(config:childBuilder:))(config, childBuilder)
+		            return (safeDIOverrides.parentBuilder.safeDIBuilder ?? Parent.init(config:childBuilder:))(config, childBuilder)
 		        }
 		        let parentBuilder = Instantiator<Parent> {
 		            __safeDI_parentBuilder(config: $0)
@@ -4420,7 +4507,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            receivedValue: (() -> ReceivedValue)? = nil,
 		            service: Service.SafeDIMockConfiguration = .init()
@@ -4434,12 +4522,12 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let receivedValue = (safeDIParameters.receivedValue ?? ReceivedValue.init)()
+		        let receivedValue = (safeDIOverrides.receivedValue ?? ReceivedValue.init)()
 		        func __safeDI_service() -> Service {
-		            let database = (safeDIParameters.service.database ?? Database.init)()
-		            return (safeDIParameters.service.safeDIBuilder ?? Service.init(database:receivedValue:))(database, receivedValue)
+		            let database = (safeDIOverrides.service.database ?? Database.init)()
+		            return (safeDIOverrides.service.safeDIBuilder ?? Service.init(database:receivedValue:))(database, receivedValue)
 		        }
 		        let service: Service = __safeDI_service()
 		        return Root(receivedValue: receivedValue, service: service)
@@ -4503,7 +4591,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            parentBuilder: Parent.SafeDIMockConfiguration = .init()
 		        ) {
@@ -4514,11 +4603,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_parentBuilder(token: Token) -> Parent {
-		            let child = (safeDIParameters.parentBuilder.child ?? Child.init(token:))(token)
-		            return (safeDIParameters.parentBuilder.safeDIBuilder ?? Parent.init(token:child:))(token, child)
+		            let child = (safeDIOverrides.parentBuilder.child ?? Child.init(token:))(token)
+		            return (safeDIOverrides.parentBuilder.safeDIBuilder ?? Parent.init(token:child:))(token, child)
 		        }
 		        let parentBuilder = Instantiator<Parent> {
 		            __safeDI_parentBuilder(token: $0)
@@ -4578,7 +4667,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> ConcreteService)? = nil,
 		            consumer: ((ConcreteService) -> Consumer)? = nil
@@ -4592,10 +4682,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service = (safeDIParameters.service ?? ConcreteService.init)()
-		        let consumer = (safeDIParameters.consumer ?? Consumer.init(service:))(service)
+		        let service = (safeDIOverrides.service ?? ConcreteService.init)()
+		        let consumer = (safeDIOverrides.consumer ?? Consumer.init(service:))(service)
 		        return Root(service: service, consumer: consumer)
 		    }
 		}
@@ -4662,7 +4752,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil,
 		            service: Service.SafeDIMockConfiguration = .init()
@@ -4676,17 +4767,17 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        func __safeDI_service() -> Service {
 		            func __safeDI_channelBuilder(key: String) -> Channel {
-		                (safeDIParameters.service.channelBuilder ?? Channel.init(key:shared:))(key, shared)
+		                (safeDIOverrides.service.channelBuilder ?? Channel.init(key:shared:))(key, shared)
 		            }
 		            let channelBuilder = Instantiator<Channel> {
 		                __safeDI_channelBuilder(key: $0)
 		            }
-		            return (safeDIParameters.service.safeDIBuilder ?? Service.init(channelBuilder:shared:))(channelBuilder, shared)
+		            return (safeDIOverrides.service.safeDIBuilder ?? Service.init(channelBuilder:shared:))(channelBuilder, shared)
 		        }
 		        let service: Service = __safeDI_service()
 		        return Root(shared: shared, service: service)
@@ -4734,7 +4825,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: (@Sendable () -> Child)? = nil
 		        ) {
@@ -4745,9 +4837,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let __safeDI_childBuilder__safeDIBuilder = safeDIParameters.childBuilder ?? Child.init
+		        let __safeDI_childBuilder__safeDIBuilder = safeDIOverrides.childBuilder ?? Child.init
 		        @Sendable func __safeDI_childBuilder() -> Child {
 		            __safeDI_childBuilder__safeDIBuilder()
 		        }
@@ -4823,7 +4915,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            parentBuilder: Parent.SafeDIMockConfiguration = .init()
 		        ) {
@@ -4834,15 +4927,15 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_parentBuilder(token: Token) -> Parent {
 		            func __safeDI_child() -> Child {
-		                let grandchild = (safeDIParameters.parentBuilder.child.grandchild ?? Grandchild.init(token:))(token)
-		                return (safeDIParameters.parentBuilder.child.safeDIBuilder ?? Child.init(token:grandchild:))(token, grandchild)
+		                let grandchild = (safeDIOverrides.parentBuilder.child.grandchild ?? Grandchild.init(token:))(token)
+		                return (safeDIOverrides.parentBuilder.child.safeDIBuilder ?? Child.init(token:grandchild:))(token, grandchild)
 		            }
 		            let child: Child = __safeDI_child()
-		            return (safeDIParameters.parentBuilder.safeDIBuilder ?? Parent.init(token:child:))(token, child)
+		            return (safeDIOverrides.parentBuilder.safeDIBuilder ?? Parent.init(token:child:))(token, child)
 		        }
 		        let parentBuilder = Instantiator<Parent> {
 		            __safeDI_parentBuilder(token: $0)
@@ -4905,7 +4998,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            concreteService: (() -> ConcreteService)? = nil,
 		            consumerBuilder: ((ServiceProtocol) -> Consumer)? = nil
@@ -4919,11 +5013,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let concreteService = (safeDIParameters.concreteService ?? ConcreteService.init)()
+		        let concreteService = (safeDIOverrides.concreteService ?? ConcreteService.init)()
 		        func __safeDI_consumerBuilder() -> Consumer {
-		            (safeDIParameters.consumerBuilder ?? Consumer.init(service:))(service)
+		            (safeDIOverrides.consumerBuilder ?? Consumer.init(service:))(service)
 		        }
 		        let consumerBuilder = Instantiator<Consumer>(__safeDI_consumerBuilder)
 		        return Root(consumerBuilder: consumerBuilder, concreteService: concreteService)
@@ -4978,7 +5072,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Consumer {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            dependency: (() -> Dependency)? = nil,
 		            idProvider: IDProvider? = nil
@@ -4992,10 +5087,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Consumer {
-		        let idProvider: IDProvider? = safeDIParameters.idProvider
-		        let dependency = (safeDIParameters.dependency ?? Dependency.init)()
+		        let idProvider: IDProvider? = safeDIOverrides.idProvider
+		        let dependency = (safeDIOverrides.dependency ?? Dependency.init)()
 		        return Consumer(idProvider: idProvider, dependency: dependency)
 		    }
 		}
@@ -5048,7 +5143,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            transitiveDep: (() -> TransitiveDep)? = nil,
 		            child: ((TransitiveDep) -> Child)? = nil
@@ -5062,10 +5158,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let transitiveDep = (safeDIParameters.transitiveDep ?? TransitiveDep.init)()
-		        let child = (safeDIParameters.child ?? Child.init(transitiveDep:))(transitiveDep)
+		        let transitiveDep = (safeDIOverrides.transitiveDep ?? TransitiveDep.init)()
+		        let child = (safeDIOverrides.child ?? Child.init(transitiveDep:))(transitiveDep)
 		        return Parent(child: child)
 		    }
 		}
@@ -5155,7 +5251,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: ((ExternalClient) -> Child)? = nil
 		        ) {
@@ -5167,9 +5264,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        client: ExternalClient,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let child = (safeDIParameters.child ?? Child.init(client:))(client)
+		        let child = (safeDIOverrides.child ?? Child.init(client:))(client)
 		        return Parent(child: child)
 		    }
 		}
@@ -5215,7 +5312,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		// Parent receives Child, which has @Received(onlyIfAvailable: true) idProvider.
 		// IDProvider is not in Parent's scope. The mock exposes idProvider as an
-		// optional parameter (defaulting to nil) inside SafeDIParameters and threads it to Child.
+		// optional parameter (defaulting to nil) inside SafeDIOverrides and threads it to Child.
 		#expect(output.mockFiles["Parent+SafeDIMock.swift"] == """
 		// This file was generated by the SafeDIGenerateDependencyTree build tool plugin.
 		// Any modifications made to this file will be overwritten on subsequent builds.
@@ -5223,7 +5320,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: ((IDProvider?) -> Child)? = nil,
 		            idProvider: IDProvider? = nil
@@ -5237,10 +5335,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let idProvider: IDProvider? = safeDIParameters.idProvider
-		        let child = (safeDIParameters.child ?? Child.init(idProvider:))(idProvider)
+		        let idProvider: IDProvider? = safeDIOverrides.idProvider
+		        let child = (safeDIOverrides.child ?? Child.init(idProvider:))(idProvider)
 		        return Parent(child: child)
 		    }
 		}
@@ -5287,7 +5385,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension DeviceService {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            appClipService: AppClipService? = nil
 		        ) {
@@ -5299,9 +5398,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        name: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> DeviceService {
-		        let appClipService: AppClipService? = safeDIParameters.appClipService
+		        let appClipService: AppClipService? = safeDIOverrides.appClipService
 		        return DeviceService(appClipService: appClipService, name: name)
 		    }
 		}
@@ -5352,7 +5451,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            interceptorBuilder: Interceptor.SafeDIMockConfiguration = .init()
 		        ) {
@@ -5363,10 +5463,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let __safeDI_interceptorBuilder__interceptorBuilder_loggingService_safeDIBuilder = safeDIParameters.interceptorBuilder.loggingService ?? LoggingService.init
-		        let __safeDI_interceptorBuilder__safeDIBuilder = safeDIParameters.interceptorBuilder.safeDIBuilder ?? Interceptor.init(loggingService:)
+		        let __safeDI_interceptorBuilder__interceptorBuilder_loggingService_safeDIBuilder = safeDIOverrides.interceptorBuilder.loggingService ?? LoggingService.init
+		        let __safeDI_interceptorBuilder__safeDIBuilder = safeDIOverrides.interceptorBuilder.safeDIBuilder ?? Interceptor.init(loggingService:)
 		        @Sendable func __safeDI_interceptorBuilder() -> Interceptor {
 		            let loggingService = __safeDI_interceptorBuilder__interceptorBuilder_loggingService_safeDIBuilder()
 		            return __safeDI_interceptorBuilder__safeDIBuilder(loggingService)
@@ -5437,7 +5537,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            interceptorBuilder: Interceptor.SafeDIMockConfiguration = .init()
 		        ) {
@@ -5448,12 +5549,12 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let __safeDI_interceptorBuilder__interceptorBuilder_handler_safeDIBuilder = safeDIParameters.interceptorBuilder.handler.safeDIBuilder ?? Handler.init(logger:logLevel:)
-		        let __safeDI_interceptorBuilder__interceptorBuilder_handler_logLevel = safeDIParameters.interceptorBuilder.handler.logLevel
-		        let __safeDI_interceptorBuilder__interceptorBuilder_handler_logger_safeDIBuilder = safeDIParameters.interceptorBuilder.handler.logger ?? Logger.init
-		        let __safeDI_interceptorBuilder__safeDIBuilder = safeDIParameters.interceptorBuilder.safeDIBuilder ?? Interceptor.init(handler:)
+		        let __safeDI_interceptorBuilder__interceptorBuilder_handler_safeDIBuilder = safeDIOverrides.interceptorBuilder.handler.safeDIBuilder ?? Handler.init(logger:logLevel:)
+		        let __safeDI_interceptorBuilder__interceptorBuilder_handler_logLevel = safeDIOverrides.interceptorBuilder.handler.logLevel
+		        let __safeDI_interceptorBuilder__interceptorBuilder_handler_logger_safeDIBuilder = safeDIOverrides.interceptorBuilder.handler.logger ?? Logger.init
+		        let __safeDI_interceptorBuilder__safeDIBuilder = safeDIOverrides.interceptorBuilder.safeDIBuilder ?? Interceptor.init(handler:)
 		        @Sendable func __safeDI_interceptorBuilder() -> Interceptor {
 		            func __safeDI_handler() -> Handler {
 		                let logger = __safeDI_interceptorBuilder__interceptorBuilder_handler_logger_safeDIBuilder()
@@ -5526,7 +5627,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil,
 		            interceptorBuilder: Interceptor.SafeDIMockConfiguration = .init()
@@ -5540,11 +5642,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service = (safeDIParameters.service ?? Service.init)()
-		        let __safeDI_interceptorBuilder__interceptorBuilder_logger_safeDIBuilder = safeDIParameters.interceptorBuilder.logger ?? Logger.init
-		        let __safeDI_interceptorBuilder__safeDIBuilder = safeDIParameters.interceptorBuilder.safeDIBuilder ?? Interceptor.init(logger:)
+		        let service = (safeDIOverrides.service ?? Service.init)()
+		        let __safeDI_interceptorBuilder__interceptorBuilder_logger_safeDIBuilder = safeDIOverrides.interceptorBuilder.logger ?? Logger.init
+		        let __safeDI_interceptorBuilder__safeDIBuilder = safeDIOverrides.interceptorBuilder.safeDIBuilder ?? Interceptor.init(logger:)
 		        @Sendable func __safeDI_interceptorBuilder() -> Interceptor {
 		            let logger = __safeDI_interceptorBuilder__interceptorBuilder_logger_safeDIBuilder()
 		            return __safeDI_interceptorBuilder__safeDIBuilder(logger)
@@ -5603,7 +5705,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -5614,11 +5717,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childBuilder(name: String) -> Child {
-		            let service = (safeDIParameters.childBuilder.service ?? Service.init)()
-		            return (safeDIParameters.childBuilder.safeDIBuilder ?? Child.init(name:service:))(name, service)
+		            let service = (safeDIOverrides.childBuilder.service ?? Service.init)()
+		            return (safeDIOverrides.childBuilder.safeDIBuilder ?? Child.init(name:service:))(name, service)
 		        }
 		        let childBuilder = Instantiator<Child> {
 		            __safeDI_childBuilder(name: $0)
@@ -5699,7 +5802,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Service {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            externalEngine: (() -> ExternalEngine)? = nil
 		        ) {
@@ -5711,9 +5815,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        name: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Service {
-		        let externalEngine = (safeDIParameters.externalEngine ?? ExternalEngine.instantiate)()
+		        let externalEngine = (safeDIOverrides.externalEngine ?? ExternalEngine.instantiate)()
 		        return Service(externalEngine: externalEngine, name: name)
 		    }
 		}
@@ -5785,7 +5889,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Service {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            externalEngine: (() -> ExternalEngine)? = nil
 		        ) {
@@ -5796,9 +5901,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Service {
-		        let externalEngine = (safeDIParameters.externalEngine ?? ExternalEngine.instantiate)()
+		        let externalEngine = (safeDIOverrides.externalEngine ?? ExternalEngine.instantiate)()
 		        return Service(externalEngine: externalEngine)
 		    }
 		}
@@ -5856,7 +5961,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -5868,11 +5974,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        service: ExternalService,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
 		        func __safeDI_child() -> Child {
-		            let service = (safeDIParameters.child.service ?? InternalService.init)()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(service:))(service)
+		            let service = (safeDIOverrides.child.service ?? InternalService.init)()
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(service:))(service)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Parent(service: service, child: child)
@@ -5923,7 +6029,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Service {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            installScopedDefaultsService: (() -> UserDefaultsService)? = nil,
 		            userScopedDefaultsService: (() -> UserDefaultsService)? = nil
@@ -5937,10 +6044,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Service {
-		        let installScopedDefaultsService = (safeDIParameters.installScopedDefaultsService ?? UserDefaultsService.init)()
-		        let userScopedDefaultsService = (safeDIParameters.userScopedDefaultsService ?? UserDefaultsService.init)()
+		        let installScopedDefaultsService = (safeDIOverrides.installScopedDefaultsService ?? UserDefaultsService.init)()
+		        let userScopedDefaultsService = (safeDIOverrides.userScopedDefaultsService ?? UserDefaultsService.init)()
 		        return Service(installScopedDefaultsService: installScopedDefaultsService, userScopedDefaultsService: userScopedDefaultsService)
 		    }
 		}
@@ -6011,7 +6118,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension NoteView {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            userService: (() -> DefaultUserService)? = nil
 		        ) {
@@ -6023,9 +6131,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        userName: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> NoteView {
-		        let userService = AnyUserService((safeDIParameters.userService ?? DefaultUserService.init)())
+		        let userService = AnyUserService((safeDIOverrides.userService ?? DefaultUserService.init)())
 		        return NoteView(userName: userName, userService: userService)
 		    }
 		}
@@ -6089,7 +6197,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> SharedThing)? = nil,
 		            childA: ((SharedThing) -> ChildA)? = nil,
@@ -6106,13 +6215,13 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let shared = (safeDIParameters.shared ?? SharedThing.init)()
-		        let childA = (safeDIParameters.childA ?? ChildA.init(shared:))(shared)
+		        let shared = (safeDIOverrides.shared ?? SharedThing.init)()
+		        let childA = (safeDIOverrides.childA ?? ChildA.init(shared:))(shared)
 		        func __safeDI_childB() -> ChildB {
-		            let shared = (safeDIParameters.childB.shared ?? SharedThing.init)()
-		            return (safeDIParameters.childB.safeDIBuilder ?? ChildB.init(shared:))(shared)
+		            let shared = (safeDIOverrides.childB.shared ?? SharedThing.init)()
+		            return (safeDIOverrides.childB.safeDIBuilder ?? ChildB.init(shared:))(shared)
 		        }
 		        let childB: ChildB = __safeDI_childB()
 		        return Parent(childA: childA, childB: childB)
@@ -6179,7 +6288,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension NameEntry {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            stringStorage: (() -> SomeExternalType)? = nil,
 		            userService: ((StringStorage) -> UserService)? = nil
@@ -6193,10 +6303,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> NameEntry {
-		        let stringStorage = (safeDIParameters.stringStorage ?? SomeExternalType.instantiate)()
-		        let userService = (safeDIParameters.userService ?? UserService.init(stringStorage:))(stringStorage)
+		        let stringStorage = (safeDIOverrides.stringStorage ?? SomeExternalType.instantiate)()
+		        let userService = (safeDIOverrides.userService ?? UserService.init(stringStorage:))(stringStorage)
 		        return NameEntry(userService: userService)
 		    }
 		}
@@ -6259,7 +6369,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: ConcreteService.SafeDIMockConfiguration = .init()
 		        ) {
@@ -6270,11 +6381,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_service() -> ConcreteService {
-		            let helper = (safeDIParameters.service.helper ?? Helper.init)()
-		            return (safeDIParameters.service.safeDIBuilder ?? ConcreteService.init(helper:))(helper)
+		            let helper = (safeDIOverrides.service.helper ?? Helper.init)()
+		            return (safeDIOverrides.service.safeDIBuilder ?? ConcreteService.init(helper:))(helper)
 		        }
 		        let service: AnyService = AnyService(__safeDI_service())
 		        return Root(service: service)
@@ -6340,7 +6451,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: ((String) -> ConcreteChild)? = nil
 		        ) {
@@ -6351,10 +6463,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childBuilder(name: String) -> ConcreteChild {
-		            (safeDIParameters.childBuilder ?? ConcreteChild.init(name:))(name)
+		            (safeDIOverrides.childBuilder ?? ConcreteChild.init(name:))(name)
 		        }
 		        let childBuilder = ErasedInstantiator<String, AnyChild> {
 		            AnyChild(__safeDI_childBuilder(name: $0))
@@ -6415,7 +6527,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		// Both ChildA and ChildB have @Received(onlyIfAvailable: true) appClipService.
 		// The generated mock must NOT declare appClipService twice at the same scope.
-		// It should be a single onlyIfAvailable entry in SafeDIParameters.
+		// It should be a single onlyIfAvailable entry in SafeDIOverrides.
 		#expect(output.mockFiles["Parent+SafeDIMock.swift"] == """
 		// This file was generated by the SafeDIGenerateDependencyTree build tool plugin.
 		// Any modifications made to this file will be overwritten on subsequent builds.
@@ -6423,7 +6535,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ((AppClipService?) -> ChildA)? = nil,
 		            childB: ((AppClipService?) -> ChildB)? = nil,
@@ -6440,11 +6553,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let appClipService: AppClipService? = safeDIParameters.appClipService
-		        let childA = (safeDIParameters.childA ?? ChildA.init(appClipService:))(appClipService)
-		        let childB = (safeDIParameters.childB ?? ChildB.init(appClipService:))(appClipService)
+		        let appClipService: AppClipService? = safeDIOverrides.appClipService
+		        let childA = (safeDIOverrides.childA ?? ChildA.init(appClipService:))(appClipService)
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(appClipService:))(appClipService)
 		        return Parent(childA: childA, childB: childB)
 		    }
 		}
@@ -6509,7 +6622,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Container {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            stateService: (() -> StateService)? = nil,
 		            imageLoader: ((StateService) -> ImageLoader)? = nil,
@@ -6526,13 +6640,13 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Container {
-		        let stateService = (safeDIParameters.stateService ?? StateService.init)()
-		        let imageLoader = (safeDIParameters.imageLoader ?? ImageLoader.init(stateService:))(stateService)
+		        let stateService = (safeDIOverrides.stateService ?? StateService.init)()
+		        let imageLoader = (safeDIOverrides.imageLoader ?? ImageLoader.init(stateService:))(stateService)
 		        func __safeDI_engine() -> Engine {
-		            let stateService = (safeDIParameters.engine.stateService ?? StateService.init)()
-		            return (safeDIParameters.engine.safeDIBuilder ?? Engine.init(stateService:))(stateService)
+		            let stateService = (safeDIOverrides.engine.stateService ?? StateService.init)()
+		            return (safeDIOverrides.engine.safeDIBuilder ?? Engine.init(stateService:))(stateService)
 		        }
 		        let engine: Engine = __safeDI_engine()
 		        return Container(imageLoader: imageLoader, engine: engine)
@@ -6656,7 +6770,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ((User) -> ChildA)? = nil,
 		            childB: ((User?) -> ChildB)? = nil
@@ -6671,10 +6786,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        user: User,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let childA = (safeDIParameters.childA ?? ChildA.init(user:))(user)
-		        let childB = (safeDIParameters.childB ?? ChildB.init(user:))(user)
+		        let childA = (safeDIOverrides.childA ?? ChildA.init(user:))(user)
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(user:))(user)
 		        return Parent(childA: childA, childB: childB)
 		    }
 		}
@@ -6881,7 +6996,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            consumer: ((ServiceProtocol?) -> Consumer)? = nil,
 		            concreteService: ConcreteService? = nil
@@ -6895,10 +7011,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let concreteService: ConcreteService? = safeDIParameters.concreteService
-		        let consumer = (safeDIParameters.consumer ?? Consumer.init(service:))(service)
+		        let concreteService: ConcreteService? = safeDIOverrides.concreteService
+		        let consumer = (safeDIOverrides.consumer ?? Consumer.init(service:))(service)
 		        return Parent(consumer: consumer)
 		    }
 		}
@@ -6964,7 +7080,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension ProfileService {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            imageService: ((ApplicationStateService?) -> ImageService)? = nil,
 		            applicationStateService: ApplicationStateService? = nil
@@ -6978,10 +7095,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> ProfileService {
-		        let applicationStateService: ApplicationStateService? = safeDIParameters.applicationStateService
-		        let imageService = (safeDIParameters.imageService ?? ImageService.init(applicationStateService:))(applicationStateService)
+		        let applicationStateService: ApplicationStateService? = safeDIOverrides.applicationStateService
+		        let imageService = (safeDIOverrides.imageService ?? ImageService.init(applicationStateService:))(applicationStateService)
 		        return ProfileService(imageService: imageService)
 		    }
 		}
@@ -7027,7 +7144,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            presenterBuilder: ((@escaping () -> Void) -> Presenter)? = nil
 		        ) {
@@ -7038,10 +7156,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
 		        func __safeDI_presenterBuilder(onDismiss: @escaping () -> Void) -> Presenter {
-		            (safeDIParameters.presenterBuilder ?? Presenter.init(onDismiss:))(onDismiss)
+		            (safeDIOverrides.presenterBuilder ?? Presenter.init(onDismiss:))(onDismiss)
 		        }
 		        let presenterBuilder = Instantiator<Presenter> {
 		            __safeDI_presenterBuilder(onDismiss: $0)
@@ -7202,7 +7320,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
 		            childB: ((ExternalService) -> ChildB)? = nil
@@ -7217,14 +7336,14 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        service: ExternalService,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childA() -> ChildA {
-		            let service = (safeDIParameters.childA.service ?? LocalService.init)()
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.init(service:))(service)
+		            let service = (safeDIOverrides.childA.service ?? LocalService.init)()
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.init(service:))(service)
 		        }
 		        let childA: ChildA = __safeDI_childA()
-		        let childB = (safeDIParameters.childB ?? ChildB.init(service:))(service)
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(service:))(service)
 		        return Root(childA: childA, childB: childB)
 		    }
 		}
@@ -7284,7 +7403,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		)
 
 		// Both must appear as parameters — different types should not suppress each other.
-		// ExternalService is disambiguated as a flat param; LocalService? is in SafeDIParameters.
+		// ExternalService is disambiguated as a flat param; LocalService? is in SafeDIOverrides.
 		#expect(output.mockFiles["Root+SafeDIMock.swift"] == """
 		// This file was generated by the SafeDIGenerateDependencyTree build tool plugin.
 		// Any modifications made to this file will be overwritten on subsequent builds.
@@ -7292,7 +7411,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ((ExternalService) -> ChildA)? = nil,
 		            childB: ((LocalService?) -> ChildB)? = nil,
@@ -7310,11 +7430,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        service_ExternalService: ExternalService,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service: LocalService? = safeDIParameters.service
-		        let childA = (safeDIParameters.childA ?? ChildA.init(service:))(service)
-		        let childB = (safeDIParameters.childB ?? ChildB.init(service:))(service)
+		        let service: LocalService? = safeDIOverrides.service
+		        let childA = (safeDIOverrides.childA ?? ChildA.init(service:))(service)
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(service:))(service)
 		        return Root(childA: childA, childB: childB)
 		    }
 		}
@@ -7369,7 +7489,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            parent: Parent.SafeDIMockConfiguration = .init()
 		        ) {
@@ -7380,15 +7501,15 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_parent() -> Parent {
 		            func __safeDI_child() -> Child {
-		                let leaf = (safeDIParameters.parent.child.leaf ?? Leaf.init)()
-		                return (safeDIParameters.parent.child.safeDIBuilder ?? Child.init(leaf:))(leaf)
+		                let leaf = (safeDIOverrides.parent.child.leaf ?? Leaf.init)()
+		                return (safeDIOverrides.parent.child.safeDIBuilder ?? Child.init(leaf:))(leaf)
 		            }
 		            let child: Child = __safeDI_child()
-		            return (safeDIParameters.parent.safeDIBuilder ?? Parent.init(child:))(child)
+		            return (safeDIOverrides.parent.safeDIBuilder ?? Parent.init(child:))(child)
 		        }
 		        let parent: Parent = __safeDI_parent()
 		        return Root(parent: parent)
@@ -7453,7 +7574,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            widgetService: WidgetService.SafeDIMockConfiguration = .init(),
 		            parent: ((WidgetService) -> Parent)? = nil
@@ -7467,14 +7589,14 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_widgetService() -> WidgetService {
-		            let config = (safeDIParameters.widgetService.config ?? Config.init)()
-		            return (safeDIParameters.widgetService.safeDIBuilder ?? WidgetService.init(config:))(config)
+		            let config = (safeDIOverrides.widgetService.config ?? Config.init)()
+		            return (safeDIOverrides.widgetService.safeDIBuilder ?? WidgetService.init(config:))(config)
 		        }
 		        let widgetService: WidgetService = __safeDI_widgetService()
-		        let parent = (safeDIParameters.parent ?? Parent.init(widgetService:))(widgetService)
+		        let parent = (safeDIOverrides.parent ?? Parent.init(widgetService:))(widgetService)
 		        return Root(parent: parent, widgetService: widgetService)
 		    }
 		}
@@ -7547,7 +7669,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            widgetService: WidgetService.SafeDIMockConfiguration = .init(),
 		            parent: Parent.SafeDIMockConfiguration = .init()
@@ -7561,16 +7684,16 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_widgetService() -> WidgetService {
-		            let config = (safeDIParameters.widgetService.config ?? Config.init)()
-		            return (safeDIParameters.widgetService.safeDIBuilder ?? WidgetService.init(config:))(config)
+		            let config = (safeDIOverrides.widgetService.config ?? Config.init)()
+		            return (safeDIOverrides.widgetService.safeDIBuilder ?? WidgetService.init(config:))(config)
 		        }
 		        let widgetService: WidgetService = __safeDI_widgetService()
 		        func __safeDI_parent() -> Parent {
-		            let grandchild = (safeDIParameters.parent.grandchild ?? Grandchild.init(widgetService:))(widgetService)
-		            return (safeDIParameters.parent.safeDIBuilder ?? Parent.init(grandchild:))(grandchild)
+		            let grandchild = (safeDIOverrides.parent.grandchild ?? Grandchild.init(widgetService:))(widgetService)
+		            return (safeDIOverrides.parent.safeDIBuilder ?? Parent.init(grandchild:))(grandchild)
 		        }
 		        let parent: Parent = __safeDI_parent()
 		        return Root(parent: parent, widgetService: widgetService)
@@ -7645,7 +7768,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            parent: Parent.SafeDIMockConfiguration = .init(),
 		            widgetService: WidgetService.SafeDIMockConfiguration = .init()
@@ -7659,24 +7783,24 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_parent() -> Parent {
 		            func __safeDI_grandchild() -> Grandchild {
 		                func __safeDI_widgetService() -> WidgetService {
-		                    let config = (safeDIParameters.parent.grandchild.widgetService.config ?? Config.init)()
-		                    return (safeDIParameters.parent.grandchild.widgetService.safeDIBuilder ?? WidgetService.init(config:))(config)
+		                    let config = (safeDIOverrides.parent.grandchild.widgetService.config ?? Config.init)()
+		                    return (safeDIOverrides.parent.grandchild.widgetService.safeDIBuilder ?? WidgetService.init(config:))(config)
 		                }
 		                let widgetService: WidgetService = __safeDI_widgetService()
-		                return (safeDIParameters.parent.grandchild.safeDIBuilder ?? Grandchild.init(widgetService:))(widgetService)
+		                return (safeDIOverrides.parent.grandchild.safeDIBuilder ?? Grandchild.init(widgetService:))(widgetService)
 		            }
 		            let grandchild: Grandchild = __safeDI_grandchild()
-		            return (safeDIParameters.parent.safeDIBuilder ?? Parent.init(grandchild:))(grandchild)
+		            return (safeDIOverrides.parent.safeDIBuilder ?? Parent.init(grandchild:))(grandchild)
 		        }
 		        let parent: Parent = __safeDI_parent()
 		        func __safeDI_widgetService() -> WidgetService {
-		            let config = (safeDIParameters.widgetService.config ?? Config.init)()
-		            return (safeDIParameters.widgetService.safeDIBuilder ?? WidgetService.init(config:))(config)
+		            let config = (safeDIOverrides.widgetService.config ?? Config.init)()
+		            return (safeDIOverrides.widgetService.safeDIBuilder ?? WidgetService.init(config:))(config)
 		        }
 		        let widgetService: WidgetService = __safeDI_widgetService()
 		        return Root(parent: parent, widgetService: widgetService)
@@ -7738,7 +7862,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: ((String) -> Child)? = nil,
 		            parent: ((Instantiator<Child>) -> Parent)? = nil
@@ -7752,15 +7877,15 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childBuilder(name: String) -> Child {
-		            (safeDIParameters.childBuilder ?? Child.init(name:))(name)
+		            (safeDIOverrides.childBuilder ?? Child.init(name:))(name)
 		        }
 		        let childBuilder = Instantiator<Child> {
 		            __safeDI_childBuilder(name: $0)
 		        }
-		        let parent = (safeDIParameters.parent ?? Parent.init(childBuilder:))(childBuilder)
+		        let parent = (safeDIOverrides.parent ?? Parent.init(childBuilder:))(childBuilder)
 		        return Root(parent: parent, childBuilder: childBuilder)
 		    }
 		}
@@ -7823,7 +7948,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -7834,12 +7960,12 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            let localService = (safeDIParameters.child.localService ?? LocalService.init)()
-		            let crossModuleService = (safeDIParameters.child.crossModuleService ?? CrossModuleService.init)()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(localService:crossModuleService:))(localService, crossModuleService)
+		            let localService = (safeDIOverrides.child.localService ?? LocalService.init)()
+		            let crossModuleService = (safeDIOverrides.child.crossModuleService ?? CrossModuleService.init)()
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(localService:crossModuleService:))(localService, crossModuleService)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -7901,7 +8027,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            dependentService: ((ParallelModuleType) -> DependentService)? = nil
 		        ) {
@@ -7913,9 +8040,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        parallelModuleType: ParallelModuleType,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let dependentService = (safeDIParameters.dependentService ?? DependentService.init(parallelModuleType:))(parallelModuleType)
+		        let dependentService = (safeDIOverrides.dependentService ?? DependentService.init(parallelModuleType:))(parallelModuleType)
 		        return Root(dependentService: dependentService)
 		    }
 		}
@@ -7981,7 +8108,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -7993,15 +8121,15 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        service: ExternalService,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
 		            func __safeDI_grandchild() -> Grandchild {
-		                let service = (safeDIParameters.child.grandchild.service ?? LocalService.init)()
-		                return (safeDIParameters.child.grandchild.safeDIBuilder ?? Grandchild.init(service:))(service)
+		                let service = (safeDIOverrides.child.grandchild.service ?? LocalService.init)()
+		                return (safeDIOverrides.child.grandchild.safeDIBuilder ?? Grandchild.init(service:))(service)
 		            }
 		            let grandchild: Grandchild = __safeDI_grandchild()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(grandchild:service:))(grandchild, service)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(grandchild:service:))(grandchild, service)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -8061,7 +8189,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> SharedThing)? = nil,
 		            parentBuilder: ((String, SharedThing) -> Parent)? = nil
@@ -8075,11 +8204,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let shared = (safeDIParameters.shared ?? SharedThing.init)()
+		        let shared = (safeDIOverrides.shared ?? SharedThing.init)()
 		        func __safeDI_parentBuilder(name: String) -> Parent {
-		            (safeDIParameters.parentBuilder ?? Parent.init(name:shared:))(name, shared)
+		            (safeDIOverrides.parentBuilder ?? Parent.init(name:shared:))(name, shared)
 		        }
 		        let parentBuilder = Instantiator<Parent> {
 		            __safeDI_parentBuilder(name: $0)
@@ -8141,7 +8270,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: ((String) -> Item)? = nil,
 		            wrapper: ((Instantiator<Item>) -> ThirdPartyWrapper)? = nil
@@ -8155,15 +8285,15 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childBuilder(name: String) -> Item {
-		            (safeDIParameters.childBuilder ?? Item.init(name:))(name)
+		            (safeDIOverrides.childBuilder ?? Item.init(name:))(name)
 		        }
 		        let childBuilder = Instantiator<Item> {
 		            __safeDI_childBuilder(name: $0)
 		        }
-		        let wrapper = (safeDIParameters.wrapper ?? ThirdPartyWrapper.instantiate(childBuilder:))(childBuilder)
+		        let wrapper = (safeDIOverrides.wrapper ?? ThirdPartyWrapper.instantiate(childBuilder:))(childBuilder)
 		        return Root(childBuilder: childBuilder, wrapper: wrapper)
 		    }
 		}
@@ -8236,7 +8366,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childABuilder: ChildA.SafeDIMockConfiguration = .init(),
 		            shared: (() -> Shared)? = nil,
@@ -8253,18 +8384,18 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childABuilder(name: String) -> ChildA {
-		            let shared = (safeDIParameters.childABuilder.shared ?? Shared.init)()
-		            return (safeDIParameters.childABuilder.safeDIBuilder ?? ChildA.init(shared:name:))(shared, name)
+		            let shared = (safeDIOverrides.childABuilder.shared ?? Shared.init)()
+		            return (safeDIOverrides.childABuilder.safeDIBuilder ?? ChildA.init(shared:name:))(shared, name)
 		        }
 		        let childABuilder = Instantiator<ChildA> {
 		            __safeDI_childABuilder(name: $0)
 		        }
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        func __safeDI_childBBuilder(name: String) -> ChildB {
-		            (safeDIParameters.childBBuilder ?? ChildB.init(shared:name:))(shared, name)
+		            (safeDIOverrides.childBBuilder ?? ChildB.init(shared:name:))(shared, name)
 		        }
 		        let childBBuilder = Instantiator<ChildB> {
 		            __safeDI_childBBuilder(name: $0)
@@ -8335,7 +8466,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil,
 		            child: Child.SafeDIMockConfiguration = .init()
@@ -8349,17 +8481,17 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        func __safeDI_child() -> Child {
 		            func __safeDI_grandchildBuilder(name: String) -> Grandchild {
-		                (safeDIParameters.child.grandchildBuilder ?? Grandchild.init(shared:name:))(shared, name)
+		                (safeDIOverrides.child.grandchildBuilder ?? Grandchild.init(shared:name:))(shared, name)
 		            }
 		            let grandchildBuilder = Instantiator<Grandchild> {
 		                __safeDI_grandchildBuilder(name: $0)
 		            }
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(grandchildBuilder:))(grandchildBuilder)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(grandchildBuilder:))(grandchildBuilder)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(shared: shared, child: child)
@@ -8430,7 +8562,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            builderA: ChildA.SafeDIMockConfiguration = .init(),
 		            shared: (() -> Shared)? = nil,
@@ -8447,18 +8580,18 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_builderA(name: String) -> ChildA {
-		            let shared = (safeDIParameters.builderA.shared ?? Shared.init)()
-		            return (safeDIParameters.builderA.safeDIBuilder ?? ChildA.init(shared:name:))(shared, name)
+		            let shared = (safeDIOverrides.builderA.shared ?? Shared.init)()
+		            return (safeDIOverrides.builderA.safeDIBuilder ?? ChildA.init(shared:name:))(shared, name)
 		        }
 		        let builderA = Instantiator<ChildA> {
 		            __safeDI_builderA(name: $0)
 		        }
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        func __safeDI_builderB(name: String) -> ChildB {
-		            (safeDIParameters.builderB ?? ChildB.init(shared:name:))(shared, name)
+		            (safeDIOverrides.builderB ?? ChildB.init(shared:name:))(shared, name)
 		        }
 		        let builderB = Instantiator<ChildB> {
 		            __safeDI_builderB(name: $0)
@@ -8535,7 +8668,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
 		            shared: (() -> Shared)? = nil,
@@ -8552,22 +8686,22 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childA() -> ChildA {
-		            let shared = (safeDIParameters.childA.shared ?? Shared.init)()
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.init(shared:))(shared)
+		            let shared = (safeDIOverrides.childA.shared ?? Shared.init)()
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.init(shared:))(shared)
 		        }
 		        let childA: ChildA = __safeDI_childA()
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        func __safeDI_childB() -> ChildB {
 		            func __safeDI_grandchildBuilder(name: String) -> Grandchild {
-		                (safeDIParameters.childB.grandchildBuilder ?? Grandchild.init(shared:name:))(shared, name)
+		                (safeDIOverrides.childB.grandchildBuilder ?? Grandchild.init(shared:name:))(shared, name)
 		            }
 		            let grandchildBuilder = Instantiator<Grandchild> {
 		                __safeDI_grandchildBuilder(name: $0)
 		            }
-		            return (safeDIParameters.childB.safeDIBuilder ?? ChildB.init(grandchildBuilder:))(grandchildBuilder)
+		            return (safeDIOverrides.childB.safeDIBuilder ?? ChildB.init(grandchildBuilder:))(grandchildBuilder)
 		        }
 		        let childB: ChildB = __safeDI_childB()
 		        return Root(childA: childA, childB: childB)
@@ -8640,7 +8774,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            serviceA: ServiceA.SafeDIMockConfiguration = .init(),
 		            serviceB: (() -> ServiceB)? = nil,
@@ -8657,22 +8792,22 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_serviceA() -> ServiceA {
-		            let serviceB = (safeDIParameters.serviceA.serviceB ?? ServiceB.init)()
-		            return (safeDIParameters.serviceA.safeDIBuilder ?? ServiceA.init(serviceB:))(serviceB)
+		            let serviceB = (safeDIOverrides.serviceA.serviceB ?? ServiceB.init)()
+		            return (safeDIOverrides.serviceA.safeDIBuilder ?? ServiceA.init(serviceB:))(serviceB)
 		        }
 		        let serviceA: ServiceA = __safeDI_serviceA()
-		        let serviceB = (safeDIParameters.serviceB ?? ServiceB.init)()
+		        let serviceB = (safeDIOverrides.serviceB ?? ServiceB.init)()
 		        func __safeDI_child() -> Child {
 		            func __safeDI_grandchildBuilder(name: String) -> Grandchild {
-		                (safeDIParameters.child.grandchildBuilder ?? Grandchild.init(serviceA:serviceB:name:))(serviceA, serviceB, name)
+		                (safeDIOverrides.child.grandchildBuilder ?? Grandchild.init(serviceA:serviceB:name:))(serviceA, serviceB, name)
 		            }
 		            let grandchildBuilder = Instantiator<Grandchild> {
 		                __safeDI_grandchildBuilder(name: $0)
 		            }
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(grandchildBuilder:))(grandchildBuilder)
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(grandchildBuilder:))(grandchildBuilder)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Root(child: child)
@@ -8754,7 +8889,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            shared: (() -> Shared)? = nil,
 		            childA: ChildA.SafeDIMockConfiguration = .init(),
@@ -8771,26 +8907,26 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let shared = (safeDIParameters.shared ?? Shared.init)()
+		        let shared = (safeDIOverrides.shared ?? Shared.init)()
 		        func __safeDI_childA() -> ChildA {
 		            func __safeDI_grandchild() -> Grandchild {
 		                func __safeDI_greatGrandchildBuilder(name: String) -> GreatGrandchild {
-		                    (safeDIParameters.childA.grandchild.greatGrandchildBuilder ?? GreatGrandchild.init(shared:name:))(shared, name)
+		                    (safeDIOverrides.childA.grandchild.greatGrandchildBuilder ?? GreatGrandchild.init(shared:name:))(shared, name)
 		                }
 		                let greatGrandchildBuilder = Instantiator<GreatGrandchild> {
 		                    __safeDI_greatGrandchildBuilder(name: $0)
 		                }
-		                return (safeDIParameters.childA.grandchild.safeDIBuilder ?? Grandchild.init(greatGrandchildBuilder:))(greatGrandchildBuilder)
+		                return (safeDIOverrides.childA.grandchild.safeDIBuilder ?? Grandchild.init(greatGrandchildBuilder:))(greatGrandchildBuilder)
 		            }
 		            let grandchild: Grandchild = __safeDI_grandchild()
-		            return (safeDIParameters.childA.safeDIBuilder ?? ChildA.init(grandchild:))(grandchild)
+		            return (safeDIOverrides.childA.safeDIBuilder ?? ChildA.init(grandchild:))(grandchild)
 		        }
 		        let childA: ChildA = __safeDI_childA()
 		        func __safeDI_childB() -> ChildB {
-		            let shared = (safeDIParameters.childB.shared ?? Shared.init)()
-		            return (safeDIParameters.childB.safeDIBuilder ?? ChildB.init(shared:))(shared)
+		            let shared = (safeDIOverrides.childB.shared ?? Shared.init)()
+		            return (safeDIOverrides.childB.safeDIBuilder ?? ChildB.init(shared:))(shared)
 		        }
 		        let childB: ChildB = __safeDI_childB()
 		        return Root(childA: childA, childB: childB)
@@ -8857,7 +8993,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil,
 		            childA: ((Service) -> ChildA)? = nil,
@@ -8874,11 +9011,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service = (safeDIParameters.service ?? Service.init)()
-		        let childA = (safeDIParameters.childA ?? ChildA.init(service:))(service)
-		        let childB = (safeDIParameters.childB ?? ChildB.init(service:))(service)
+		        let service = (safeDIOverrides.service ?? Service.init)()
+		        let childA = (safeDIOverrides.childA ?? ChildA.init(service:))(service)
+		        let childB = (safeDIOverrides.childB ?? ChildB.init(service:))(service)
 		        return Root(childA: childA, childB: childB)
 		    }
 		}
@@ -9186,7 +9323,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil,
 		            flowVC: FlowVC.SafeDIMockConfiguration = .init()
@@ -9200,18 +9338,18 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service = (safeDIParameters.service ?? Service.init)()
+		        let service = (safeDIOverrides.service ?? Service.init)()
 		        func __safeDI_flowVC() -> FlowVC {
 		            func __safeDI_childBuilder(name: String) -> Child {
-		                (safeDIParameters.flowVC.childBuilder ?? Child.init(service:name:))(service, name)
+		                (safeDIOverrides.flowVC.childBuilder ?? Child.init(service:name:))(service, name)
 		            }
 		            let childBuilder = Instantiator<Child> {
 		                __safeDI_childBuilder(name: $0)
 		            }
-		            let presenter = (safeDIParameters.flowVC.presenter ?? Presenter.init(service:))(service)
-		            return (safeDIParameters.flowVC.safeDIBuilder ?? FlowVC.init(service:childBuilder:presenter:))(service, childBuilder, presenter)
+		            let presenter = (safeDIOverrides.flowVC.presenter ?? Presenter.init(service:))(service)
+		            return (safeDIOverrides.flowVC.safeDIBuilder ?? FlowVC.init(service:childBuilder:presenter:))(service, childBuilder, presenter)
 		        }
 		        let flowVC: FlowVC = __safeDI_flowVC()
 		        return Root(service: service, flowVC: flowVC)
@@ -9332,7 +9470,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            aBuilder: ((Root) -> A)? = nil
 		        ) {
@@ -9343,10 +9482,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_aBuilder(root: Root) -> A {
-		            (safeDIParameters.aBuilder ?? A.init(root:))(root)
+		            (safeDIOverrides.aBuilder ?? A.init(root:))(root)
 		        }
 		        let aBuilder = Instantiator<A> {
 		            __safeDI_aBuilder(root: $0)
@@ -9412,7 +9551,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            aBuilder: A.SafeDIMockConfiguration = .init()
 		        ) {
@@ -9423,19 +9563,19 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_aBuilder() -> A {
 		            func __safeDI_bBuilder() -> B {
 		                func __safeDI_cBuilder() -> C {
 		                    let aBuilder = Instantiator<A>(__safeDI_aBuilder)
-		                    return (safeDIParameters.aBuilder.bBuilder.cBuilder.safeDIBuilder ?? C.init(aBuilder:))(aBuilder)
+		                    return (safeDIOverrides.aBuilder.bBuilder.cBuilder.safeDIBuilder ?? C.init(aBuilder:))(aBuilder)
 		                }
 		                let cBuilder = Instantiator<C>(__safeDI_cBuilder)
-		                return (safeDIParameters.aBuilder.bBuilder.safeDIBuilder ?? B.init(cBuilder:))(cBuilder)
+		                return (safeDIOverrides.aBuilder.bBuilder.safeDIBuilder ?? B.init(cBuilder:))(cBuilder)
 		            }
 		            let bBuilder = Instantiator<B>(__safeDI_bBuilder)
-		            return (safeDIParameters.aBuilder.safeDIBuilder ?? A.init(bBuilder:))(bBuilder)
+		            return (safeDIOverrides.aBuilder.safeDIBuilder ?? A.init(bBuilder:))(bBuilder)
 		        }
 		        let aBuilder = Instantiator<A>(__safeDI_aBuilder)
 		        return Root(aBuilder: aBuilder)
@@ -9485,7 +9625,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            aBuilder: A.SafeDIMockConfiguration = .init()
 		        ) {
@@ -9496,13 +9637,13 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_aBuilder(context: String) -> A {
 		            let aBuilder = Instantiator<A> {
 		                __safeDI_aBuilder(context: $0)
 		            }
-		            return (safeDIParameters.aBuilder.safeDIBuilder ?? A.init(aBuilder:context:))(aBuilder, context)
+		            return (safeDIOverrides.aBuilder.safeDIBuilder ?? A.init(aBuilder:context:))(aBuilder, context)
 		        }
 		        let aBuilder = Instantiator<A> {
 		            __safeDI_aBuilder(context: $0)
@@ -9615,7 +9756,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            childBuilder: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -9626,11 +9768,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_childBuilder(configuration: Configuration) -> Child {
-		            let presenter = (safeDIParameters.childBuilder.presenter ?? Presenter.init(configuration:))(configuration)
-		            return (safeDIParameters.childBuilder.safeDIBuilder ?? Child.init(configuration:presenter:))(configuration, presenter)
+		            let presenter = (safeDIOverrides.childBuilder.presenter ?? Presenter.init(configuration:))(configuration)
+		            return (safeDIOverrides.childBuilder.safeDIBuilder ?? Child.init(configuration:presenter:))(configuration, presenter)
 		        }
 		        let childBuilder = Instantiator<Child> {
 		            __safeDI_childBuilder(configuration: $0)
@@ -9698,7 +9840,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil,
 		            selfBuilder: Child.SafeDIMockConfiguration = .init()
@@ -9712,12 +9855,12 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
-		        let service = (safeDIParameters.service ?? Service.init)()
+		        let service = (safeDIOverrides.service ?? Service.init)()
 		        func __safeDI_selfBuilder() -> Child {
 		            let selfBuilder = Instantiator<Child>(__safeDI_selfBuilder)
-		            return (safeDIParameters.selfBuilder.safeDIBuilder ?? Child.init(selfBuilder:service:))(selfBuilder, service)
+		            return (safeDIOverrides.selfBuilder.safeDIBuilder ?? Child.init(selfBuilder:service:))(selfBuilder, service)
 		        }
 		        let selfBuilder = Instantiator<Child>(__safeDI_selfBuilder)
 		        return Child(selfBuilder: selfBuilder, service: service)
@@ -9727,6 +9870,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            _ safeDIBuilder: ((Instantiator<Child>, Service) -> Child)? = nil
@@ -9734,6 +9878,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		            self.safeDIBuilder = safeDIBuilder
 		        }
 
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((Instantiator<Child>, Service) -> Child)?
 		    }
 		}
@@ -9747,7 +9892,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil,
 		            childBuilder: Child.SafeDIMockConfiguration = .init()
@@ -9761,16 +9907,16 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service = (safeDIParameters.service ?? Service.init)()
+		        let service = (safeDIOverrides.service ?? Service.init)()
 		        func __safeDI_childBuilder() -> Child {
 		            func __safeDI_selfBuilder() -> Child {
 		                let selfBuilder = Instantiator<Child>(__safeDI_selfBuilder)
 		                return Child.init(selfBuilder:service:)(selfBuilder, service)
 		            }
 		            let selfBuilder = Instantiator<Child>(__safeDI_selfBuilder)
-		            return (safeDIParameters.childBuilder.safeDIBuilder ?? Child.init(selfBuilder:service:))(selfBuilder, service)
+		            return (safeDIOverrides.childBuilder.safeDIBuilder ?? Child.init(selfBuilder:service:))(selfBuilder, service)
 		        }
 		        let childBuilder = Instantiator<Child>(__safeDI_childBuilder)
 		        return Root(service: service, childBuilder: childBuilder)
@@ -9857,7 +10003,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil
 		        ) {
@@ -9869,9 +10016,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        flag: Bool = false,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
-		        let service = (safeDIParameters.service ?? Service.init)()
+		        let service = (safeDIOverrides.service ?? Service.init)()
 		        return Child.customMock(service: service, flag: flag)
 		    }
 		}
@@ -9885,7 +10032,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil,
 		            childBuilder: ((Service, Bool) -> Child)? = nil
@@ -9899,11 +10047,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service = (safeDIParameters.service ?? Service.init)()
+		        let service = (safeDIOverrides.service ?? Service.init)()
 		        func __safeDI_childBuilder(flag: Bool) -> Child {
-		            (safeDIParameters.childBuilder ?? Child.customMock(service:flag:))(service, flag)
+		            (safeDIOverrides.childBuilder ?? Child.customMock(service:flag:))(service, flag)
 		        }
 		        let childBuilder = Instantiator<Child> {
 		            __safeDI_childBuilder(flag: $0)
@@ -9996,7 +10144,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Player {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            cachedPlayerBuilder: ((Player) -> CachedPlayer)? = nil
 		        ) {
@@ -10007,10 +10156,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Player {
 		        func __safeDI_cachedPlayerBuilder(player: Player) -> CachedPlayer {
-		            (safeDIParameters.cachedPlayerBuilder ?? CachedPlayer.init(player:))(player)
+		            (safeDIOverrides.cachedPlayerBuilder ?? CachedPlayer.init(player:))(player)
 		        }
 		        let cachedPlayerBuilder = Instantiator<CachedPlayer> {
 		            __safeDI_cachedPlayerBuilder(player: $0)
@@ -10022,6 +10171,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Player {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            cachedPlayerBuilder: ((Player) -> CachedPlayer)? = nil,
@@ -10032,6 +10182,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let cachedPlayerBuilder: ((Player) -> CachedPlayer)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((Instantiator<CachedPlayer>) -> Player)?
 		    }
 		}
@@ -10045,7 +10196,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            player: Player.SafeDIMockConfiguration = .init()
 		        ) {
@@ -10056,16 +10208,16 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_player() -> Player {
 		            func __safeDI_cachedPlayerBuilder(player: Player) -> CachedPlayer {
-		                (safeDIParameters.player.cachedPlayerBuilder ?? CachedPlayer.init(player:))(player)
+		                (safeDIOverrides.player.cachedPlayerBuilder ?? CachedPlayer.init(player:))(player)
 		            }
 		            let cachedPlayerBuilder = Instantiator<CachedPlayer> {
 		                __safeDI_cachedPlayerBuilder(player: $0)
 		            }
-		            return (safeDIParameters.player.safeDIBuilder ?? Player.init(cachedPlayerBuilder:))(cachedPlayerBuilder)
+		            return (safeDIOverrides.player.safeDIBuilder ?? Player.init(cachedPlayerBuilder:))(cachedPlayerBuilder)
 		        }
 		        let player: Player = __safeDI_player()
 		        return Root(player: player)
@@ -10147,7 +10299,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension OptionalChild {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: Service? = nil
 		        ) {
@@ -10158,9 +10311,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> OptionalChild {
-		        let service: Service? = safeDIParameters.service
+		        let service: Service? = safeDIOverrides.service
 		        return OptionalChild(service: service)
 		    }
 		}
@@ -10174,7 +10327,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil,
 		            optionalChild: ((Service?) -> OptionalChild)? = nil,
@@ -10191,11 +10345,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let service = (safeDIParameters.service ?? Service.init)()
-		        let optionalChild = (safeDIParameters.optionalChild ?? OptionalChild.init(service:))(service)
-		        let requiredChild = (safeDIParameters.requiredChild ?? RequiredChild.init(service:))(service)
+		        let service = (safeDIOverrides.service ?? Service.init)()
+		        let optionalChild = (safeDIOverrides.optionalChild ?? OptionalChild.init(service:))(service)
+		        let requiredChild = (safeDIOverrides.requiredChild ?? RequiredChild.init(service:))(service)
 		        return Parent(optionalChild: optionalChild, requiredChild: requiredChild)
 		    }
 		}
@@ -10203,6 +10357,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            optionalChild: ((Service?) -> OptionalChild)? = nil,
@@ -10216,6 +10371,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		        let optionalChild: ((Service?) -> OptionalChild)?
 		        let requiredChild: ((Service) -> RequiredChild)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((OptionalChild, RequiredChild) -> Parent)?
 		    }
 		}
@@ -10229,7 +10385,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension RequiredChild {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil
 		        ) {
@@ -10240,9 +10397,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> RequiredChild {
-		        let service = (safeDIParameters.service ?? Service.init)()
+		        let service = (safeDIOverrides.service ?? Service.init)()
 		        return RequiredChild(service: service)
 		    }
 		}
@@ -10256,7 +10413,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            service: (() -> Service)? = nil,
 		            parent: Parent.SafeDIMockConfiguration = .init()
@@ -10270,13 +10428,13 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let service = (safeDIParameters.service ?? Service.init)()
+		        let service = (safeDIOverrides.service ?? Service.init)()
 		        func __safeDI_parent() -> Parent {
-		            let optionalChild = (safeDIParameters.parent.optionalChild ?? OptionalChild.init(service:))(service)
-		            let requiredChild = (safeDIParameters.parent.requiredChild ?? RequiredChild.init(service:))(service)
-		            return (safeDIParameters.parent.safeDIBuilder ?? Parent.init(optionalChild:requiredChild:))(optionalChild, requiredChild)
+		            let optionalChild = (safeDIOverrides.parent.optionalChild ?? OptionalChild.init(service:))(service)
+		            let requiredChild = (safeDIOverrides.parent.requiredChild ?? RequiredChild.init(service:))(service)
+		            return (safeDIOverrides.parent.safeDIBuilder ?? Parent.init(optionalChild:requiredChild:))(optionalChild, requiredChild)
 		        }
 		        let parent: Parent = __safeDI_parent()
 		        return Root(service: service, parent: parent)
@@ -10361,7 +10519,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            factory: Parent.SafeDIMockConfiguration = .init()
 		        ) {
@@ -10372,10 +10531,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let __safeDI_factory__factory_service_safeDIBuilder = safeDIParameters.factory.service ?? ConcreteService.init
-		        let __safeDI_factory__safeDIBuilder = safeDIParameters.factory.safeDIBuilder ?? Parent.init(service:name:)
+		        let __safeDI_factory__factory_service_safeDIBuilder = safeDIOverrides.factory.service ?? ConcreteService.init
+		        let __safeDI_factory__safeDIBuilder = safeDIOverrides.factory.safeDIBuilder ?? Parent.init(service:name:)
 		        @Sendable func __safeDI_factory(name: String) -> Parent {
 		            let service: AnyService = AnyService(__safeDI_factory__factory_service_safeDIBuilder())
 		            return __safeDI_factory__safeDIBuilder(service, name)
@@ -10447,7 +10606,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init(),
 		            factory: Parent.SafeDIMockConfiguration = .init()
@@ -10461,16 +10621,16 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
 		        func __safeDI_child() -> Child {
-		            let leaf = (safeDIParameters.child.leaf ?? Leaf.init)()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(leaf:))(leaf)
+		            let leaf = (safeDIOverrides.child.leaf ?? Leaf.init)()
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(leaf:))(leaf)
 		        }
 		        let child: Child = __safeDI_child()
-		        let __safeDI_factory__factory_child_safeDIBuilder = safeDIParameters.factory.child.safeDIBuilder ?? Child.init(leaf:)
-		        let __safeDI_factory__factory_child_leaf_safeDIBuilder = safeDIParameters.factory.child.leaf ?? Leaf.init
-		        let __safeDI_factory__safeDIBuilder = safeDIParameters.factory.safeDIBuilder ?? Parent.init(child:name:)
+		        let __safeDI_factory__factory_child_safeDIBuilder = safeDIOverrides.factory.child.safeDIBuilder ?? Child.init(leaf:)
+		        let __safeDI_factory__factory_child_leaf_safeDIBuilder = safeDIOverrides.factory.child.leaf ?? Leaf.init
+		        let __safeDI_factory__safeDIBuilder = safeDIOverrides.factory.safeDIBuilder ?? Parent.init(child:name:)
 		        @Sendable func __safeDI_factory(name: String) -> Parent {
 		            func __safeDI_child() -> Child {
 		                let leaf = __safeDI_factory__factory_child_leaf_safeDIBuilder()
@@ -10495,7 +10655,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init()
 		        ) {
@@ -10507,11 +10668,11 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        name: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
 		        func __safeDI_child() -> Child {
-		            let leaf = (safeDIParameters.child.leaf ?? Leaf.init)()
-		            return (safeDIParameters.child.safeDIBuilder ?? Child.init(leaf:))(leaf)
+		            let leaf = (safeDIOverrides.child.leaf ?? Leaf.init)()
+		            return (safeDIOverrides.child.safeDIBuilder ?? Child.init(leaf:))(leaf)
 		        }
 		        let child: Child = __safeDI_child()
 		        return Parent(child: child, name: name)
@@ -10521,6 +10682,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            child: Child.SafeDIMockConfiguration = .init(),
@@ -10531,6 +10693,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let child: Child.SafeDIMockConfiguration
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: (@Sendable (Child, String) -> Parent)?
 		    }
 		}
@@ -10544,7 +10707,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            leaf: (() -> Leaf)? = nil
 		        ) {
@@ -10555,9 +10719,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Child {
-		        let leaf = (safeDIParameters.leaf ?? Leaf.init)()
+		        let leaf = (safeDIOverrides.leaf ?? Leaf.init)()
 		        return Child(leaf: leaf)
 		    }
 		}
@@ -10565,6 +10729,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Child {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            leaf: (() -> Leaf)? = nil,
@@ -10575,6 +10740,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let leaf: (() -> Leaf)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: ((Leaf) -> Child)?
 		    }
 		}
@@ -10645,7 +10811,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            outerFactory: Parent.SafeDIMockConfiguration = .init()
 		        ) {
@@ -10656,10 +10823,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let __safeDI_outerFactory__outerFactory_innerFactory_safeDIBuilder = safeDIParameters.outerFactory.innerFactory ?? Leaf.init(id:)
-		        let __safeDI_outerFactory__safeDIBuilder = safeDIParameters.outerFactory.safeDIBuilder ?? Parent.init(innerFactory:name:)
+		        let __safeDI_outerFactory__outerFactory_innerFactory_safeDIBuilder = safeDIOverrides.outerFactory.innerFactory ?? Leaf.init(id:)
+		        let __safeDI_outerFactory__safeDIBuilder = safeDIOverrides.outerFactory.safeDIBuilder ?? Parent.init(innerFactory:name:)
 		        @Sendable func __safeDI_outerFactory(name: String) -> Parent {
 		            let __safeDI_innerFactory__safeDIBuilder = __safeDI_outerFactory__outerFactory_innerFactory_safeDIBuilder
 		            @Sendable func __safeDI_innerFactory(id: Int) -> Leaf {
@@ -10686,7 +10853,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            innerFactory: (@Sendable (Int) -> Leaf)? = nil
 		        ) {
@@ -10698,9 +10866,9 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        name: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
-		        let __safeDI_innerFactory__safeDIBuilder = safeDIParameters.innerFactory ?? Leaf.init(id:)
+		        let __safeDI_innerFactory__safeDIBuilder = safeDIOverrides.innerFactory ?? Leaf.init(id:)
 		        @Sendable func __safeDI_innerFactory(id: Int) -> Leaf {
 		            __safeDI_innerFactory__safeDIBuilder(id)
 		        }
@@ -10714,6 +10882,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            innerFactory: (@Sendable (Int) -> Leaf)? = nil,
@@ -10724,6 +10893,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let innerFactory: (@Sendable (Int) -> Leaf)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: (@Sendable (SendableInstantiator<Leaf>, String) -> Parent)?
 		    }
 		}
@@ -10796,7 +10966,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Root {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            outerFactory: Parent.SafeDIMockConfiguration = .init()
 		        ) {
@@ -10807,10 +10978,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		    }
 
 		    static func mock(
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Root {
-		        let __safeDI_outerFactory__outerFactory_innerFactory_safeDIBuilder = safeDIParameters.outerFactory.innerFactory ?? Leaf.init(id:)
-		        let __safeDI_outerFactory__safeDIBuilder = safeDIParameters.outerFactory.safeDIBuilder ?? Parent.init(innerFactory:name:)
+		        let __safeDI_outerFactory__outerFactory_innerFactory_safeDIBuilder = safeDIOverrides.outerFactory.innerFactory ?? Leaf.init(id:)
+		        let __safeDI_outerFactory__safeDIBuilder = safeDIOverrides.outerFactory.safeDIBuilder ?? Parent.init(innerFactory:name:)
 		        @Sendable func __safeDI_outerFactory(name: String) -> Parent {
 		            func __safeDI_innerFactory(id: Int) -> Leaf {
 		                __safeDI_outerFactory__outerFactory_innerFactory_safeDIBuilder(id)
@@ -10836,7 +11007,8 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
-		    struct SafeDIParameters {
+		    /// Overrides for the mock dependency tree.
+		    struct SafeDIOverrides {
 		        init(
 		            innerFactory: ((Int) -> Leaf)? = nil
 		        ) {
@@ -10848,10 +11020,10 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		    static func mock(
 		        name: String,
-		        safeDIParameters: SafeDIParameters = .init()
+		        safeDIOverrides: SafeDIOverrides = .init()
 		    ) -> Parent {
 		        func __safeDI_innerFactory(id: Int) -> Leaf {
-		            (safeDIParameters.innerFactory ?? Leaf.init(id:))(id)
+		            (safeDIOverrides.innerFactory ?? Leaf.init(id:))(id)
 		        }
 		        let innerFactory = Instantiator<Leaf> {
 		            __safeDI_innerFactory(id: $0)
@@ -10863,6 +11035,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 
 		#if DEBUG
 		extension Parent {
+		    /// Configuration for how this type is constructed within a mock tree.
 		    struct SafeDIMockConfiguration {
 		        init(
 		            innerFactory: (@Sendable (Int) -> Leaf)? = nil,
@@ -10873,6 +11046,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 		        }
 
 		        let innerFactory: (@Sendable (Int) -> Leaf)?
+		        /// Overrides how this type is constructed. Parameters match the type's initializer or custom mock method. When `nil`, the default generated construction function is used.
 		        let safeDIBuilder: (@Sendable (Instantiator<Leaf>, String) -> Parent)?
 		    }
 		}


### PR DESCRIPTION
## Summary
- Renames `SafeDIParameters` → `SafeDIOverrides` (type and `safeDIOverrides:` argument label) so the generated type name communicates its purpose: overriding defaults in the mock dependency tree
- Adds `///` doc comments to generated `SafeDIOverrides`, `SafeDIMockConfiguration`, and `safeDIBuilder` so users get useful autocomplete tooltips
- Adds missing `additionalMocksToGenerate` to the `#SafeDIConfiguration` source doc comment
- Expands manual documentation for `safeDIBuilder` to explain it overrides/customizes how a type is constructed, with parameters matching init or custom mock method

## Test plan
- [x] All 742 tests pass
- [x] SwiftFormat lint passes
- [x] Verify generated output in a real project uses `SafeDIOverrides` and shows doc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)