### PR TITLE
Tests: declare Instantiable conformance directly in fixtures

### DIFF
--- a/Tests/SafeDIToolTests/SafeDIToolCodeGenerationErrorTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolCodeGenerationErrorTests.swift
@@ -52,7 +52,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {
+					public final class RootViewController: UIViewController, Instantiable {
 					    @Instantiated(fulfilledByType: "DoesNotExist")
 					    let networkService: NetworkService
 					}
@@ -82,7 +82,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated let childBuilder: Instantiator<Child>
 					}
 					""",
@@ -90,7 +90,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable
-					public final class Child {
+					public final class Child: Instantiable {
 					    @Forwarded let value: Grandchild.NestedType
 					    @Instantiated let grandchild: Grandchild
 					}
@@ -99,7 +99,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable
-					public final class Grandchild {
+					public final class Grandchild: Instantiable {
 					    public struct NestedType {}
 					    @Received let value: NestedType
 					}
@@ -129,7 +129,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated let childBuilder: Instantiator<Child>
 					}
 					""",
@@ -137,7 +137,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable
-					public final class Child {
+					public final class Child: Instantiable {
 					    public struct NestedType {}
 					    @Forwarded let value: NestedType
 					    @Instantiated let grandchild: Grandchild
@@ -147,7 +147,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable
-					public final class Grandchild {
+					public final class Grandchild: Instantiable {
 					    @Received let value: Root.NestedType
 					}
 					""",
@@ -173,7 +173,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable(conformsElsewhere: true)
-					extension Array {
+					extension Array: Instantiable {
 					    public static func instantiate() -> Container<Int> {
 					        .init(0)
 					    }
@@ -181,7 +181,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable(conformsElsewhere: true)
-					extension Array {
+					extension Array: Instantiable {
 					    public static func instantiate() -> Container<Int> {
 					        .init(0)
 					    }
@@ -209,7 +209,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable(conformsElsewhere: true)
-					extension Array {
+					extension Array: Instantiable {
 					    public static func instantiate() -> Container<Int> {
 					        .init(0)
 					    }
@@ -217,7 +217,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable(conformsElsewhere: true)
-					extension Array {
+					extension Array: Instantiable {
 					    public static func instantiate(intValue: Int) -> Container<Int> {
 					        .init(intValue)
 					    }
@@ -246,7 +246,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					public protocol NetworkService {}
 
 					@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-					public final class DefaultNetworkService: NetworkService {
+					public final class DefaultNetworkService: NetworkService, Instantiable {
 					    @Instantiated let urlSession: URLSession // URLSession is not `@Instantiable`! This will fail!
 					}
 					""",
@@ -254,7 +254,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {
+					public final class RootViewController: UIViewController, Instantiable {
 					    @Instantiated let networkService: NetworkService
 					}
 					""",
@@ -282,7 +282,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					public protocol NetworkService {}
 
 					@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-					public final class DefaultNetworkService: NetworkService {
+					public final class DefaultNetworkService: NetworkService, Instantiable {
 					    @Received let urlSession: URLSession // URLSession is not `@Instantiable`! This will fail!
 					}
 					""",
@@ -290,7 +290,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {
+					public final class RootViewController: UIViewController, Instantiable {
 					    @Instantiated let networkService: NetworkService
 					}
 					""",
@@ -319,7 +319,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated(fulfilledByType: "SomeErasedType") let erasedType: ErasedType
 					    @Instantiated let child: Child
 					}
@@ -330,13 +330,13 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					public protocol ErasedType {}
 
 					@Instantiable
-					public final class SomeErasedType: ErasedType {}
+					public final class SomeErasedType: ErasedType, Instantiable {}
 					""",
 					"""
 					import SafeDI
 
 					@Instantiable
-					public final class Child {
+					public final class Child: Instantiable {
 					    @Received let erasedType: any ErasedType
 					}
 					""",
@@ -365,7 +365,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated(fulfilledByType: "SomeErasedType") let erasedType: any ErasedType
 					    @Instantiated let child: Child
 					}
@@ -376,13 +376,13 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					public protocol ErasedType {}
 
 					@Instantiable
-					public final class SomeErasedType: ErasedType {}
+					public final class SomeErasedType: ErasedType, Instantiable {}
 					""",
 					"""
 					import SafeDI
 
 					@Instantiable
-					public final class Child {
+					public final class Child: Instantiable {
 					    @Received let erasedType: ErasedType
 					}
 					""",
@@ -411,7 +411,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated let thing: Thing
 					    @Instantiated let child: Child
 					}
@@ -420,13 +420,13 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable
-					public final class Thing {}
+					public final class Thing: Instantiable {}
 					""",
 					"""
 					import SafeDI
 
 					@Instantiable
-					public final class Child {
+					public final class Child: Instantiable {
 					    @Received let thing: Thing!
 					}
 					""",
@@ -455,7 +455,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated let thing: Thing!
 					    @Instantiated let child: Child
 					}
@@ -464,13 +464,13 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable
-					public final class Thing {}
+					public final class Thing: Instantiable {}
 					""",
 					"""
 					import SafeDI
 
 					@Instantiable
-					public final class Child {
+					public final class Child: Instantiable {
 					    @Received let thing: Thing
 					}
 					""",
@@ -498,7 +498,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated let thing: Thing
 					    @Instantiated let child: Child
 					}
@@ -507,13 +507,13 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable
-					public final class Thing {}
+					public final class Thing: Instantiable {}
 					""",
 					"""
 					import SafeDI
 
 					@Instantiable
-					public final class Child {
+					public final class Child: Instantiable {
 					    @Received let thing: Thing?
 					}
 					""",
@@ -542,7 +542,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated let thing: Thing?
 					    @Instantiated let child: Child
 					}
@@ -551,13 +551,13 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable
-					public final class Thing {}
+					public final class Thing: Instantiable {}
 					""",
 					"""
 					import SafeDI
 
 					@Instantiable
-					public final class Child {
+					public final class Child: Instantiable {
 					    @Received let thing: Thing
 					}
 					""",
@@ -586,7 +586,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated let thing: Thing
 					    @Instantiated let child: Child
 					}
@@ -595,16 +595,16 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable
-					public final class Thing {}
+					public final class Thing: Instantiable {}
 
 					@Instantiable
-					public final class OtherThing {}
+					public final class OtherThing: Instantiable {}
 					""",
 					"""
 					import SafeDI
 
 					@Instantiable
-					public final class Child {
+					public final class Child: Instantiable {
 					    @Received let thing: OtherThing
 					}
 					""",
@@ -634,7 +634,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated let thing: Thing
 					    @Instantiated let otherThing: OtherThing
 					    @Instantiated let child: Child
@@ -644,16 +644,16 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import SafeDI
 
 					@Instantiable
-					public final class Thing {}
+					public final class Thing: Instantiable {}
 
 					@Instantiable
-					public final class OtherThing {}
+					public final class OtherThing: Instantiable {}
 					""",
 					"""
 					import SafeDI
 
 					@Instantiable
-					public final class Child {
+					public final class Child: Instantiable {
 					    @Received let thing: OtherThing
 					}
 					""",
@@ -680,7 +680,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					public protocol NetworkService {}
 
 					@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-					public final class DefaultNetworkService: NetworkService {
+					public final class DefaultNetworkService: NetworkService, Instantiable {
 					    @Forwarded let urlSession: URLSession
 					}
 					""",
@@ -688,7 +688,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {
+					public final class RootViewController: UIViewController, Instantiable {
 					    @Instantiated let networkService: NetworkService
 					}
 					""",
@@ -712,33 +712,33 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated let childA: ChildA
 					    @Instantiated let childB: ChildB
 					}
 					""",
 					"""
 					@Instantiable
-					public final class ChildA {
+					public final class ChildA: Instantiable {
 					    @Instantiated let grandchild: Grandchild
 					    @Instantiated let blankie: Blankie
 					}
 					""",
 					"""
 					@Instantiable
-					public final class ChildB {
+					public final class ChildB: Instantiable {
 					    @Instantiated let grandchild: Grandchild
 					}
 					""",
 					"""
 					@Instantiable
-					public final class Grandchild {
+					public final class Grandchild: Instantiable {
 					    @Received let blankie: Blankie
 					}
 					""",
 					"""
 					@Instantiable
-					public final class Blankie {}
+					public final class Blankie: Instantiable {}
 					""",
 				],
 				buildSwiftOutputDirectory: true,
@@ -769,34 +769,34 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated let childA: ChildA
 					    @Instantiated let childB: ChildB
 					}
 					""",
 					"""
 					@Instantiable
-					public final class ChildA {
+					public final class ChildA: Instantiable {
 					    @Instantiated let grandchild: Grandchild
 					    @Instantiated let blankie: Blankie
 					}
 					""",
 					"""
 					@Instantiable
-					public final class ChildB {
+					public final class ChildB: Instantiable {
 					    @Instantiated let grandchild: Grandchild
 					}
 					""",
 					"""
 					@Instantiable
-					public final class Grandchild {
+					public final class Grandchild: Instantiable {
 					    @Received let blankie: Blankie
 					    @Received let blankie2: Blankie
 					}
 					""",
 					"""
 					@Instantiable
-					public final class Blankie {}
+					public final class Blankie: Instantiable {}
 					""",
 				],
 				buildSwiftOutputDirectory: true,
@@ -823,7 +823,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					public protocol NetworkService {}
 
 					@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-					public final class DefaultNetworkService: NetworkService {
+					public final class DefaultNetworkService: NetworkService, Instantiable {
 					    public init() {}
 					}
 					""",
@@ -833,7 +833,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					}
 
 					@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-					public final class DefaultAuthService: AuthService {
+					public final class DefaultAuthService: AuthService, Instantiable {
 					    public func login(username: String, password: String) async -> User {
 					        User(username: username)
 					    }
@@ -847,7 +847,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {
+					public final class RootViewController: UIViewController, Instantiable {
 					    public init(authService: AuthService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 					        self.authService = authService
 					        self.loggedInViewControllerBuilder = loggedInViewControllerBuilder
@@ -882,7 +882,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					public protocol NetworkService {}
 
 					@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-					public final class DefaultNetworkService: NetworkService {
+					public final class DefaultNetworkService: NetworkService, Instantiable {
 					    public init() {}
 					}
 					""",
@@ -892,7 +892,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					}
 
 					@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-					public final class DefaultAuthService: AuthService {
+					public final class DefaultAuthService: AuthService, Instantiable {
 					    public func login(username: String, password: String) async -> User {
 					        User(username: username)
 					    }
@@ -906,7 +906,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {
+					public final class RootViewController: UIViewController, Instantiable {
 					    public init(authService: AuthService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 					        self.authService = authService
 					        self.loggedInViewControllerBuilder = loggedInViewControllerBuilder
@@ -943,7 +943,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					public protocol NetworkService {}
 
 					@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-					public final class DefaultNetworkService: NetworkService {
+					public final class DefaultNetworkService: NetworkService, Instantiable {
 					    public init() {}
 					}
 					""",
@@ -951,7 +951,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {
+					public final class RootViewController: UIViewController, Instantiable {
 					    @Instantiated let networkService: NetworkService
 
 					    @Instantiated let authService: AuthService
@@ -963,7 +963,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					}
 
 					@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-					public final class DefaultAuthService: AuthService {
+					public final class DefaultAuthService: AuthService, Instantiable {
 					    public func login(username: String, password: String) async -> User {
 					        User(username: username)
 					    }
@@ -998,7 +998,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					public protocol NetworkService {}
 
 					@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-					public final class DefaultNetworkService: NetworkService {
+					public final class DefaultNetworkService: NetworkService, Instantiable {
 					    public init() {}
 					}
 					""",
@@ -1006,7 +1006,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {
+					public final class RootViewController: UIViewController, Instantiable {
 					    @Instantiated let networkService: NetworkService
 
 					    @Instantiated let authService: AuthService
@@ -1018,7 +1018,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					}
 
 					@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-					public final class DefaultAuthService: AuthService {
+					public final class DefaultAuthService: AuthService, Instantiable {
 					    public func login(username: String, password: String) async -> User {
 					        User(username: username)
 					    }
@@ -1051,7 +1051,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					public protocol NetworkService {}
 
 					@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-					public final class DefaultNetworkService: NetworkService {
+					public final class DefaultNetworkService: NetworkService, Instantiable {
 					    public init() {}
 					}
 					""",
@@ -1061,7 +1061,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					}
 
 					@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-					public final class DefaultAuthService: AuthService {
+					public final class DefaultAuthService: AuthService, Instantiable {
 					    public func login(username: String, password: String) async -> User {
 					        User(username: username)
 					    }
@@ -1075,7 +1075,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {
+					public final class RootViewController: UIViewController, Instantiable {
 					    public init(authService: AuthService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 					        self.authService = authService
 					        self.loggedInViewControllerBuilder = loggedInViewControllerBuilder
@@ -1117,7 +1117,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {
+					public final class RootViewController: UIViewController, Instantiable {
 					    @Instantiated let urlSessionWrapper: URLSessionWrapper
 					}
 					""",
@@ -1142,13 +1142,13 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable
-					public final class RootViewController: UIViewController {}
+					public final class RootViewController: UIViewController, Instantiable {}
 					""",
 					"""
 					import UIKit
 
 					@Instantiable
-					public final class RootViewController: UIViewController {}
+					public final class RootViewController: UIViewController, Instantiable {}
 					""",
 				],
 				buildSwiftOutputDirectory: true,
@@ -1171,13 +1171,13 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {}
+					public final class RootViewController: UIViewController, Instantiable {}
 					""",
 					"""
 					import UIKit
 
 					@Instantiable
-					public final class RootViewController: UIViewController {}
+					public final class RootViewController: UIViewController, Instantiable {}
 					""",
 				],
 				buildSwiftOutputDirectory: true,
@@ -1200,7 +1200,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable
-					public final class RootViewController: UIViewController {}
+					public final class RootViewController: UIViewController, Instantiable {}
 					""",
 					"""
 					import UIKit
@@ -1233,7 +1233,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {}
+					public final class RootViewController: UIViewController, Instantiable {}
 					""",
 					"""
 					import UIKit
@@ -1266,7 +1266,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable
-					public final class RootViewController: UIViewController {}
+					public final class RootViewController: UIViewController, Instantiable {}
 					""",
 					"""
 					import UIKit
@@ -1336,13 +1336,13 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true, fulfillingAdditionalTypes: [UIViewController.self])
-					public final class RootViewController: UIViewController {}
+					public final class RootViewController: UIViewController, Instantiable {}
 					""",
 					"""
 					import UIKit
 
 					@Instantiable(fulfillingAdditionalTypes: [UIViewController.self])
-					public final class SplashViewController: UIViewController {}
+					public final class SplashViewController: UIViewController, Instantiable {}
 					""",
 				],
 				buildSwiftOutputDirectory: true,
@@ -1364,25 +1364,25 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated let a: A
 					}
 					""",
 					"""
 					@Instantiable
-					public final class A {
+					public final class A: Instantiable {
 					    @Instantiated let b: B
 					}
 					""",
 					"""
 					@Instantiable
-					public final class B {
+					public final class B: Instantiable {
 					    @Instantiated let c: C
 					}
 					""",
 					"""
 					@Instantiable
-					public final class C {
+					public final class C: Instantiable {
 					    @Instantiated let a: A
 					}
 					""",
@@ -1406,23 +1406,23 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 						@Instantiated public let a: A // A -> C -> Received B
 						@Instantiated public let b: B // B -> Received A
 					}
 
 					@Instantiable
-					public final class A {
+					public final class A: Instantiable {
 						@Instantiated let c: C
 					}
 
 					@Instantiable
-					public final class B {
+					public final class B: Instantiable {
 						@Received public let a: A
 					}
 
 					@Instantiable
-					public final class C {
+					public final class C: Instantiable {
 						@Received public let b: B
 					}
 					""",
@@ -1446,25 +1446,25 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 					    @Instantiated let a: A
 					}
 					""",
 					"""
 					@Instantiable
-					public final class A {
+					public final class A: Instantiable {
 					    @Instantiated let b: B
 					}
 					""",
 					"""
 					@Instantiable
-					public final class B {
+					public final class B: Instantiable {
 					    @Instantiated let c: C
 					}
 					""",
 					"""
 					@Instantiable
-					public final class C {
+					public final class C: Instantiable {
 					    @Received let a: A
 					}
 					""",
@@ -1488,25 +1488,25 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(isRoot: true)
-					public struct Root {
+					public struct Root: Instantiable {
 					    @Instantiated let aBuilder: Instantiator<A>
 					}
 					""",
 					"""
 					@Instantiable
-					public struct A {
+					public struct A: Instantiable {
 					    @Instantiated let bBuilder: Instantiator<B>
 					}
 					""",
 					"""
 					@Instantiable
-					public struct B {
+					public struct B: Instantiable {
 					    @Instantiated let cBuilder: Instantiator<C>
 					}
 					""",
 					"""
 					@Instantiable
-					public struct C {
+					public struct C: Instantiable {
 					    @Received let aBuilder: Instantiator<A>
 					}
 					""",
@@ -1530,25 +1530,25 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(isRoot: true)
-					public struct Root {
+					public struct Root: Instantiable {
 					    @Instantiated let aBuilder: Instantiator<A>?
 					}
 					""",
 					"""
 					@Instantiable
-					public struct A {
+					public struct A: Instantiable {
 					    @Instantiated let bBuilder: Instantiator<B>
 					}
 					""",
 					"""
 					@Instantiable
-					public struct B {
+					public struct B: Instantiable {
 					    @Instantiated let cBuilder: Instantiator<C>
 					}
 					""",
 					"""
 					@Instantiable
-					public struct C {
+					public struct C: Instantiable {
 					    @Received(onlyIfAvailable: true) let aBuilder: Instantiator<A>?
 					}
 					""",
@@ -1572,25 +1572,25 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(isRoot: true)
-					public struct Root {
+					public struct Root: Instantiable {
 					    @Instantiated let a: A
 					}
 					""",
 					"""
 					@Instantiable
-					public struct A {
+					public struct A: Instantiable {
 					    @Instantiated let b: B
 					}
 					""",
 					"""
 					@Instantiable
-					public struct B {
+					public struct B: Instantiable {
 					    @Instantiated let c: C
 					}
 					""",
 					"""
 					@Instantiable
-					public struct C {
+					public struct C: Instantiable {
 					    @Instantiated let a2: A
 					}
 					""",
@@ -1614,7 +1614,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(isRoot: true)
-					public struct Root {
+					public struct Root: Instantiable {
 					    @Instantiated private let a: A
 					    @Instantiated private let b: B
 					    @Instantiated private let c: C
@@ -1622,19 +1622,19 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable
-					public struct A {
+					public struct A: Instantiable {
 					    @Received private let b: B
 					}
 					""",
 					"""
 					@Instantiable
-					public struct B {
+					public struct B: Instantiable {
 					    @Received private let c: C
 					}
 					""",
 					"""
 					@Instantiable
-					public struct C {
+					public struct C: Instantiable {
 					    @Received private let a: A
 					}
 					""",
@@ -1658,7 +1658,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(isRoot: true)
-					public struct Root {
+					public struct Root: Instantiable {
 					    @Instantiated private let a: A
 					    @Instantiated private let b: B
 					    @Received(fulfilledByDependencyNamed: "b", ofType: B.self) private let renamedB: B
@@ -1667,19 +1667,19 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable
-					public struct A {
+					public struct A: Instantiable {
 					    @Received private let renamedB: B
 					}
 					""",
 					"""
 					@Instantiable
-					public struct B {
+					public struct B: Instantiable {
 					    @Received private let c: C
 					}
 					""",
 					"""
 					@Instantiable
-					public struct C {
+					public struct C: Instantiable {
 					    @Received private let a: A
 					}
 					""",
@@ -1703,13 +1703,13 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(isRoot: true)
-					public struct Root {
+					public struct Root: Instantiable {
 					    @Instantiated private let a: A
 					}
 					""",
 					"""
 					@Instantiable
-					public struct A {
+					public struct A: Instantiable {
 					    @Instantiated private let b: B
 					    @Received(fulfilledByDependencyNamed: "b", ofType: B.self) private let renamedB: B
 					    @Instantiated private let c: C
@@ -1717,13 +1717,13 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable
-					public struct B {
+					public struct B: Instantiable {
 					    @Received private let c: C
 					}
 					""",
 					"""
 					@Instantiable
-					public struct C {
+					public struct C: Instantiable {
 					    @Received private let renamedB: B
 					}
 					""",
@@ -1747,7 +1747,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(isRoot: true)
-					public final class Root {
+					public final class Root: Instantiable {
 						public init(aBuilder: Instantiator<A>) {
 							fatalError("SafeDI doesn't inspect the initializer body")
 						}
@@ -1757,7 +1757,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable
-					public final class A {
+					public final class A: Instantiable {
 						public init(c: C) {
 							fatalError("SafeDI doesn't inspect the initializer body")
 						}
@@ -1767,7 +1767,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable
-					public final class B {
+					public final class B: Instantiable {
 						public init(cRenamed: CRenamed?) {
 							fatalError("SafeDI doesn't inspect the initializer body")
 						}
@@ -1777,7 +1777,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable
-					public final class C {
+					public final class C: Instantiable {
 						public init(b: B) {
 							fatalError("SafeDI doesn't inspect the initializer body")
 						}
@@ -1811,7 +1811,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					}
 
 					@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-					public final class DefaultAuthService: AuthService {
+					public final class DefaultAuthService: AuthService, Instantiable {
 					    public func login(username: String, password: String) async -> User {
 					        User()
 					    }
@@ -1823,7 +1823,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					public protocol NetworkService {}
 
 					@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-					public final class DefaultNetworkService: NetworkService {
+					public final class DefaultNetworkService: NetworkService, Instantiable {
 					    public init() {}
 					}
 					""",
@@ -1831,7 +1831,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {
+					public final class RootViewController: UIViewController, Instantiable {
 					    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<String, UIViewController>) {
 					        self.authService = authService
 					        self.networkService = networkService
@@ -1861,7 +1861,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable
-					public final class LoggedInViewController: UIViewController {
+					public final class LoggedInViewController: UIViewController, Instantiable {
 					    @Forwarded private let user: User
 
 					    @Received let networkService: NetworkService
@@ -1893,7 +1893,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					}
 
 					@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-					public final class DefaultAuthService: AuthService {
+					public final class DefaultAuthService: AuthService, Instantiable {
 					    public func login(username: String, password: String) async -> User {
 					        User()
 					    }
@@ -1905,7 +1905,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					public protocol NetworkService {}
 
 					@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-					public final class DefaultNetworkService: NetworkService {
+					public final class DefaultNetworkService: NetworkService, Instantiable {
 					    public init() {}
 					}
 					""",
@@ -1913,7 +1913,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable(isRoot: true)
-					public final class RootViewController: UIViewController {
+					public final class RootViewController: UIViewController, Instantiable {
 					    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<String, UIViewController>) {
 					        self.authService = authService
 					        self.networkService = networkService
@@ -1943,7 +1943,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					import UIKit
 
 					@Instantiable
-					public final class LoggedInViewController: UIViewController {
+					public final class LoggedInViewController: UIViewController, Instantiable {
 					    @Forwarded private let user: User
 
 					    @Forwarded private let userManager: UserManager
@@ -2012,7 +2012,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 		let swiftFile = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString + ".swift")
 		try """
 		@Instantiable
-		public struct NotRoot {
+		public struct NotRoot: Instantiable {
 		    public init() {}
 		}
 		""".write(to: swiftFile, atomically: true, encoding: .utf8)
@@ -2044,12 +2044,12 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 		let swiftFile = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString + ".swift")
 		try """
 		@Instantiable(isRoot: true)
-		public struct Root {
+		public struct Root: Instantiable {
 		    public init(dep: Dep) { self.dep = dep }
 		    @Instantiated let dep: Dep
 		}
 		@Instantiable
-		public struct Dep {
+		public struct Dep: Instantiable {
 		    public init() {}
 		}
 		""".write(to: swiftFile, atomically: true, encoding: .utf8)
@@ -2120,7 +2120,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(isRoot: true)
-					public struct Root {
+					public struct Root: Instantiable {
 					    public init(a: A) {
 					        fatalError("SafeDI doesn't inspect the initializer body")
 					    }
@@ -2130,7 +2130,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable
-					public struct A {
+					public struct A: Instantiable {
 					    public init(b: B) {
 					        fatalError("SafeDI doesn't inspect the initializer body")
 					    }
@@ -2140,7 +2140,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable
-					public struct B {
+					public struct B: Instantiable {
 					    public init(cBuilder: Instantiator<C>) {
 					        fatalError("SafeDI doesn't inspect the initializer body")
 					    }
@@ -2150,7 +2150,7 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable
-					public struct C {
+					public struct C: Instantiable {
 					    public init(a: A) {
 					        fatalError("SafeDI doesn't inspect the initializer body")
 					    }

--- a/Tests/SafeDIToolTests/SafeDIToolCodeGenerationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolCodeGenerationTests.swift
@@ -61,7 +61,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(isRoot: true, fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    let urlSession: URLSession = .shared
 				}
 				""",
@@ -86,7 +86,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 
 				    let urlSession: URLSession = .shared
@@ -94,7 +94,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -136,7 +136,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 
 				    let urlSession: URLSession = .shared
@@ -144,7 +144,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public actor Root {
+				public actor Root: Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -186,7 +186,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 
 				    let urlSession: URLSession = .shared
@@ -194,7 +194,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -236,7 +236,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 
 				    let urlSession: URLSession = .shared
@@ -244,7 +244,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root1 {
+				public struct Root1: Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -254,7 +254,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root2 {
+				public struct Root2: Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -309,7 +309,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init(userService: any UserService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -325,7 +325,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [UserService.self])
-				public final class DefaultUserService: UserService {
+				public final class DefaultUserService: UserService, Instantiable {
 				    public init() {}
 
 				    public var userName: String?
@@ -366,7 +366,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(fulfillingAdditionalTypes: [(any SomeProtocol<OtherType>).self])
-				public final class SomeClass: SomeProtocol {
+				public final class SomeClass: SomeProtocol, Instantiable {
 				    public init() {}
 
 				    public typealias SomeAssociatedType = OtherType
@@ -411,7 +411,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init(userService: UserService?) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -427,7 +427,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [UserService.self])
-				public final class DefaultUserService: UserService {
+				public final class DefaultUserService: UserService, Instantiable {
 				    public init() {}
 
 				    public var userName: String?
@@ -470,7 +470,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -486,7 +486,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -494,7 +494,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<User, UIViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -524,7 +524,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    public init(user: User, networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -578,7 +578,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -594,7 +594,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -602,7 +602,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -630,7 +630,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class UserService {
+				public final class UserService: Instantiable {
 				    public init(user: User) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -642,7 +642,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    public init(user: User, networkService: NetworkService, userService: UserService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -703,7 +703,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(networkServiceBuilder: Instantiator<NetworkService>) {
 				        self.networkServiceBuilder = networkServiceBuilder
 				        super.init(nibName: nil, bundle: nil)
@@ -757,7 +757,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -773,7 +773,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -781,7 +781,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<(userID: String, userName: String), UIViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -809,7 +809,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class UserService {
+				public final class UserService: Instantiable {
 				    public init(userName: String, userID: String) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -823,7 +823,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    public init(userName: String, userID: String, networkService: NetworkService, userService: UserService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -885,7 +885,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -901,7 +901,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -909,7 +909,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<LoggedInViewController.ForwardedProperties, UIViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -937,7 +937,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class UserService {
+				public final class UserService: Instantiable {
 				    public init(userName: String, userID: String) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -951,7 +951,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    public init(userName: String, userID: String, networkService: NetworkService, userService: UserService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1005,7 +1005,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import SwiftUI
 
 				@Instantiable(isRoot: true)
-				public struct RootView: View {
+				public struct RootView: View, Instantiable {
 				    public init(splashScreenView: AnyView) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1021,7 +1021,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import SwiftUI
 
 				@Instantiable
-				public struct SplashScreenView: View {
+				public struct SplashScreenView: View, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -1057,7 +1057,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import SwiftUI
 
 				@Instantiable(isRoot: true)
-				public struct RootView: View {
+				public struct RootView: View, Instantiable {
 				    public init(splashScreenViewBuilder: ErasedInstantiator<(), AnyView>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1073,7 +1073,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import SwiftUI
 
 				@Instantiable
-				public struct SplashScreenView: View {
+				public struct SplashScreenView: View, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -1119,7 +1119,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1135,7 +1135,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -1143,7 +1143,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -1171,7 +1171,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class UserService {
+				public final class UserService: Instantiable {
 				    public init(user: User, networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1185,7 +1185,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    public init(user: User, userService: UserService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1240,7 +1240,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1255,7 +1255,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -1263,7 +1263,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -1291,7 +1291,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class UserService {
+				public final class UserService: Instantiable {
 				    public init(user: User, networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1305,7 +1305,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    public init(user: User, userServiceInstantiator: Instantiator<UserService>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1356,7 +1356,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1366,7 +1366,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    // This Child is incorrectly configured! It is missing the required initializer.
 
 				    @Instantiated let grandchild: Grandchild
@@ -1376,7 +1376,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Grandchild {
+				public final class Grandchild: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -1410,7 +1410,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1420,7 +1420,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(grandchild: Grandchild, nonInjectedProperty: Int = 5) {
 				        self.grandchild = grandchild
 				        self.nonInjectedProperty = nonInjectedProperty
@@ -1433,7 +1433,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Grandchild {
+				public final class Grandchild: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -1467,7 +1467,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1477,7 +1477,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				final class Child {
+				final class Child: Instantiable {
 				    public init(grandchild: Grandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1487,7 +1487,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Grandchild {
+				public final class Grandchild: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -1521,7 +1521,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1531,7 +1531,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				final class Child {
+				final class Child: Instantiable {
 				    public init(grandchild: Grandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1541,7 +1541,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Grandchild {
+				public final class Grandchild: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -1575,7 +1575,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(childA: ChildA, childB: ChildB, greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1587,7 +1587,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class ChildA {
+				public final class ChildA: Instantiable {
 				    public init(grandchildAA: GrandchildAA, grandchildAB: GrandchildAB) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1598,7 +1598,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildAA {
+				public final class GrandchildAA: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1608,7 +1608,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildAB {
+				public final class GrandchildAB: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1618,7 +1618,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class ChildB {
+				public final class ChildB: Instantiable {
 				    public init(grandchildBA: GrandchildBA, grandchildBB: GrandchildBB) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1629,7 +1629,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildBA {
+				public final class GrandchildBA: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1639,7 +1639,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildBB {
+				public final class GrandchildBB: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1649,7 +1649,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchild {
+				public final class GreatGrandchild: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -1692,7 +1692,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(childA: ChildA, childB: ChildB) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1703,7 +1703,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class ChildA {
+				public final class ChildA: Instantiable {
 				    public init(grandchildAA: GrandchildAA, grandchildAB: GrandchildAB, greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1715,7 +1715,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildAA {
+				public final class GrandchildAA: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1725,7 +1725,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildAB {
+				public final class GrandchildAB: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1735,7 +1735,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class ChildB {
+				public final class ChildB: Instantiable {
 				    public init(grandchildBA: GrandchildBA, grandchildBB: GrandchildBB, greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1747,7 +1747,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildBA {
+				public final class GrandchildBA: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1757,7 +1757,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildBB {
+				public final class GrandchildBB: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1767,7 +1767,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchild {
+				public final class GreatGrandchild: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -1811,7 +1811,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1821,13 +1821,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Recreated {
+				public final class Recreated: Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(grandchild: Grandchild, recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1838,7 +1838,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Grandchild {
+				public final class Grandchild: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild, recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1849,7 +1849,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchild {
+				public final class GreatGrandchild: Instantiable {
 				    public init(recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1894,7 +1894,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child, recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1905,13 +1905,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Recreated {
+				public final class Recreated: Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(grandchild: Grandchild, recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1922,7 +1922,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Grandchild {
+				public final class Grandchild: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1932,7 +1932,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchild {
+				public final class GreatGrandchild: Instantiable {
 				    public init(recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1979,7 +1979,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child, recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -1990,13 +1990,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Recreated {
+				public final class Recreated: Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(grandchild: Grandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2006,7 +2006,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Grandchild {
+				public final class Grandchild: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2016,7 +2016,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchild {
+				public final class GreatGrandchild: Instantiable {
 				    public init(greatGreatGrandchild: GreatGreatGrandchild, recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2027,7 +2027,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GreatGreatGrandchild {
+				public final class GreatGreatGrandchild: Instantiable {
 				    public init(recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2078,7 +2078,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2088,13 +2088,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Recreated: Sendable {
+				public final class Recreated: Sendable, Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(grandchild: Grandchild, recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2105,7 +2105,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Grandchild {
+				public final class Grandchild: Instantiable {
 				    public init(greatGrandchildA: GreatGrandchildA, greatGrandchildB: GreatGrandchildB) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2116,7 +2116,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchildA {
+				public final class GreatGrandchildA: Instantiable {
 				    public init(greatGreatGrandchild: GreatGreatGrandchild, recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2127,7 +2127,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchildB {
+				public final class GreatGrandchildB: Instantiable {
 				    public init(greatGreatGrandchild: GreatGreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2137,7 +2137,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GreatGreatGrandchild {
+				public final class GreatGreatGrandchild: Instantiable {
 				    public init(recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2197,7 +2197,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(childABuilder: SendableErasedInstantiator<Recreated, ChildAProtocol>, childB: ChildB, recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2209,14 +2209,14 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Recreated {
+				public final class Recreated: Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				public protocol ChildAProtocol: Sendable {}
 				@Instantiable
-				public final class ChildA: ChildAProtocol {
+				public final class ChildA: ChildAProtocol, Instantiable {
 				    public init(grandchildA: GrandchildA, grandchildB: GrandchildB, recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2228,7 +2228,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class ChildB {
+				public final class ChildB: Instantiable {
 				    public init(grandchildA: GrandchildA, grandchildB: GrandchildB, recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2240,7 +2240,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildA {
+				public final class GrandchildA: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild, recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2251,7 +2251,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildB {
+				public final class GrandchildB: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2261,7 +2261,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchild {
+				public final class GreatGrandchild: Instantiable {
 				    public init(recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2327,7 +2327,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(childA: ChildA, childB: ChildB) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2338,7 +2338,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class ChildA {
+				public final class ChildA: Instantiable {
 				    public init(grandchildAA: GrandchildAA, grandchildAB: GrandchildAB) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2349,7 +2349,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildAA {
+				public final class GrandchildAA: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2359,7 +2359,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildAB {
+				public final class GrandchildAB: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2369,7 +2369,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class ChildB {
+				public final class ChildB: Instantiable {
 				    public init(grandchildBA: GrandchildBA, grandchildBB: GrandchildBB) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2380,7 +2380,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildBA {
+				public final class GrandchildBA: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2390,7 +2390,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildBB {
+				public final class GrandchildBB: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2400,7 +2400,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchild {
+				public final class GreatGrandchild: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -2458,7 +2458,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child, keyValueStore: KeyValueStore) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2469,7 +2469,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(keyValueStore: KeyValueStore) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2539,7 +2539,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2554,7 +2554,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -2562,7 +2562,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<User, UIViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -2592,7 +2592,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    public init(user: User, networkService: NetworkService, keyValueStore: KeyValueStore) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2661,7 +2661,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable
-				public final class GreatGrandchild: Sendable {
+				public final class GreatGrandchild: Sendable, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -2676,7 +2676,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import GreatGrandchildModule
 
 				@Instantiable
-				public final class GrandchildAA {
+				public final class GrandchildAA: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2688,7 +2688,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import GreatGrandchildModule
 
 				@Instantiable
-				public final class GrandchildAB {
+				public final class GrandchildAB: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2700,7 +2700,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import GreatGrandchildModule
 
 				@Instantiable
-				public final class GrandchildBA {
+				public final class GrandchildBA: Instantiable {
 				    public init(greatGrandchildInstantiator: SendableInstantiator<GreatGrandchild>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2712,7 +2712,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import GreatGrandchildModule
 
 				@Instantiable
-				public final class GrandchildBB {
+				public final class GrandchildBB: Instantiable {
 				    public init(greatGrandchildInstantiator: SendableInstantiator<GreatGrandchild>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2734,7 +2734,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 
 				@MainActor
 				@Instantiable
-				public final class ChildA {
+				public final class ChildA: Instantiable {
 				    public init(grandchildAA: GrandchildAA, grandchildAB: GrandchildAB) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2747,7 +2747,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				@preconcurrency import GrandchildModule
 
 				@Instantiable
-				public final class ChildB {
+				public final class ChildB: Instantiable {
 				    public init(grandchildBA: GrandchildBA, grandchildBB: GrandchildBB) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2772,7 +2772,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 
 				@MainActor
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(childA: ChildA, childB: ChildB) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2855,7 +2855,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init(defaultUserService: DefaultUserService, userService: any UserService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -2873,7 +2873,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [UserService.self])
-				public final class DefaultUserService: UserService {
+				public final class DefaultUserService: UserService, Instantiable {
 				    public init() {}
 
 				    public var userName: String?
@@ -2910,7 +2910,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable
-				public struct NotRoot {
+				public struct NotRoot: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -2931,7 +2931,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable
-				public struct NotRoot {
+				public struct NotRoot: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -2954,7 +2954,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: false)
-				public struct NotRoot {
+				public struct NotRoot: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -2997,7 +2997,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -3007,7 +3007,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3022,7 +3022,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -3049,7 +3049,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    public init(userManager: UserManager, profileViewControllerBuilder: Instantiator<ProfileViewController>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3063,7 +3063,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class ProfileViewController: UIViewController {
+				public final class ProfileViewController: UIViewController, Instantiable {
 				    public init(userVendor: UserVendor, editProfileViewControllerBuilder: Instantiator<EditProfileViewController>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3077,7 +3077,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class EditProfileViewController: UIViewController {
+				public final class EditProfileViewController: UIViewController, Instantiable {
 				    public init(userVendor: UserVendor, userManager: UserManager) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3132,7 +3132,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(childBuilder: Instantiator<Child>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3142,7 +3142,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(iterator: IndexingIterator<Array<Element>>, grandchildBuilder: Instantiator<Grandchild>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3153,7 +3153,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Grandchild {
+				public final class Grandchild: Instantiable {
 				    public init(anyIterator: AnyIterator) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3219,7 +3219,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -3229,7 +3229,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3244,7 +3244,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -3271,7 +3271,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    public init(userManager: UserManager, userNetworkService: NetworkService, profileViewControllerBuilder: Instantiator<ProfileViewController>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3287,7 +3287,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class ProfileViewController: UIViewController {
+				public final class ProfileViewController: UIViewController, Instantiable {
 				    public init(userVendor: UserVendor, editProfileViewControllerBuilder: Instantiator<EditProfileViewController>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3301,7 +3301,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class EditProfileViewController: UIViewController {
+				public final class EditProfileViewController: UIViewController, Instantiable {
 				    public init(userVendor: UserVendor, userManager: UserManager, userNetworkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3363,7 +3363,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -3373,7 +3373,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService, renamedNetworkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3391,7 +3391,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService) {
 				        self.authService = authService
 				        super.init(nibName: nil, bundle: nil)
@@ -3440,7 +3440,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -3450,7 +3450,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService, renamedNetworkService: NetworkService, renamedAgainNetworkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3469,7 +3469,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -3539,7 +3539,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -3549,7 +3549,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3564,7 +3564,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -3591,7 +3591,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    public init(userManager: UserManager, userVendor: UserVendor, profileViewControllerBuilder: Instantiator<ProfileViewController>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3607,7 +3607,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class ProfileViewController: UIViewController {
+				public final class ProfileViewController: UIViewController, Instantiable {
 				    public init(editProfileViewControllerBuilder: Instantiator<EditProfileViewController>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3619,7 +3619,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class EditProfileViewController: UIViewController {
+				public final class EditProfileViewController: UIViewController, Instantiable {
 				    public init(userVendor: UserVendor, userManager: UserManager) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3696,7 +3696,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -3706,7 +3706,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3721,7 +3721,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -3748,7 +3748,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    public init(userManager: UserManager, profileViewControllerBuilder: Instantiator<ProfileViewController>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3762,7 +3762,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class ProfileViewController: UIViewController {
+				public final class ProfileViewController: UIViewController, Instantiable {
 				    public init(editProfileViewControllerBuilder: Instantiator<EditProfileViewController>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3774,7 +3774,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class EditProfileViewController: UIViewController {
+				public final class EditProfileViewController: UIViewController, Instantiable {
 				    public init(userVendor: UserVendor, userManager: UserManager) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3829,7 +3829,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3839,13 +3839,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Unrelated {
+				public final class Unrelated: Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(grandchild: Grandchild, unrelated: Unrelated, greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3857,7 +3857,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Grandchild {
+				public final class Grandchild: Instantiable {
 				    public init(greatGrandchild: GreatGrandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3867,7 +3867,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchild {
+				public final class GreatGrandchild: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -3903,7 +3903,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3938,7 +3938,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class A {
+				public final class A: Instantiable {
 				    public init(x: X) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3948,7 +3948,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class B {
+				public final class B: Instantiable {
 				    public init(a: A, d: D, t: T, o: O, y: Y, s: S) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3963,7 +3963,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class C {
+				public final class C: Instantiable {
 				    public init(u: U, n: N, y: Y) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3975,7 +3975,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class D {
+				public final class D: Instantiable {
 				    public init(o: O, g: G) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3986,7 +3986,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class E {
+				public final class E: Instantiable {
 				    public init(g: G) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3996,7 +3996,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class F {
+				public final class F: Instantiable {
 				    public init(a: A, x: X) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4007,13 +4007,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class G {
+				public final class G: Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable
-				public final class H {
+				public final class H: Instantiable {
 				    public init(u: U, g: G) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4024,7 +4024,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class I {
+				public final class I: Instantiable {
 				    public init(f: F) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4034,7 +4034,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class J {
+				public final class J: Instantiable {
 				    public init(a: A, g: G) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4045,7 +4045,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class K {
+				public final class K: Instantiable {
 				    public init(i: I, t: T) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4056,7 +4056,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class L {
+				public final class L: Instantiable {
 				    public init(o: O, v: V, e: E) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4068,7 +4068,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class M {
+				public final class M: Instantiable {
 				    public init(e: E) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4078,7 +4078,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class N {
+				public final class N: Instantiable {
 				    public init(o: O, p: P, e: E) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4090,7 +4090,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class O {
+				public final class O: Instantiable {
 				    public init(m: M, e: E, g: G, a: A) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4103,7 +4103,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class P {
+				public final class P: Instantiable {
 				    public init(i: I, x: X) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4114,7 +4114,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Q {
+				public final class Q: Instantiable {
 				    public init(u: U, t: T, e: E) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4126,7 +4126,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class R {
+				public final class R: Instantiable {
 				    public init(a: A, m: M, o: O, n: N, e: E) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4140,7 +4140,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class S {
+				public final class S: Instantiable {
 				    public init(a: A, t: T, o: O, r: R) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4153,7 +4153,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class T {
+				public final class T: Instantiable {
 				    public init(e: E, n: N) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4164,7 +4164,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class U {
+				public final class U: Instantiable {
 				    public init(p: P, d: D, o: O, w: W, n: N) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4178,7 +4178,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class V {
+				public final class V: Instantiable {
 				    public init(a: A, t: T, o: O, f: F, c: C, i: I, d: D) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4194,7 +4194,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class W {
+				public final class W: Instantiable {
 				    public init(a: A, x: X, o: O, n: N) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4207,13 +4207,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class X {
+				public final class X: Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable
-				public final class Y {
+				public final class Y: Instantiable {
 				    public init(u: U, p: P) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4224,7 +4224,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Z {
+				public final class Z: Instantiable {
 				    public init(e: E, p: P, l: L, i: I, n: N) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4287,7 +4287,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(childBuilder: Instantiator<Child>?) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4297,7 +4297,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -4330,7 +4330,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init(aBuilder: Instantiator<A>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4340,7 +4340,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct A {
+				public struct A: Instantiable {
 				    public init(bBuilder: Instantiator<B>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4350,7 +4350,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct B {
+				public struct B: Instantiable {
 				    public init(cBuilder: Instantiator<C>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4360,7 +4360,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct C {
+				public struct C: Instantiable {
 				    public init(aBuilder: Instantiator<A>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4406,7 +4406,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init(a: A) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4416,7 +4416,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct A {
+				public struct A: Instantiable {
 				    public init(aBuilder: Instantiator<A>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4458,7 +4458,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init(aBuilder: Instantiator<A>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4468,7 +4468,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct A {
+				public struct A: Instantiable {
 				    public init(aBuilder: Instantiator<A>, context: String) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4511,7 +4511,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 					public init(aBuilder: Instantiator<A>) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -4521,7 +4521,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct A {
+				public struct A: Instantiable {
 					public init(root: Root) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -4560,7 +4560,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init(stringContainer: Container<String>, intContainer: Container<Int>, floatContainer: Container<Float>, voidContainer: Container<Void>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4620,7 +4620,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init(stringContainer: MyModule.Container<String>, intContainer: MyModule.Container<Int>, floatContainer: MyModule.Container<Float>, voidContainer: MyModule.Container<Void>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4682,13 +4682,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import Foundation
 
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(inner: Inner) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
 
 				    @Instantiable
-				    public final class Inner {
+				    public final class Inner: Instantiable {
 				        public init() {}
 				    }
 
@@ -4697,7 +4697,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4741,13 +4741,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import Foundation
 
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(grandchild: Grandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
 
 				    @Instantiable
-				    public final class Grandchild {
+				    public final class Grandchild: Instantiable {
 				        public init(greatGrandchild: GreatGrandchild, pathalogical: Pathalogical) {
 				            fatalError("SafeDI doesn't inspect the initializer body")
 				        }
@@ -4756,7 +4756,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				        @Instantiated let pathalogical: Pathalogical
 
 				        @Instantiable
-				        public final class GreatGrandchild {
+				        public final class GreatGrandchild: Instantiable {
 				            public init(pathalogical: Pathalogical) {
 				                fatalError("SafeDI doesn't inspect the initializer body")
 				            }
@@ -4764,13 +4764,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				            @Instantiated let pathalogical: Pathalogical
 
 				            @Instantiable
-				            public final class Pathalogical {
+				            public final class Pathalogical: Instantiable {
 				                public init() {}
 				            }
 				        }
 
 				        @Instantiable
-				        public final class Pathalogical {
+				        public final class Pathalogical: Instantiable {
 				            public init() {}
 				        }
 				    }
@@ -4780,7 +4780,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4833,13 +4833,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import Foundation
 
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(grandchild: Grandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
 
 				    @Instantiable
-				    public final class Grandchild {
+				    public final class Grandchild: Instantiable {
 				        public init(greatGrandchild: GreatGrandchild, pathalogical: Grandchild.Pathalogical) {
 				            fatalError("SafeDI doesn't inspect the initializer body")
 				        }
@@ -4848,7 +4848,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				        @Instantiated let pathalogical: Grandchild.Pathalogical
 
 				        @Instantiable
-				        public final class GreatGrandchild {
+				        public final class GreatGrandchild: Instantiable {
 				            public init(pathalogical: Child.Grandchild.GreatGrandchild.Pathalogical) {
 				                fatalError("SafeDI doesn't inspect the initializer body")
 				            }
@@ -4856,13 +4856,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				            @Instantiated let pathalogical: Child.Grandchild.GreatGrandchild.Pathalogical
 
 				            @Instantiable
-				            public final class Pathalogical {
+				            public final class Pathalogical: Instantiable {
 				                public init() {}
 				            }
 				        }
 
 				        @Instantiable
-				        public final class Pathalogical {
+				        public final class Pathalogical: Instantiable {
 				            public init() {}
 				        }
 				    }
@@ -4872,7 +4872,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4925,14 +4925,14 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import Foundation
 
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(pathalogical: Child.Grandchild.Pathalogical, grandchild: Grandchild) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
 				    @Instantiated let pathalogical: Child.Grandchild.Pathalogical
 
 				    @Instantiable
-				    public final class Grandchild {
+				    public final class Grandchild: Instantiable {
 				        public init(greatGrandchild: GreatGrandchild, pathalogical: Pathalogical) {
 				            fatalError("SafeDI doesn't inspect the initializer body")
 				        }
@@ -4941,7 +4941,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				        @Received let pathalogical: Pathalogical
 
 				        @Instantiable
-				        public final class GreatGrandchild {
+				        public final class GreatGrandchild: Instantiable {
 				            public init(pathalogical: Grandchild.Pathalogical) {
 				                fatalError("SafeDI doesn't inspect the initializer body")
 				            }
@@ -4949,13 +4949,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				            @Received let pathalogical: Grandchild.Pathalogical
 
 				            @Instantiable
-				            public final class Pathalogical {
+				            public final class Pathalogical: Instantiable {
 				                public init() {}
 				            }
 				        }
 
 				        @Instantiable
-				        public final class Pathalogical {
+				        public final class Pathalogical: Instantiable {
 				            public init() {}
 				        }
 				    }
@@ -4965,7 +4965,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -5014,7 +5014,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import Foundation
 
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(inner: Inner) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -5022,7 +5022,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				    public protocol Inner {}
 
 				    @Instantiable(fulfillingAdditionalTypes: [Inner.self])
-				    public final class DefaultInner: Inner {
+				    public final class DefaultInner: Inner, Instantiable {
 				        public init() {}
 				    }
 
@@ -5031,7 +5031,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -5075,7 +5075,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				import Foundation
 
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(inner: Inner) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -5083,7 +5083,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				    public protocol Inner {}
 
 				    @Instantiable(fulfillingAdditionalTypes: [Child.Inner.self])
-				    public final class DefaultInner: Inner {
+				    public final class DefaultInner: Inner, Instantiable {
 				        public init() {}
 				    }
 
@@ -5092,7 +5092,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(child: Child) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -5137,14 +5137,14 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 
 				public final class EnclosingType {
 				    @Instantiable
-				    public final class SomeType: ErasedType {
+				    public final class SomeType: ErasedType, Instantiable {
 				        public init() {}
 				    }
 				}
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public final class TypeWithDependency {
+				public final class TypeWithDependency: Instantiable {
 				    public init(erasedType: ErasedType ) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -5185,7 +5185,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 
 				public final class EnclosingType {
 				    @Instantiable
-				    public final class SomeType: ErasedType {
+				    public final class SomeType: ErasedType, Instantiable {
 				        public init() {}
 				    }
 				}
@@ -5196,7 +5196,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(isRoot: true)
-				public final class TypeWithDependency {
+				public final class TypeWithDependency: Instantiable {
 				    public init(erasedType: ErasedType ) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -5230,7 +5230,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 					public init(a: A, b: B) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5241,7 +5241,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class A {
+				public final class A: Instantiable {
 					public init() {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5249,7 +5249,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class B {
+				public final class B: Instantiable {
 					public init(a: A?) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5284,7 +5284,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 					public init(a: A?, b: B) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5295,7 +5295,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class A {
+				public final class A: Instantiable {
 					public init() {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5303,7 +5303,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class B {
+				public final class B: Instantiable {
 					public init(a: A?) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5338,7 +5338,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 					public init(b: B) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5348,7 +5348,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class A {
+				public final class A: Instantiable {
 					public init() {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5356,7 +5356,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class B {
+				public final class B: Instantiable {
 					public init(a: A?) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5390,7 +5390,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 					public init(aBuilder: Instantiator<A>) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5400,7 +5400,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class A {
+				public final class A: Instantiable {
 					public init(b: B, c: C) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5411,7 +5411,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class B {
+				public final class B: Instantiable {
 					public init(c: C?) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5421,7 +5421,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class C {
+				public final class C: Instantiable {
 					public init() {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5458,7 +5458,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 					public init(aBuilder: Instantiator<A>, bBuilder: Instantiator<B>) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5469,7 +5469,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class A {
+				public final class A: Instantiable {
 					public init(c: C, d: D) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5480,7 +5480,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class B {
+				public final class B: Instantiable {
 					public init(c: C?) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5490,7 +5490,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class C {
+				public final class C: Instantiable {
 					public init() {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5498,7 +5498,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class D {
+				public final class D: Instantiable {
 					public init(b: B) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5545,7 +5545,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 					public init(aBuilder: Instantiator<A>) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5555,7 +5555,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class A {
+				public final class A: Instantiable {
 					public init(c: C) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5565,7 +5565,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class B {
+				public final class B: Instantiable {
 					public init(c: C?) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5575,7 +5575,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class C {
+				public final class C: Instantiable {
 					public init(b: B) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5617,7 +5617,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 					public init(b: B) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5627,7 +5627,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class A {
+				public final class A: Instantiable {
 					public init() {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5635,7 +5635,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class B {
+				public final class B: Instantiable {
 					public init(aRenamed: ARenamed?) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5673,7 +5673,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 					public init(aBuilder: Instantiator<A>) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5683,7 +5683,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class A {
+				public final class A: Instantiable {
 					public init(b: B, c: C) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5694,7 +5694,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class B {
+				public final class B: Instantiable {
 					public init(cRenamed: CRenamed?) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5704,7 +5704,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class C {
+				public final class C: Instantiable {
 					public init() {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5745,7 +5745,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 					public init(aBuilder: Instantiator<A>, bBuilder: Instantiator<B>) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5756,7 +5756,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class A {
+				public final class A: Instantiable {
 					public init(c: C, d: D) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5767,7 +5767,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class B {
+				public final class B: Instantiable {
 					public init(cRenamed: CRenamed?) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5777,7 +5777,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class C {
+				public final class C: Instantiable {
 					public init() {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5785,7 +5785,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class D {
+				public final class D: Instantiable {
 					public init(b: B) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -5849,7 +5849,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init(consumer: Consumer, service: Service) {
 				        self.consumer = consumer
 				        self.service = service
@@ -5861,7 +5861,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct Consumer {
+				public struct Consumer: Instantiable {
 				    public init(service: Service, alias: Service) {
 				        self.service = service
 				        self.alias = alias
@@ -5873,7 +5873,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct Service {
+				public struct Service: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -5920,7 +5920,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init(consumer: Consumer, service: Service) {
 				        self.consumer = consumer
 				        self.service = service
@@ -5932,7 +5932,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct Consumer {
+				public struct Consumer: Instantiable {
 				    public init(service: Service, alias: Service?) {
 				        self.service = service
 				        self.alias = alias
@@ -5944,7 +5944,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct Service {
+				public struct Service: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -6051,20 +6051,20 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable
-				public struct Dep {
+				public struct Dep: Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root1 {
+				public struct Root1: Instantiable {
 				    public init(dep: Dep) {
 				        self.dep = dep
 				    }
 				    @Instantiated let dep: Dep
 				}
 				@Instantiable(isRoot: true)
-				public struct Root2 {
+				public struct Root2: Instantiable {
 				    public init(dep: Dep) {
 				        self.dep = dep
 				    }
@@ -6108,7 +6108,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -6140,7 +6140,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 		let depFile = rootDirectory.appendingPathComponent("Dep.swift")
 		try """
 		@Instantiable
-		public struct Dep {
+		public struct Dep: Instantiable {
 		    public init() {}
 		}
 		""".write(to: depFile, atomically: true, encoding: .utf8)
@@ -6148,7 +6148,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 		let featureARootFile = featureADirectory.appendingPathComponent("Root.swift")
 		try """
 		@Instantiable(isRoot: true)
-		public struct FeatureARoot {
+		public struct FeatureARoot: Instantiable {
 		    public init(dep: Dep) {
 		        self.dep = dep
 		    }
@@ -6159,7 +6159,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 		let featureBRootFile = featureBDirectory.appendingPathComponent("Root.swift")
 		try """
 		@Instantiable(isRoot: true)
-		public struct FeatureBRoot {
+		public struct FeatureBRoot: Instantiable {
 		    public init(dep: Dep) {
 		        self.dep = dep
 		    }
@@ -6239,14 +6239,14 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 		let rootFile = rootDirectory.appendingPathComponent("Root.swift")
 		try """
 		@Instantiable(isRoot: true)
-		public struct Root {
+		public struct Root: Instantiable {
 		    public init(dep: Dep) {
 		        self.dep = dep
 		    }
 		    @Instantiated let dep: Dep
 		}
 		@Instantiable
-		public struct Dep {
+		public struct Dep: Instantiable {
 		    public init() {}
 		}
 		""".write(to: rootFile, atomically: true, encoding: .utf8)
@@ -6289,7 +6289,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 		let depFile = rootDirectory.appendingPathComponent("Dep.swift")
 		try """
 		@Instantiable
-		public struct Dep {
+		public struct Dep: Instantiable {
 		    public init() {}
 		}
 		""".write(to: depFile, atomically: true, encoding: .utf8)
@@ -6297,7 +6297,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 		let featureARootFile = featureADirectory.appendingPathComponent("Root.swift")
 		try """
 		@Instantiable(isRoot: true)
-		public struct FeatureARoot {
+		public struct FeatureARoot: Instantiable {
 		    public init(dep: Dep) {
 		        self.dep = dep
 		    }
@@ -6308,7 +6308,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 		let featureBRootFile = featureBDirectory.appendingPathComponent("Root.swift")
 		try """
 		@Instantiable(isRoot: true)
-		public struct FeatureBRoot {
+		public struct FeatureBRoot: Instantiable {
 		    public init(dep: Dep) {
 		        self.dep = dep
 		    }
@@ -6413,14 +6413,14 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 		let swiftFile = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString + ".swift")
 		try """
 		@Instantiable(isRoot: true)
-		public struct Root {
+		public struct Root: Instantiable {
 		    public init(dep: Dep) {
 		        self.dep = dep
 		    }
 		    @Instantiated let dep: Dep
 		}
 		@Instantiable
-		public struct Dep {
+		public struct Dep: Instantiable {
 		    public init() {}
 		}
 		""".write(to: swiftFile, atomically: true, encoding: .utf8)
@@ -6475,14 +6475,14 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				public protocol NetworkService {}
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init(networkService: NetworkService) {
 				        self.networkService = networkService
 				    }
@@ -6511,7 +6511,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 					public init(childVCBuilder: Instantiator<ChildVC>, service: Service) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -6522,7 +6522,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class ChildVC {
+				public final class ChildVC: Instantiable {
 					public init(grandchildVCBuilder: Instantiator<GrandchildVC>) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -6532,7 +6532,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildVC {
+				public final class GrandchildVC: Instantiable {
 					public init(service: Service?) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -6542,7 +6542,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class Service {
+				public final class Service: Instantiable {
 					public init() {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -6587,7 +6587,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct NotRoot {
+				public struct NotRoot: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -6636,13 +6636,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct Dep {
+				public struct Dep: Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public struct TargetRoot {
+				public struct TargetRoot: Instantiable {
 				    public init(dep: Dep) {
 				        self.dep = dep
 				    }
@@ -6653,7 +6653,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			additionalDirectorySwiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct AdditionalRoot {
+				public struct AdditionalRoot: Instantiable {
 				    public init(dep: Dep) {
 				        self.dep = dep
 				    }
@@ -6684,13 +6684,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct Dep {
+				public struct Dep: Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public struct TargetRoot {
+				public struct TargetRoot: Instantiable {
 				    public init(dep: Dep) {
 				        self.dep = dep
 				    }
@@ -6701,7 +6701,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			additionalDirectorySwiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct AdditionalRootA {
+				public struct AdditionalRootA: Instantiable {
 				    public init(dep: Dep) {
 				        self.dep = dep
 				    }
@@ -6710,7 +6710,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public struct AdditionalRootB {
+				public struct AdditionalRootB: Instantiable {
 				    public init(dep: Dep) {
 				        self.dep = dep
 				    }
@@ -6746,7 +6746,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct Dep {
+				public struct Dep: Instantiable {
 				    public init() {}
 				}
 				""",
@@ -6754,7 +6754,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			additionalDirectorySwiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct AdditionalRoot {
+				public struct AdditionalRoot: Instantiable {
 				    public init(dep: Dep) {
 				        self.dep = dep
 				    }
@@ -6785,13 +6785,13 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct SharedDep {
+				public struct SharedDep: Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable
-				public struct TargetOnlyDep {
+				public struct TargetOnlyDep: Instantiable {
 				    public init(shared: SharedDep) {
 				        self.shared = shared
 				    }
@@ -6800,7 +6800,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public struct TargetRoot {
+				public struct TargetRoot: Instantiable {
 				    public init(dep: TargetOnlyDep) {
 				        self.dep = dep
 				    }
@@ -6811,7 +6811,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 			additionalDirectorySwiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct AdditionalRoot {
+				public struct AdditionalRoot: Instantiable {
 				    public init(shared: SharedDep) {
 				        self.shared = shared
 				    }
@@ -6838,14 +6838,14 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 		let rootFile = rootDirectory.appendingPathComponent("Root.swift")
 		try """
 		@Instantiable(isRoot: true)
-		public struct Root {
+		public struct Root: Instantiable {
 		    public init(dep: Dep) {
 		        self.dep = dep
 		    }
 		    @Instantiated let dep: Dep
 		}
 		@Instantiable
-		public struct Dep {
+		public struct Dep: Instantiable {
 		    public init() {}
 		}
 		""".write(to: rootFile, atomically: true, encoding: .utf8)
@@ -6883,7 +6883,7 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 		let rootFile = rootDirectory.appendingPathComponent("Root.swift")
 		try """
 		@Instantiable(isRoot: true)
-		public struct Root {
+		public struct Root: Instantiable {
 		    public init() {}
 		}
 		""".write(to: rootFile, atomically: true, encoding: .utf8)

--- a/Tests/SafeDIToolTests/SafeDIToolDOTGenerationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolDOTGenerationTests.swift
@@ -66,13 +66,13 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    let urlSession: URLSession = .shared
 				}
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    @Instantiated let networkService: NetworkService
 				}
 				""",
@@ -100,19 +100,19 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    let urlSession: URLSession = .shared
 				}
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root1 {
+				public struct Root1: Instantiable {
 				    @Instantiated let networkService: NetworkService
 				}
 				""",
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root2 {
+				public struct Root2: Instantiable {
 				    @Instantiated let networkService: NetworkService
 				}
 				""",
@@ -145,7 +145,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public func login(username: String, password: String) async -> User {
 				        User()
 				    }
@@ -156,7 +156,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -164,7 +164,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<User, UIViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -194,7 +194,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    @Forwarded private let user: User
 
 				    @Received let networkService: NetworkService                }
@@ -229,7 +229,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public func login(username: String, password: String) async -> User {
 				        User()
 				    }
@@ -240,7 +240,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -248,7 +248,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -276,7 +276,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class UserService {
+				public final class UserService: Instantiable {
 				    @Received let user: User
 				}
 				""",
@@ -284,7 +284,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    @Forwarded private let user: User
 
 				    @Received let networkService: NetworkService
@@ -325,7 +325,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public func login(username: String, password: String) async -> User {
 				        User()
 				    }
@@ -336,7 +336,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -344,7 +344,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<(userID: String, userName: String), UIViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -372,7 +372,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class UserService {
+				public final class UserService: Instantiable {
 				    @Received let userName: String
 
 				    @Received let userID: String
@@ -382,7 +382,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    @Forwarded private let userName: String
 
 				    @Forwarded private let userID: String
@@ -426,7 +426,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public func login(username: String, password: String) async -> User {
 				        User()
 				    }
@@ -437,7 +437,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -445,7 +445,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<LoggedInViewController.ForwardedProperties, UIViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -473,7 +473,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class UserService {
+				public final class UserService: Instantiable {
 				    @Received let userName: String
 
 				    @Received let userID: String
@@ -483,7 +483,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    @Forwarded private let userName: String
 
 				    @Forwarded private let userID: String
@@ -524,7 +524,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public func login(username: String, password: String) async -> User {
 				        User()
 				    }
@@ -535,7 +535,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -543,7 +543,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -571,7 +571,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class UserService {
+				public final class UserService: Instantiable {
 				    @Received let user: User
 
 				    @Received private let networkService: NetworkService
@@ -581,7 +581,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    @Forwarded private let user: User
 
 				    @Instantiated let userService: UserService
@@ -618,7 +618,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public func login(username: String, password: String) async -> User {
 				        User()
 				    }
@@ -629,7 +629,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -637,7 +637,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -665,7 +665,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class UserService {
+				public final class UserService: Instantiable {
 				    @Received let user: User
 
 				    @Received private let networkService: NetworkService
@@ -675,7 +675,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    @Forwarded private let user: User
 
 				    @Instantiated let userServiceInstantiator: Instantiator<UserService>
@@ -705,7 +705,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    @Instantiated let childA: ChildA
 				    @Instantiated let childB: ChildB
 				    @Instantiated let greatGrandchild: GreatGrandchild
@@ -713,45 +713,45 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class ChildA {
+				public final class ChildA: Instantiable {
 				    @Instantiated let grandchildAA: GrandchildAA
 				    @Instantiated let grandchildAB: GrandchildAB
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildAA {
+				public final class GrandchildAA: Instantiable {
 				    @Received let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildAB {
+				public final class GrandchildAB: Instantiable {
 				    @Received let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class ChildB {
+				public final class ChildB: Instantiable {
 				    @Instantiated let grandchildBA: GrandchildBA
 				    @Instantiated let grandchildBB: GrandchildBB
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildBA {
+				public final class GrandchildBA: Instantiable {
 				    @Received let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildBB {
+				public final class GrandchildBB: Instantiable {
 				    @Received let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchild {}
+				public final class GreatGrandchild: Instantiable {}
 				""",
 
 			],
@@ -780,14 +780,14 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    @Instantiated let childA: ChildA
 				    @Instantiated let childB: ChildB
 				}
 				""",
 				"""
 				@Instantiable
-				public final class ChildA {
+				public final class ChildA: Instantiable {
 				    @Instantiated let grandchildAA: GrandchildAA
 				    @Instantiated let grandchildAB: GrandchildAB
 				    @Instantiated let greatGrandchild: GreatGrandchild
@@ -795,19 +795,19 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildAA {
+				public final class GrandchildAA: Instantiable {
 				    @Received let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildAB {
+				public final class GrandchildAB: Instantiable {
 				    @Received let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class ChildB {
+				public final class ChildB: Instantiable {
 				    @Instantiated let grandchildBA: GrandchildBA
 				    @Instantiated let grandchildBB: GrandchildBB
 				    @Instantiated let greatGrandchild: GreatGrandchild
@@ -815,19 +815,19 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildBA {
+				public final class GrandchildBA: Instantiable {
 				    @Received let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildBB {
+				public final class GrandchildBB: Instantiable {
 				    @Received let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchild {}
+				public final class GreatGrandchild: Instantiable {}
 				""",
 
 			],
@@ -857,31 +857,31 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    @Instantiated let child: Child
 				}
 				""",
 				"""
 				@Instantiable
-				public final class Recreated {}
+				public final class Recreated: Instantiable {}
 				""",
 				"""
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    @Instantiated let grandchild: Grandchild
 				    @Instantiated let recreated: Recreated
 				}
 				""",
 				"""
 				@Instantiable
-				public final class Grandchild {
+				public final class Grandchild: Instantiable {
 				    @Instantiated let greatGrandchild: GreatGrandchild
 				    @Instantiated let recreated: Recreated
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchild {
+				public final class GreatGrandchild: Instantiable {
 				    @Received let recreated: Recreated
 				}
 				""",
@@ -910,52 +910,52 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    @Instantiated let childA: ChildA
 				    @Instantiated let childB: ChildB
 				}
 				""",
 				"""
 				@Instantiable
-				public final class ChildA {
+				public final class ChildA: Instantiable {
 				    @Instantiated let grandchildAA: GrandchildAA
 				    @Instantiated let grandchildAB: GrandchildAB
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildAA {
+				public final class GrandchildAA: Instantiable {
 				    @Instantiated let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildAB {
+				public final class GrandchildAB: Instantiable {
 				    @Instantiated let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class ChildB {
+				public final class ChildB: Instantiable {
 				    @Instantiated let grandchildBA: GrandchildBA
 				    @Instantiated let grandchildBB: GrandchildBB
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildBA {
+				public final class GrandchildBA: Instantiable {
 				    @Instantiated let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GrandchildBB {
+				public final class GrandchildBB: Instantiable {
 				    @Instantiated let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchild {}
+				public final class GreatGrandchild: Instantiable {}
 				""",
 
 			],
@@ -987,7 +987,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable
-				public final class GreatGrandchild: Sendable {}
+				public final class GreatGrandchild: Sendable, Instantiable {}
 				""",
 			],
 			buildDOTFileOutput: false,
@@ -1000,7 +1000,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import GreatGrandchildModule
 
 				@Instantiable
-				public final class GrandchildAA {
+				public final class GrandchildAA: Instantiable {
 				    @Instantiated let greatGrandchild: GreatGrandchild
 				}
 				""",
@@ -1008,7 +1008,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import GreatGrandchildModule
 
 				@Instantiable
-				public final class GrandchildAB {
+				public final class GrandchildAB: Instantiable {
 				    @Instantiated let greatGrandchild: GreatGrandchild
 				}
 				""",
@@ -1016,7 +1016,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import GreatGrandchildModule
 
 				@Instantiable
-				public final class GrandchildBA {
+				public final class GrandchildBA: Instantiable {
 				    @Instantiated var greatGrandchildInstantiator: SendableInstantiator<GreatGrandchild>
 				}
 				""",
@@ -1024,7 +1024,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import GreatGrandchildModule
 
 				@Instantiable
-				public final class GrandchildBB {
+				public final class GrandchildBB: Instantiable {
 				    @Instantiated greatGrandchildInstantiator: SendableInstantiator<GreatGrandchild>
 				}
 				""",
@@ -1042,7 +1042,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 
 				@MainActor
 				@Instantiable
-				public final class ChildA {
+				public final class ChildA: Instantiable {
 				    @Instantiated let grandchildAA: GrandchildAA
 				    @Instantiated let grandchildAB: GrandchildAB
 				}
@@ -1051,7 +1051,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				@preconcurrency import GrandchildModule
 
 				@Instantiable
-				public final class ChildB {
+				public final class ChildB: Instantiable {
 				    @Instantiated let grandchildBA: GrandchildBA
 				    @Instantiated let grandchildBB: GrandchildBB
 				}
@@ -1072,7 +1072,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 
 				@MainActor
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    @Instantiated let childA: ChildA
 				    @Instantiated let childB: ChildB
 				}
@@ -1111,7 +1111,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    @Instantiated private let defaultUserService: DefaultUserService
 
 				    @Received(fulfilledByDependencyNamed: "defaultUserService", ofType: DefaultUserService.self) private let userService: any UserService
@@ -1125,7 +1125,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [UserService.self])
-				public final class DefaultUserService: UserService {
+				public final class DefaultUserService: UserService, Instantiable {
 				    public init() {}
 
 				    public var userName: String?
@@ -1157,7 +1157,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self])
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -1167,7 +1167,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self])
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public func login(username: String, password: String) async -> User {
 				        User(username: username)
 				    }
@@ -1184,7 +1184,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -1220,30 +1220,30 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    @Instantiated let child: Child
 				}
 				""",
 				"""
 				@Instantiable
-				public final class Unrelated {}
+				public final class Unrelated: Instantiable {}
 				""",
 				"""
 				@Instantiable
-				public final class Child {
+				public final class Child: Instantiable {
 				    @Instantiated let grandchild: Grandchild
 				    @Instantiated let unrelated: Unrelated @Instantiated let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class Grandchild {
+				public final class Grandchild: Instantiable {
 				    @Received let greatGrandchild: GreatGrandchild
 				}
 				""",
 				"""
 				@Instantiable
-				public final class GreatGrandchild {}
+				public final class GreatGrandchild: Instantiable {}
 				""",
 			],
 			buildDOTFileOutput: true,
@@ -1268,7 +1268,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    @Instantiated let a: A
 				    @Instantiated let b: B
 				    @Instantiated let c: C
@@ -1299,13 +1299,13 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class A {
+				public final class A: Instantiable {
 				    @Received let x: X
 				}
 				""",
 				"""
 				@Instantiable
-				public final class B {
+				public final class B: Instantiable {
 				    @Received let a: A
 				    @Received let d: D
 				    @Received let t: T
@@ -1316,7 +1316,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class C {
+				public final class C: Instantiable {
 				    @Received let u: U
 				    @Received let n: N
 				    @Received let y: Y
@@ -1324,58 +1324,58 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class D {
+				public final class D: Instantiable {
 				    @Received let o: O
 				    @Received let g: G
 				}
 				""",
 				"""
 				@Instantiable
-				public final class E {
+				public final class E: Instantiable {
 				    @Received let g: G
 				}
 				""",
 				"""
 				@Instantiable
-				public final class F {
+				public final class F: Instantiable {
 				    @Received let a: A
 				    @Received let x: X
 				}
 				""",
 				"""
 				@Instantiable
-				public final class G {}
+				public final class G: Instantiable {}
 				""",
 				"""
 				@Instantiable
-				public final class H {
+				public final class H: Instantiable {
 				    @Received let u: U
 				    @Received let g: G
 				}
 				""",
 				"""
 				@Instantiable
-				public final class I {
+				public final class I: Instantiable {
 				    @Received let f: F
 				}
 				""",
 				"""
 				@Instantiable
-				public final class J {
+				public final class J: Instantiable {
 				    @Received let a: A
 				    @Received let g: G
 				}
 				""",
 				"""
 				@Instantiable
-				public final class K {
+				public final class K: Instantiable {
 				    @Received let i: I
 				    @Received let t: T
 				}
 				""",
 				"""
 				@Instantiable
-				public final class L {
+				public final class L: Instantiable {
 				    @Received let o: O
 				    @Received let v: V
 				    @Received let e: E
@@ -1383,13 +1383,13 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class M {
+				public final class M: Instantiable {
 				    @Received let e: E
 				}
 				""",
 				"""
 				@Instantiable
-				public final class N {
+				public final class N: Instantiable {
 				    @Received let o: O
 				    @Received let p: P
 				    @Received let e: E
@@ -1397,7 +1397,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class O {
+				public final class O: Instantiable {
 				    @Received let m: M
 				    @Received let e: E
 				    @Received let g: G
@@ -1406,14 +1406,14 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class P {
+				public final class P: Instantiable {
 				    @Received let i: I
 				    @Received let x: X
 				}
 				""",
 				"""
 				@Instantiable
-				public final class Q {
+				public final class Q: Instantiable {
 				    @Received let u: U
 				    @Received let t: T
 				    @Received let e: E
@@ -1421,7 +1421,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class R {
+				public final class R: Instantiable {
 				    @Received let a: A
 				    @Received let m: M
 				    @Received let o: O
@@ -1431,7 +1431,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class S {
+				public final class S: Instantiable {
 				    @Received let a: A
 				    @Received let t: T
 				    @Received let o: O
@@ -1440,14 +1440,14 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class T {
+				public final class T: Instantiable {
 				    @Received let e: E
 				    @Received let n: N
 				}
 				""",
 				"""
 				@Instantiable
-				public final class U {
+				public final class U: Instantiable {
 				    @Received let p: P
 				    @Received let d: D
 				    @Received let o: O
@@ -1457,7 +1457,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class V {
+				public final class V: Instantiable {
 				    @Received let a: A
 				    @Received let t: T
 				    @Received let o: O
@@ -1469,7 +1469,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class W {
+				public final class W: Instantiable {
 				    @Received let a: A
 				    @Received let x: X
 				    @Received let o: O
@@ -1478,18 +1478,18 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public final class X {}
+				public final class X: Instantiable {}
 				""",
 				"""
 				@Instantiable
-				public final class Y {
+				public final class Y: Instantiable {
 				    @Received let u: U
 				    @Received let p: P
 				}
 				""",
 				"""
 				@Instantiable
-				public final class Z {
+				public final class Z: Instantiable {
 				    @Received let e: E
 				    @Received let p: P
 				    @Received let l: L
@@ -1542,25 +1542,25 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    @Instantiated let aBuilder: Instantiator<A>
 				}
 				""",
 				"""
 				@Instantiable
-				public struct A {
+				public struct A: Instantiable {
 				    @Instantiated let bBuilder: Instantiator<B>
 				}
 				""",
 				"""
 				@Instantiable
-				public struct B {
+				public struct B: Instantiable {
 				    @Instantiated let cBuilder: Instantiator<C>
 				}
 				""",
 				"""
 				@Instantiable
-				public struct C {
+				public struct C: Instantiable {
 				    @Instantiated let aBuilder: Instantiator<A>
 				}
 				""",
@@ -1587,13 +1587,13 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    @Instantiated let a: A
 				}
 				""",
 				"""
 				@Instantiable
-				public struct A {
+				public struct A: Instantiable {
 				    @Instantiated let aBuilder: Instantiator<A>
 				}
 				""",
@@ -1619,13 +1619,13 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    @Instantiated let aBuilder: Instantiator<A>
 				}
 				""",
 				"""
 				@Instantiable
-				public struct A {
+				public struct A: Instantiable {
 				    @Instantiated let aBuilder: Instantiator<A>
 				    @Forwarded let context: String
 				}
@@ -1653,7 +1653,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    @Instantiated let stringContainer: Container<String>
 				    @Instantiated let intContainer: Container<Int>
 				    @Instantiated let floatContainer: Container<Float>
@@ -1703,7 +1703,7 @@ struct SafeDIToolDOTGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    @Instantiated let stringContainer: MyModule.Container<String>
 				    @Instantiated let intContainer: MyModule.Container<Int>
 				    @Instantiated let floatContainer: MyModule.Container<Float>

--- a/Tests/SafeDIToolTests/SafeDIToolMockGenerationConfigurationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockGenerationConfigurationTests.swift
@@ -260,7 +260,7 @@ struct SafeDIToolMockGenerationConfigurationTests: ~Copyable {
 				public class ExternalService {}
 
 				@Instantiable(mockAttributes: "@MainActor", generateMock: true)
-				extension ExternalService {
+				extension ExternalService: Instantiable {
 				    public static func instantiate() -> ExternalService {
 				        ExternalService()
 				    }

--- a/Tests/SafeDIToolTests/SafeDIToolMockGenerationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockGenerationTests.swift
@@ -3092,7 +3092,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true, generateMock: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(a: A?, b: B) {
 				        self.a = a
 				        self.b = b
@@ -3104,13 +3104,13 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(generateMock: true)
-				public final class A {
+				public final class A: Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable(generateMock: true)
-				public final class B {
+				public final class B: Instantiable {
 				    public init(a: A?) {
 				        self.a = a
 				    }
@@ -3206,7 +3206,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true, generateMock: true)
-				public struct Root {
+				public struct Root: Instantiable {
 				    public init(defaultUserService: DefaultUserService, userService: any UserService) {
 				        self.defaultUserService = defaultUserService
 				        self.userService = userService
@@ -3223,7 +3223,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [UserService.self], generateMock: true)
-				public final class DefaultUserService: UserService {
+				public final class DefaultUserService: UserService, Instantiable {
 				    public init() {}
 
 				    public var userName: String?
@@ -3293,7 +3293,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self], generateMock: true)
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3309,7 +3309,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self], generateMock: true)
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -3317,7 +3317,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(isRoot: true, generateMock: true)
-				public final class RootViewController: UIViewController {
+				public final class RootViewController: UIViewController, Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: ErasedInstantiator<User, UIViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -3336,7 +3336,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				import UIKit
 
 				@Instantiable(generateMock: true)
-				public final class LoggedInViewController: UIViewController {
+				public final class LoggedInViewController: UIViewController, Instantiable {
 				    public init(user: User, networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3724,7 +3724,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self], generateMock: true)
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -3732,7 +3732,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				public protocol AuthService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self], generateMock: true)
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3744,13 +3744,13 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				public protocol UserVendor {}
 
 				@Instantiable(fulfillingAdditionalTypes: [UserVendor.self], generateMock: true)
-				public final class UserManager: UserVendor {
+				public final class UserManager: UserVendor, Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable(isRoot: true, generateMock: true)
-				public final class RootViewController {
+				public final class RootViewController: Instantiable {
 				    public init(authService: AuthService, networkService: NetworkService, loggedInViewControllerBuilder: Instantiator<LoggedInViewController>) {
 				        self.authService = authService
 				        self.networkService = networkService
@@ -3766,7 +3766,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(generateMock: true)
-				public final class LoggedInViewController {
+				public final class LoggedInViewController: Instantiable {
 				    public init(userManager: UserManager, userNetworkService: NetworkService, profileViewControllerBuilder: Instantiator<ProfileViewController>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3780,7 +3780,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(generateMock: true)
-				public final class ProfileViewController {
+				public final class ProfileViewController: Instantiable {
 				    public init(userVendor: UserVendor, editProfileViewControllerBuilder: Instantiator<EditProfileViewController>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -3792,7 +3792,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(generateMock: true)
-				public final class EditProfileViewController {
+				public final class EditProfileViewController: Instantiable {
 				    public init(userVendor: UserVendor, userManager: UserManager, userNetworkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4081,7 +4081,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(isRoot: true, generateMock: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(childBuilder: Instantiator<Child>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4091,7 +4091,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(generateMock: true)
-				public final class Child {
+				public final class Child: Instantiable {
 				    public init(iterator: IndexingIterator<Array<Element>>, grandchildBuilder: Instantiator<Grandchild>) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4102,7 +4102,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(generateMock: true)
-				public final class Grandchild {
+				public final class Grandchild: Instantiable {
 				    public init(anyIterator: AnyIterator) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4242,7 +4242,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(fulfillingAdditionalTypes: [ChildAProtocol.self], generateMock: true)
-				public final class ChildA: ChildAProtocol {
+				public final class ChildA: ChildAProtocol, Instantiable {
 				    public init(recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4251,7 +4251,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(generateMock: true)
-				public final class ChildB {
+				public final class ChildB: Instantiable {
 				    public init(recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4260,7 +4260,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true, generateMock: true)
-				public final class Root {
+				public final class Root: Instantiable {
 				    public init(childABuilder: SendableErasedInstantiator<Recreated, ChildAProtocol>, childB: ChildB, recreated: Recreated) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4774,7 +4774,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				public protocol NetworkService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [NetworkService.self], generateMock: true)
-				public final class DefaultNetworkService: NetworkService {
+				public final class DefaultNetworkService: NetworkService, Instantiable {
 				    public init() {}
 				}
 				""",
@@ -4782,7 +4782,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				public protocol AuthService {}
 
 				@Instantiable(fulfillingAdditionalTypes: [AuthService.self], generateMock: true)
-				public final class DefaultAuthService: AuthService {
+				public final class DefaultAuthService: AuthService, Instantiable {
 				    public init(networkService: NetworkService, renamedNetworkService: NetworkService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -4794,7 +4794,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(isRoot: true, generateMock: true)
-				public final class RootViewController {
+				public final class RootViewController: Instantiable {
 				    public init(authService: AuthService) {
 				        self.authService = authService
 				    }
@@ -5050,7 +5050,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				public struct ExternalType {}
 
 				@Instantiable(generateMock: true)
-				extension ExternalType {
+				extension ExternalType: Instantiable {
 				    public static func instantiate() -> ExternalType {
 				        ExternalType()
 				    }
@@ -5379,13 +5379,13 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(generateMock: true)
-				public final class ConcreteService {
+				public final class ConcreteService: Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable(generateMock: true)
-				public final class Consumer {
+				public final class Consumer: Instantiable {
 				    public init(service: ConcreteService) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -5710,13 +5710,13 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(fulfillingAdditionalTypes: [ServiceProtocol.self], generateMock: true)
-				public final class ConcreteService: ServiceProtocol {
+				public final class ConcreteService: ServiceProtocol, Instantiable {
 				    public init() {}
 				}
 				""",
 				"""
 				@Instantiable(generateMock: true)
-				public final class Consumer {
+				public final class Consumer: Instantiable {
 				    public init(service: ServiceProtocol) {
 				        fatalError("SafeDI doesn't inspect the initializer body")
 				    }
@@ -10387,7 +10387,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 			swiftFileContent: [
 				"""
 				@Instantiable(generateMock: true)
-				public struct Root {
+				public struct Root: Instantiable {
 					public init(aBuilder: Instantiator<A>) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}
@@ -10397,7 +10397,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 				""",
 				"""
 				@Instantiable
-				public struct A {
+				public struct A: Instantiable {
 					public init(root: Root) {
 						fatalError("SafeDI doesn't inspect the initializer body")
 					}

--- a/Tests/SafeDIToolTests/SafeDIToolMockOnlyErrorTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockOnlyErrorTests.swift
@@ -48,13 +48,13 @@ struct SafeDIToolMockOnlyErrorTests: ~Copyable {
 				swiftFileContent: [
 					"""
 					@Instantiable(mockOnly: true)
-					extension MyService {
+					extension MyService: Instantiable {
 					    public static func mock() -> MyService { fatalError() }
 					}
 					""",
 					"""
 					@Instantiable(mockOnly: true)
-					extension MyService {
+					extension MyService: Instantiable {
 					    public static func mock() -> MyService { fatalError() }
 					}
 					""",
@@ -217,7 +217,7 @@ struct SafeDIToolMockOnlyErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable(mockOnly: true)
-					extension MyService {
+					extension MyService: Instantiable {
 					    public static func mock() -> MyService { MyService() }
 					}
 					""",
@@ -296,7 +296,7 @@ struct SafeDIToolMockOnlyErrorTests: ~Copyable {
 					""",
 					"""
 					@Instantiable(mockOnly: true)
-					extension MyService {
+					extension MyService: Instantiable {
 					    public static func mock() -> MyService { MyService() }
 					}
 					""",

--- a/Tests/SafeDIToolTests/SafeDIToolMockOnlyTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockOnlyTests.swift
@@ -54,7 +54,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true)
-				extension String {
+				extension String: Instantiable {
 				    public static func mock() -> String { "" }
 				}
 				""",
@@ -97,7 +97,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true)
-				extension Int {
+				extension Int: Instantiable {
 				    public static func mock() -> Int { 0 }
 				}
 				""",
@@ -140,7 +140,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true)
-				extension ExternalService {
+				extension ExternalService: Instantiable {
 				    public static func mock() -> ExternalService { fatalError() }
 				}
 				""",
@@ -195,7 +195,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true, customMockName: "testValue")
-				extension String {
+				extension String: Instantiable {
 				    public static func testValue() -> String { "test" }
 				}
 				""",
@@ -238,7 +238,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true)
-				public struct MyService {
+				public struct MyService: Instantiable {
 				    public static func mock() -> MyService { MyService() }
 				}
 				""",
@@ -305,7 +305,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true)
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func mock() -> MyService { MyService() }
 				}
 				""",
@@ -366,7 +366,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true)
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func mock() -> MyService { MyService() }
 				}
 				""",
@@ -415,7 +415,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview() -> MyService { MyService() }
 				}
 				""",
@@ -464,7 +464,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview() -> MyService { MyService() }
 				}
 				""",
@@ -532,7 +532,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview() -> MyService { MyService() }
 				}
 				""",
@@ -619,7 +619,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true, customMockName: "preview")
-				extension Child {
+				extension Child: Instantiable {
 				    public static func preview() -> Child { Child() }
 				}
 				""",
@@ -681,7 +681,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true, mockAttributes: "@MainActor")
-				extension Child {
+				extension Child: Instantiable {
 				    @MainActor public static func mock() -> Child { Child() }
 				}
 				""",
@@ -1129,7 +1129,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(fulfillingAdditionalTypes: [ServiceProtocol.self], mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview() -> MyService { MyService() }
 				}
 				""",
@@ -1186,7 +1186,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(fulfillingAdditionalTypes: [ServiceProtocol.self], mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview() -> MyService { MyService() }
 				}
 				""",
@@ -1235,7 +1235,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview() -> MyService { MyService() }
 				}
 				""",
@@ -1305,7 +1305,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview() -> MyService { MyService() }
 				}
 				""",
@@ -1393,7 +1393,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(fulfillingAdditionalTypes: [ServiceProtocol.self], mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview() -> MyService { MyService() }
 				}
 				""",
@@ -1472,7 +1472,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview() -> MyService { MyService() }
 				}
 				""",
@@ -1550,7 +1550,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview() -> MyService { MyService() }
 				}
 				""",
@@ -1629,7 +1629,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(fulfillingAdditionalTypes: [ServiceProtocol.self], mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview() -> MyService { MyService() }
 				}
 				""",
@@ -1748,7 +1748,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview() -> MyService { MyService() }
 				}
 				""",
@@ -1799,7 +1799,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview(database: Database = Database()) -> MyService {
 				        MyService(database: database)
 				    }
@@ -2331,7 +2331,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(fulfillingAdditionalTypes: [ServiceProtocol.self], mockOnly: true)
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func mock() -> MyService { MyService() }
 				}
 				""",
@@ -2400,7 +2400,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(fulfillingAdditionalTypes: [ServiceProtocol.self], mockOnly: true, customMockName: "preview")
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func preview() -> MyService { MyService() }
 				}
 				""",
@@ -2487,7 +2487,7 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 				""",
 				"""
 				@Instantiable(fulfillingAdditionalTypes: [ServiceProtocol.self], mockOnly: true)
-				extension MyService {
+				extension MyService: Instantiable {
 				    public static func mock() -> ServiceProtocol { MyService() }
 				}
 				""",


### PR DESCRIPTION
## Summary
- Update every `@Instantiable` test fixture to declare `: Instantiable` itself, matching how production code is written and what the macro requires.
- Pure test-fixture refactor; no production source changes.

## Why
The fixtures have been getting away without the conformance because the generator tests parse them as strings rather than expanding the macro. Declaring the conformance explicitly makes the fixtures match what the macro demands of production code, eliminates a quiet divergence from real-world usage, and unblocks downstream work that actually compiles these fixtures end-to-end.

## Test plan
- [x] `swift build --traits sourceBuild`
- [x] `swift test --traits sourceBuild` (all 831 tests pass)
- [x] `./CLI/lint.sh` (no formatting changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)