### PR TITLE
Add package resolution retry to all CI jobs

### DIFF
--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -1,0 +1,29 @@
+name: Retry
+description: Run a command with retries and delay between attempts.
+
+inputs:
+  command:
+    description: The command to run.
+    required: true
+  attempts:
+    description: Maximum number of attempts.
+    default: '3'
+  delay:
+    description: Seconds to wait between retries.
+    default: '10'
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        for attempt in $(seq 1 ${{ inputs.attempts }}); do
+          ${{ inputs.command }} && break
+          if [ $attempt -lt ${{ inputs.attempts }} ]; then
+            echo "Attempt $attempt failed, retrying in ${{ inputs.delay }}s..."
+            sleep ${{ inputs.delay }}
+          else
+            echo "All ${{ inputs.attempts }} attempts failed"
+            exit 1
+          fi
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
           sudo xcrun simctl list
           PLATFORM=$(echo "${{ matrix.platforms }}" | sed 's|generic/platform=||')
           sudo xcodebuild -downloadPlatform "$PLATFORM"
+      - name: Resolve Package Dependencies
+        uses: ./.github/actions/retry
+        with:
+          command: xcrun xcodebuild -resolvePackageDependencies -skipPackagePluginValidation -skipMacroValidation -scheme SafeDI-Package
       - name: Build Framework
         run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination ${{ matrix.platforms }}
 
@@ -69,6 +73,10 @@ jobs:
         uses: actions/checkout@v6
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
+      - name: Resolve Package Dependencies
+        uses: ./.github/actions/retry
+        with:
+          command: xcrun swift package resolve --package-path "Examples/Example Package Integration"
       - name: Build Package Integration
         run: xcrun swift build --package-path "Examples/Example Package Integration"
 
@@ -85,6 +93,10 @@ jobs:
       - name: Replace 'main' branch with the current branch
         if: github.event.pull_request.head.repo.full_name == github.repository # Only do this if the branch is from our repo.
         run: sed -i '' "s#branch = main;#branch = ${{ github.head_ref || github.ref_name }};#" "Examples/ExampleProjectIntegration/ExampleProjectIntegration.xcodeproj/project.pbxproj"
+      - name: Resolve Package Dependencies
+        uses: ./.github/actions/retry
+        with:
+          command: pushd Examples/ExampleProjectIntegration && xcrun xcodebuild -resolvePackageDependencies -skipPackagePluginValidation -skipMacroValidation -scheme ExampleProjectIntegration && popd
       - name: Build Project Integration
         run: pushd Examples/ExampleProjectIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExampleProjectIntegration; popd
 
@@ -101,6 +113,10 @@ jobs:
       - name: Replace 'main' branch with the current branch
         if: github.event.pull_request.head.repo.full_name == github.repository # Only do this if the branch is from our repo.
         run: sed -i '' "s#branch = main;#branch = ${{ github.head_ref || github.ref_name }};#" "Examples/ExampleMultiProjectIntegration/ExampleMultiProjectIntegration.xcodeproj/project.pbxproj"
+      - name: Resolve Package Dependencies
+        uses: ./.github/actions/retry
+        with:
+          command: pushd Examples/ExampleMultiProjectIntegration && xcrun xcodebuild -resolvePackageDependencies -skipPackagePluginValidation -skipMacroValidation -scheme ExampleMultiProjectIntegration && popd
       - name: Build Project Integration
         run: pushd Examples/ExampleMultiProjectIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExampleMultiProjectIntegration; popd
 
@@ -114,6 +130,10 @@ jobs:
         uses: actions/checkout@v6
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
+      - name: Resolve Package Dependencies
+        uses: ./.github/actions/retry
+        with:
+          command: xcrun swift package resolve
       - name: Build and Test Framework
         run: |
           for i in {1..5}; do # Run tests a few times to ensure code-gen is stable.
@@ -138,6 +158,10 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
+      - name: Resolve Package Dependencies
+        uses: ./.github/actions/retry
+        with:
+          command: swift package resolve
       - name: Build and Test Framework
         run: swift test -c release --enable-code-coverage -Xswiftc -enable-testing --traits sourceBuild
       - name: Install curl for Codecov
@@ -175,5 +199,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
+      - name: Resolve Package Dependencies
+        uses: ./.github/actions/retry
+        with:
+          command: swift package resolve --package-path CLI
       - name: Lint Swift
         run: swift run --package-path CLI swiftformat . --lint


### PR DESCRIPTION
## Summary
- Add a reusable composite action (`.github/actions/retry`) that runs a command with configurable retries and delay
- Use it in all 7 CI jobs that resolve SPM/Xcode dependencies (3 attempts, 10s delay)
- Mitigates transient network failures like https://github.com/dfed/SafeDI/actions/runs/24422055341/job/71346691882?pr=250

## Test plan
- [ ] CI runs successfully with the new retry steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)