### PR TITLE
Macro: diagnose Self.* refs in default expressions

### DIFF
--- a/Sources/SafeDICore/Errors/FixableInstantiableError.swift
+++ b/Sources/SafeDICore/Errors/FixableInstantiableError.swift
@@ -45,7 +45,7 @@ public enum FixableInstantiableError: DiagnosticError {
 	case mockOnlyWithIsRoot
 	case mockOnlyMissingMockMethod(typeName: String, methodName: String)
 	case unlabeledDefaultBeforeUnlabeledParameter(defaultedParameter: Property, followingParameter: Property)
-	case calleeScopeReferenceInDefaultExpression(parameterLabel: String, reference: String)
+	case calleeScopeReferenceInDefaultExpression(parameterLabel: String)
 
 	public enum MissingInitializer: Sendable {
 		case hasOnlyInjectableProperties
@@ -116,8 +116,8 @@ public enum FixableInstantiableError: DiagnosticError {
 			"@\(InstantiableVisitor.macroName)(mockOnly: true) requires a `public static func \(methodName)(…) -> \(typeName)` method."
 		case let .unlabeledDefaultBeforeUnlabeledParameter(defaultedParameter, followingParameter):
 			"Unlabeled parameter `\(defaultedParameter.asSource)` has a default value but is followed by unlabeled required parameter `\(followingParameter.asSource)`. SafeDI cannot generate a mock for this signature: the default cannot be elided from the mock's override surface (Swift requires the earlier positional slot to be passed when a later unlabeled parameter is required), and an unlabeled parameter cannot be exposed as a labeled field on `SafeDIMockConfiguration`. Either add an external label to the defaulted parameter, reorder so unlabeled defaults come last, or remove the default."
-		case let .calleeScopeReferenceInDefaultExpression(parameterLabel, reference):
-			"Default expression for parameter `\(parameterLabel)` references `\(reference)`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `\(reference)` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default."
+		case let .calleeScopeReferenceInDefaultExpression(parameterLabel):
+			"Default expression for parameter `\(parameterLabel)` references `Self`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self` would resolve against the wrong type. Move the referenced value to a file-scoped or module-scoped symbol, or remove the default."
 		}
 	}
 
@@ -232,7 +232,7 @@ public enum FixableInstantiableError: DiagnosticError {
 				"Add `public static func \(methodName)(…) -> \(typeName)` method"
 			case let .unlabeledDefaultBeforeUnlabeledParameter(defaultedParameter, _):
 				"Promote `\(defaultedParameter.label)` to an external label (rewrite `_ \(defaultedParameter.label):` as `\(defaultedParameter.label):`)"
-			case let .calleeScopeReferenceInDefaultExpression(parameterLabel, _):
+			case let .calleeScopeReferenceInDefaultExpression(parameterLabel):
 				"Remove the default from `\(parameterLabel)` or move the referenced value to a file-scoped or module-scoped symbol"
 			}
 			fixItID = MessageID(domain: "\(Self.self)", id: error.description)

--- a/Sources/SafeDICore/Errors/FixableInstantiableError.swift
+++ b/Sources/SafeDICore/Errors/FixableInstantiableError.swift
@@ -45,6 +45,7 @@ public enum FixableInstantiableError: DiagnosticError {
 	case mockOnlyWithIsRoot
 	case mockOnlyMissingMockMethod(typeName: String, methodName: String)
 	case unlabeledDefaultBeforeUnlabeledParameter(defaultedParameter: Property, followingParameter: Property)
+	case calleeScopeReferenceInDefaultExpression(parameterLabel: String, reference: String)
 
 	public enum MissingInitializer: Sendable {
 		case hasOnlyInjectableProperties
@@ -115,6 +116,8 @@ public enum FixableInstantiableError: DiagnosticError {
 			"@\(InstantiableVisitor.macroName)(mockOnly: true) requires a `public static func \(methodName)(…) -> \(typeName)` method."
 		case let .unlabeledDefaultBeforeUnlabeledParameter(defaultedParameter, followingParameter):
 			"Unlabeled parameter `\(defaultedParameter.asSource)` has a default value but is followed by unlabeled required parameter `\(followingParameter.asSource)`. SafeDI cannot generate a mock for this signature: the default cannot be elided from the mock's override surface (Swift requires the earlier positional slot to be passed when a later unlabeled parameter is required), and an unlabeled parameter cannot be exposed as a labeled field on `SafeDIMockConfiguration`. Either add an external label to the defaulted parameter, reorder so unlabeled defaults come last, or remove the default."
+		case let .calleeScopeReferenceInDefaultExpression(parameterLabel, reference):
+			"Default expression for parameter `\(parameterLabel)` references `\(reference)`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `\(reference)` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default."
 		}
 	}
 
@@ -155,7 +158,8 @@ public enum FixableInstantiableError: DiagnosticError {
 			     .mockOnlyWithGenerateMock,
 			     .mockOnlyWithIsRoot,
 			     .mockOnlyMissingMockMethod,
-			     .unlabeledDefaultBeforeUnlabeledParameter:
+			     .unlabeledDefaultBeforeUnlabeledParameter,
+			     .calleeScopeReferenceInDefaultExpression:
 				.error
 			}
 			message = error.description
@@ -228,6 +232,8 @@ public enum FixableInstantiableError: DiagnosticError {
 				"Add `public static func \(methodName)(…) -> \(typeName)` method"
 			case let .unlabeledDefaultBeforeUnlabeledParameter(defaultedParameter, _):
 				"Promote `\(defaultedParameter.label)` to an external label (rewrite `_ \(defaultedParameter.label):` as `\(defaultedParameter.label):`)"
+			case let .calleeScopeReferenceInDefaultExpression(parameterLabel, _):
+				"Remove the default from `\(parameterLabel)` or move the referenced value to a file-scoped or module-scoped symbol"
 			}
 			fixItID = MessageID(domain: "\(Self.self)", id: error.description)
 		}

--- a/Sources/SafeDICore/Models/TypeDescription.swift
+++ b/Sources/SafeDICore/Models/TypeDescription.swift
@@ -477,6 +477,42 @@ public enum TypeDescription: Codable, Hashable, Comparable, Sendable {
 		}
 	}
 
+	/// Whether `Self` appears anywhere inside this type. Walks recursively
+	/// into generics, wrappers, and composed sub-types. Used by the
+	/// `@Instantiable` macro to diagnose default expressions whose type
+	/// references — e.g. `Optional<Self>`, `Result<Self, E>`, `[Self]` —
+	/// would resolve against the caller's scope if the default were promoted
+	/// onto another type's `SafeDIOverrides` struct.
+	public var containsSelf: Bool {
+		switch self {
+		case let .simple(name, generics):
+			name == "Self" || generics.contains(where: \.containsSelf)
+		case let .nested(_, parentType, generics):
+			parentType.containsSelf || generics.contains(where: \.containsSelf)
+		case let .any(wrapped),
+		     let .implicitlyUnwrappedOptional(wrapped),
+		     let .optional(wrapped),
+		     let .some(wrapped):
+			wrapped.containsSelf
+		case let .array(element):
+			element.containsSelf
+		case let .dictionary(key, value):
+			key.containsSelf || value.containsSelf
+		case let .tuple(elements):
+			elements.contains(where: \.typeDescription.containsSelf)
+		case let .composition(elements):
+			elements.contains(where: \.containsSelf)
+		case let .closure(arguments, _, _, returnType):
+			arguments.contains(where: \.containsSelf) || returnType.containsSelf
+		case let .metatype(wrapped, _):
+			wrapped.containsSelf
+		case let .attributed(wrapped, _, _):
+			wrapped.containsSelf
+		case .unknown, .void:
+			false
+		}
+	}
+
 	/// The name of a simple type sans nesting, with associated generics.
 	var simpleNameAndGenerics: (name: String, generics: [TypeDescription])? {
 		switch self {

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -224,18 +224,24 @@ public struct InstantiableMacro: MemberMacro {
 					diagnosticNode: Syntax(initializerSyntax),
 					context: context,
 				)
-				// Only check init defaults when no custom mock method exists —
-				// SafeDI prefers `mockInitializer` over the init for mock
-				// construction (see `generateMockRootCode` and
-				// `generateReturnArgumentList`), so init defaults never reach
-				// the override surface when a mock method is present.
-				if visitor.mockInitializer == nil {
-					Self.validateDefaultExpressions(
-						functionSyntax: initializerSyntax.signature,
-						dependencies: visitor.dependencies,
-						context: context,
-					)
-				}
+			}
+			// Only check init defaults on the initializer SafeDI actually uses
+			// for mock construction — `InstantiableVisitor` selects the first
+			// initializer that fulfills the dependencies (see
+			// `InstantiableVisitor:377`), and `generateMockRootCode` reads that
+			// same initializer. Convenience or secondary inits with `Self.*`
+			// defaults never reach the override surface, so diagnosing them
+			// would be a false positive. Also skipped when a custom mock
+			// exists — then SafeDI prefers `mockInitializer` over any init.
+			if visitor.mockInitializer == nil,
+			   let selectedInitializer = visitor.initializers.first(where: { $0.isValid(forFulfilling: visitor.dependencies) }),
+			   let selectedInitializerSyntax = visitor.initializerToInitSyntaxMap[selectedInitializer]
+			{
+				Self.validateDefaultExpressions(
+					functionSyntax: selectedInitializerSyntax.signature,
+					dependencies: visitor.dependencies,
+					context: context,
+				)
 			}
 			if let mockInitializer = visitor.mockInitializer,
 			   let mockSyntax = visitor.mockFunctionSyntax

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -1229,19 +1229,27 @@ public struct InstantiableMacro: MemberMacro {
 	}
 
 	/// Walks each default-value expression on `functionSyntax`'s parameters and
-	/// diagnoses explicit `Self.*` / `self.*` member access. SafeDI's generated
-	/// mock surface may inline a default expression at the caller (inside the
-	/// parent type's override struct or mock body), where `Self` binds to the
-	/// parent type instead of the decorated type — silently producing the wrong
-	/// value or failing to typecheck. The diagnostic catches the syntactically
-	/// identifiable case so users get a compile error instead of a subtle
-	/// override-surface mismatch. Unqualified references to callee-scope
-	/// members can't be identified without type resolution and are not covered.
+	/// diagnoses explicit `Self.*` member access. SafeDI's generated mock surface
+	/// may promote the default onto the caller's override struct (inside another
+	/// type's extension), where `Self` binds to the caller's type instead of the
+	/// decorated type — silently producing the wrong value or failing to
+	/// typecheck. The diagnostic catches the syntactically identifiable case so
+	/// users get a compile error instead of a subtle override-surface mismatch.
 	///
-	/// Dependency parameters are exempt: SafeDI always threads dependency
-	/// arguments explicitly at the call site, so a dependency's default
-	/// expression is never surfaced on the caller's override struct and its
-	/// `Self.*` / `self.*` refs resolve correctly in the callee.
+	/// `self.` is not checked because Swift already rejects `self.` in default
+	/// expressions on `init` (self isn't constructed yet) and on static
+	/// functions (no instance) — the only parameter shapes SafeDI encounters.
+	/// Unqualified references to callee-scope members can't be identified
+	/// without type resolution and are not covered.
+	///
+	/// Two exemptions skip parameters whose defaults never reach the override
+	/// surface:
+	/// - Dependency parameters, which are always threaded explicitly at the
+	///   mock call site.
+	/// - `_`-labeled non-dependency parameters, which `ScopeGenerator` elides
+	///   from call-site arguments and excludes from `rootDefaultParameters`,
+	///   so Swift's default-argument thunk fires in the callee where `Self.*`
+	///   resolves correctly.
 	private static func validateDefaultExpressions(
 		functionSyntax: FunctionSignatureSyntax,
 		dependencies: [Dependency],
@@ -1250,15 +1258,19 @@ public struct InstantiableMacro: MemberMacro {
 		let dependencyLabels = Set(dependencies.map(\.property.label))
 		for parameter in functionSyntax.parameterClause.parameters {
 			guard let defaultValue = parameter.defaultValue?.value else { continue }
-			let parameterLabel = parameter.secondName?.text ?? parameter.firstName.text
-			guard !dependencyLabels.contains(parameterLabel) else { continue }
-			let finder = CalleeScopeReferenceFinder(viewMode: .sourceAccurate)
+			let firstName = parameter.firstName.text
+			let innerLabel = parameter.secondName?.text ?? firstName
+			guard !dependencyLabels.contains(innerLabel) else { continue }
+			// `_`-labeled non-dependency defaults are elided from the mock
+			// call site, so the default is evaluated in the callee's scope.
+			guard firstName != "_" else { continue }
+			let finder = SelfReferenceFinder(viewMode: .sourceAccurate)
 			finder.walk(Syntax(defaultValue))
 			for reference in finder.references {
 				context.diagnose(Diagnostic(
 					node: Syntax(parameter),
 					message: FixableInstantiableError.calleeScopeReferenceInDefaultExpression(
-						parameterLabel: parameterLabel,
+						parameterLabel: innerLabel,
 						reference: reference,
 					).diagnostic,
 				))
@@ -1266,15 +1278,14 @@ public struct InstantiableMacro: MemberMacro {
 		}
 	}
 
-	private final class CalleeScopeReferenceFinder: SyntaxVisitor {
+	private final class SelfReferenceFinder: SyntaxVisitor {
 		private(set) var references: [String] = []
 
 		override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
-			if let base = node.base?.as(DeclReferenceExprSyntax.self) {
-				let text = base.baseName.text
-				if text == "Self" || text == "self" {
-					references.append("\(text).\(node.declName.baseName.text)")
-				}
+			if let base = node.base?.as(DeclReferenceExprSyntax.self),
+			   base.baseName.text == "Self"
+			{
+				references.append("Self.\(node.declName.baseName.text)")
 			}
 			return .visitChildren
 		}

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -1260,18 +1260,12 @@ public struct InstantiableMacro: MemberMacro {
 	}
 
 	/// Walks each default-value expression on `functionSyntax`'s parameters and
-	/// diagnoses explicit `Self.*` member access. SafeDI's generated mock surface
-	/// may promote the default onto the caller's override struct (inside another
-	/// type's extension), where `Self` binds to the caller's type instead of the
-	/// decorated type — silently producing the wrong value or failing to
-	/// typecheck. The diagnostic catches the syntactically identifiable case so
-	/// users get a compile error instead of a subtle override-surface mismatch.
-	///
-	/// `self.` is not checked because Swift already rejects `self.` in default
-	/// expressions on `init` (self isn't constructed yet) and on static
-	/// functions (no instance) — the only parameter shapes SafeDI encounters.
-	/// Unqualified references to callee-scope members can't be identified
-	/// without type resolution and are not covered.
+	/// diagnoses any explicit reference to `Self`. SafeDI's generated mock
+	/// surface may promote the default onto the caller's override struct
+	/// (inside another type's extension), where `Self` binds to the caller's
+	/// type instead of the decorated type — silently producing the wrong value
+	/// or failing to typecheck. Unqualified references to callee-scope members
+	/// can't be identified without type resolution and are not covered.
 	///
 	/// Two exemptions skip parameters whose defaults never reach the override
 	/// surface:
@@ -1279,7 +1273,7 @@ public struct InstantiableMacro: MemberMacro {
 	///   mock call site.
 	/// - `_`-labeled non-dependency parameters, which `ScopeGenerator` elides
 	///   from call-site arguments and excludes from `rootDefaultParameters`,
-	///   so Swift's default-argument thunk fires in the callee where `Self.*`
+	///   so Swift's default-argument thunk fires in the callee where `Self`
 	///   resolves correctly.
 	private static func validateDefaultExpressions(
 		functionSyntax: FunctionSignatureSyntax,
@@ -1297,55 +1291,37 @@ public struct InstantiableMacro: MemberMacro {
 			guard firstName != "_" else { continue }
 			let finder = SelfReferenceFinder(viewMode: .sourceAccurate)
 			finder.walk(Syntax(defaultValue))
-			for reference in finder.references {
-				context.diagnose(Diagnostic(
-					node: Syntax(parameter),
-					message: FixableInstantiableError.calleeScopeReferenceInDefaultExpression(
-						parameterLabel: innerLabel,
-						reference: reference,
-					).diagnostic,
-				))
-			}
+			guard finder.containsSelfReference else { continue }
+			context.diagnose(Diagnostic(
+				node: Syntax(parameter),
+				message: FixableInstantiableError.calleeScopeReferenceInDefaultExpression(
+					parameterLabel: innerLabel,
+				).diagnostic,
+			))
 		}
 	}
 
+	/// Walks a default-value expression and sets `containsSelfReference` if
+	/// any `Self` reference is encountered — expression-level (bare `Self`,
+	/// `Self.member`, `Self(...)`) or type-level (`Optional<Self>`, `[Self]`,
+	/// `(Self, T)`, etc.). Type-level occurrences are checked via
+	/// `TypeDescription.containsSelf`, which recurses through generics,
+	/// wrappers, composed types, tuples, and closures; expression-level
+	/// occurrences are caught by matching any `DeclReferenceExprSyntax` whose
+	/// name is `Self`.
 	private final class SelfReferenceFinder: SyntaxVisitor {
-		private(set) var references: [String] = []
-
-		override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
-			if let base = node.base?.as(DeclReferenceExprSyntax.self),
-			   base.baseName.text == "Self"
-			{
-				references.append("Self.\(node.declName.baseName.text)")
-				// Skip descent so the bare-`Self` visitor below doesn't
-				// double-report the base — we've already captured the full
-				// `Self.member` reference.
-				return .skipChildren
-			}
-			return .visitChildren
-		}
+		private(set) var containsSelfReference = false
 
 		override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
-			// Catches bare `Self` in contexts that aren't member access:
-			// `Self()` constructor calls, `Self` as a function argument,
-			// `Self[…]` subscripts. Member-access `Self.foo` is captured by
-			// the visitor above (which skips descent to avoid double counting).
 			if node.baseName.text == "Self" {
-				references.append("Self")
+				containsSelfReference = true
 			}
 			return .visitChildren
 		}
 
 		override func visit(_ node: IdentifierTypeSyntax) -> SyntaxVisitorContinueKind {
-			// Catches `Self` when it appears inside a type expression — e.g.
-			// `Optional<Self>.none`, `Result<Self, E>.failure(...)`, or
-			// `[Self]` — by parsing the type syntax into a `TypeDescription`
-			// and asking it whether `Self` appears anywhere in the structure.
-			// `skipChildren` because `containsSelf` already recurses, so
-			// descending into nested type syntax would double-report.
 			if TypeSyntax(node).typeDescription.containsSelf {
-				references.append("Self")
-				return .skipChildren
+				containsSelfReference = true
 			}
 			return .visitChildren
 		}

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -226,6 +226,7 @@ public struct InstantiableMacro: MemberMacro {
 				)
 				Self.validateDefaultExpressions(
 					functionSyntax: initializerSyntax.signature,
+					dependencies: visitor.dependencies,
 					context: context,
 				)
 			}
@@ -241,6 +242,7 @@ public struct InstantiableMacro: MemberMacro {
 				)
 				Self.validateDefaultExpressions(
 					functionSyntax: mockSyntax.signature,
+					dependencies: visitor.dependencies,
 					context: context,
 				)
 			}
@@ -907,6 +909,7 @@ public struct InstantiableMacro: MemberMacro {
 				)
 				Self.validateDefaultExpressions(
 					functionSyntax: mockFunction.signature,
+					dependencies: extensionDependencies,
 					context: context,
 				)
 				let nonDependenciesWithoutDefaults = mockFunctionInitializer.arguments
@@ -1234,13 +1237,21 @@ public struct InstantiableMacro: MemberMacro {
 	/// identifiable case so users get a compile error instead of a subtle
 	/// override-surface mismatch. Unqualified references to callee-scope
 	/// members can't be identified without type resolution and are not covered.
+	///
+	/// Dependency parameters are exempt: SafeDI always threads dependency
+	/// arguments explicitly at the call site, so a dependency's default
+	/// expression is never surfaced on the caller's override struct and its
+	/// `Self.*` / `self.*` refs resolve correctly in the callee.
 	private static func validateDefaultExpressions(
 		functionSyntax: FunctionSignatureSyntax,
+		dependencies: [Dependency],
 		context: some MacroExpansionContext,
 	) {
+		let dependencyLabels = Set(dependencies.map(\.property.label))
 		for parameter in functionSyntax.parameterClause.parameters {
 			guard let defaultValue = parameter.defaultValue?.value else { continue }
 			let parameterLabel = parameter.secondName?.text ?? parameter.firstName.text
+			guard !dependencyLabels.contains(parameterLabel) else { continue }
 			let finder = CalleeScopeReferenceFinder(viewMode: .sourceAccurate)
 			finder.walk(Syntax(defaultValue))
 			for reference in finder.references {

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -224,11 +224,18 @@ public struct InstantiableMacro: MemberMacro {
 					diagnosticNode: Syntax(initializerSyntax),
 					context: context,
 				)
-				Self.validateDefaultExpressions(
-					functionSyntax: initializerSyntax.signature,
-					dependencies: visitor.dependencies,
-					context: context,
-				)
+				// Only check init defaults when no custom mock method exists —
+				// SafeDI prefers `mockInitializer` over the init for mock
+				// construction (see `generateMockRootCode` and
+				// `generateReturnArgumentList`), so init defaults never reach
+				// the override surface when a mock method is present.
+				if visitor.mockInitializer == nil {
+					Self.validateDefaultExpressions(
+						functionSyntax: initializerSyntax.signature,
+						dependencies: visitor.dependencies,
+						context: context,
+					)
+				}
 			}
 			if let mockInitializer = visitor.mockInitializer,
 			   let mockSyntax = visitor.mockFunctionSyntax

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -224,6 +224,10 @@ public struct InstantiableMacro: MemberMacro {
 					diagnosticNode: Syntax(initializerSyntax),
 					context: context,
 				)
+				Self.validateDefaultExpressions(
+					functionSyntax: initializerSyntax.signature,
+					context: context,
+				)
 			}
 			if let mockInitializer = visitor.mockInitializer,
 			   let mockSyntax = visitor.mockFunctionSyntax
@@ -233,6 +237,10 @@ public struct InstantiableMacro: MemberMacro {
 					arguments: mockInitializer.arguments,
 					dependencies: visitor.dependencies,
 					diagnosticNode: Syntax(mockSyntax),
+					context: context,
+				)
+				Self.validateDefaultExpressions(
+					functionSyntax: mockSyntax.signature,
 					context: context,
 				)
 			}
@@ -897,6 +905,10 @@ public struct InstantiableMacro: MemberMacro {
 					diagnosticNode: Syntax(mockFunction),
 					context: context,
 				)
+				Self.validateDefaultExpressions(
+					functionSyntax: mockFunction.signature,
+					context: context,
+				)
 				let nonDependenciesWithoutDefaults = mockFunctionInitializer.arguments
 					.filter { !dependencyLabels.contains($0.innerLabel) && !$0.hasDefaultValue }
 					.map(\.asProperty)
@@ -1210,6 +1222,50 @@ public struct InstantiableMacro: MemberMacro {
 				),
 				changes: changes,
 			))
+		}
+	}
+
+	/// Walks each default-value expression on `functionSyntax`'s parameters and
+	/// diagnoses explicit `Self.*` / `self.*` member access. SafeDI's generated
+	/// mock surface may inline a default expression at the caller (inside the
+	/// parent type's override struct or mock body), where `Self` binds to the
+	/// parent type instead of the decorated type — silently producing the wrong
+	/// value or failing to typecheck. The diagnostic catches the syntactically
+	/// identifiable case so users get a compile error instead of a subtle
+	/// override-surface mismatch. Unqualified references to callee-scope
+	/// members can't be identified without type resolution and are not covered.
+	private static func validateDefaultExpressions(
+		functionSyntax: FunctionSignatureSyntax,
+		context: some MacroExpansionContext,
+	) {
+		for parameter in functionSyntax.parameterClause.parameters {
+			guard let defaultValue = parameter.defaultValue?.value else { continue }
+			let parameterLabel = parameter.secondName?.text ?? parameter.firstName.text
+			let finder = CalleeScopeReferenceFinder(viewMode: .sourceAccurate)
+			finder.walk(Syntax(defaultValue))
+			for reference in finder.references {
+				context.diagnose(Diagnostic(
+					node: Syntax(parameter),
+					message: FixableInstantiableError.calleeScopeReferenceInDefaultExpression(
+						parameterLabel: parameterLabel,
+						reference: reference,
+					).diagnostic,
+				))
+			}
+		}
+	}
+
+	private final class CalleeScopeReferenceFinder: SyntaxVisitor {
+		private(set) var references: [String] = []
+
+		override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
+			if let base = node.base?.as(DeclReferenceExprSyntax.self) {
+				let text = base.baseName.text
+				if text == "Self" || text == "self" {
+					references.append("\(text).\(node.declName.baseName.text)")
+				}
+			}
+			return .visitChildren
 		}
 	}
 

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -900,6 +900,21 @@ public struct InstantiableMacro: MemberMacro {
 			let dependencyLabels = Set(extensionDependencies.map(\.property.label))
 			for mockFunction in allMockFunctions {
 				let mockFunctionInitializer = Initializer(mockFunction)
+				// For per-overload default-expression checks, resolve this mock's
+				// dependencies from the matching `instantiate()` return type — not
+				// the union across all overloads. Otherwise a label that is a
+				// non-dependency default for *this* overload but a dependency for
+				// another would incorrectly skip the callee-scope check. Falls
+				// back to the union when the return type doesn't match any known
+				// Instantiable (e.g. unknown `Self`-returning shape).
+				let mockReturnType = mockFunction.signature.returnClause?.type.typeDescription
+				let dependenciesForMock: [Dependency] = if let mockReturnType,
+				                                           let matchingInstantiable = visitor.instantiables.first(where: { $0.concreteInstantiable == mockReturnType })
+				{
+					matchingInstantiable.dependencies
+				} else {
+					extensionDependencies
+				}
 				Self.validateUnlabeledDefaultShape(
 					functionSyntax: mockFunction.signature,
 					arguments: mockFunctionInitializer.arguments,
@@ -909,7 +924,7 @@ public struct InstantiableMacro: MemberMacro {
 				)
 				Self.validateDefaultExpressions(
 					functionSyntax: mockFunction.signature,
-					dependencies: extensionDependencies,
+					dependencies: dependenciesForMock,
 					context: context,
 				)
 				let nonDependenciesWithoutDefaults = mockFunctionInitializer.arguments

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -1335,6 +1335,20 @@ public struct InstantiableMacro: MemberMacro {
 			}
 			return .visitChildren
 		}
+
+		override func visit(_ node: IdentifierTypeSyntax) -> SyntaxVisitorContinueKind {
+			// Catches `Self` when it appears inside a type expression — e.g.
+			// `Optional<Self>.none`, `Result<Self, E>.failure(...)`, or
+			// `[Self]` — by parsing the type syntax into a `TypeDescription`
+			// and asking it whether `Self` appears anywhere in the structure.
+			// `skipChildren` because `containsSelf` already recurses, so
+			// descending into nested type syntax would double-report.
+			if TypeSyntax(node).typeDescription.containsSelf {
+				references.append("Self")
+				return .skipChildren
+			}
+			return .visitChildren
+		}
 	}
 
 	private static func generateForwardedProperties(

--- a/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
+++ b/Sources/SafeDIMacros/Macros/InstantiableMacro.swift
@@ -911,10 +911,19 @@ public struct InstantiableMacro: MemberMacro {
 				// dependencies from the matching `instantiate()` return type — not
 				// the union across all overloads. Otherwise a label that is a
 				// non-dependency default for *this* overload but a dependency for
-				// another would incorrectly skip the callee-scope check. Falls
-				// back to the union when the return type doesn't match any known
-				// Instantiable (e.g. unknown `Self`-returning shape).
-				let mockReturnType = mockFunction.signature.returnClause?.type.typeDescription
+				// another would incorrectly skip the callee-scope check.
+				//
+				// `Self` return types are mapped to the extended type so the
+				// match succeeds: the visitor records instantiables by the actual
+				// extended type, not literal `Self`. Falls back to the union
+				// only when the return type is unknown (shouldn't happen for
+				// well-formed input).
+				let rawMockReturnType = mockFunction.signature.returnClause?.type.typeDescription
+				let mockReturnType: TypeDescription? = if rawMockReturnType == .simple(name: "Self", generics: []) {
+					extendedTypeDescription
+				} else {
+					rawMockReturnType
+				}
 				let dependenciesForMock: [Dependency] = if let mockReturnType,
 				                                           let matchingInstantiable = visitor.instantiables.first(where: { $0.concreteInstantiable == mockReturnType })
 				{
@@ -1308,6 +1317,21 @@ public struct InstantiableMacro: MemberMacro {
 			   base.baseName.text == "Self"
 			{
 				references.append("Self.\(node.declName.baseName.text)")
+				// Skip descent so the bare-`Self` visitor below doesn't
+				// double-report the base — we've already captured the full
+				// `Self.member` reference.
+				return .skipChildren
+			}
+			return .visitChildren
+		}
+
+		override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+			// Catches bare `Self` in contexts that aren't member access:
+			// `Self()` constructor calls, `Self` as a function argument,
+			// `Self[…]` subscripts. Member-access `Self.foo` is captured by
+			// the visitor above (which skips descent to avoid double counting).
+			if node.baseName.text == "Self" {
+				references.append("Self")
 			}
 			return .visitChildren
 		}

--- a/Tests/SafeDICoreTests/FixableInstantiableErrorTests.swift
+++ b/Tests/SafeDICoreTests/FixableInstantiableErrorTests.swift
@@ -195,20 +195,14 @@ struct FixableInstantiableErrorTests {
 	}
 
 	@Test
-	func calleeScopeReferenceInDefaultExpression_description_mentionsParameterAndReference() {
-		let error = FixableInstantiableError.calleeScopeReferenceInDefaultExpression(
-			parameterLabel: "name",
-			reference: "Self.defaultName",
-		)
-		#expect(error.description == "Default expression for parameter `name` references `Self.defaultName`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self.defaultName` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.")
+	func calleeScopeReferenceInDefaultExpression_description_mentionsParameter() {
+		let error = FixableInstantiableError.calleeScopeReferenceInDefaultExpression(parameterLabel: "name")
+		#expect(error.description == "Default expression for parameter `name` references `Self`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self` would resolve against the wrong type. Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.")
 	}
 
 	@Test
 	func calleeScopeReferenceInDefaultExpression_fixIt_describesRemediation() {
-		let error = FixableInstantiableError.calleeScopeReferenceInDefaultExpression(
-			parameterLabel: "name",
-			reference: "Self.defaultName",
-		)
+		let error = FixableInstantiableError.calleeScopeReferenceInDefaultExpression(parameterLabel: "name")
 		#expect(error.fixIt.message == "Remove the default from `name` or move the referenced value to a file-scoped or module-scoped symbol")
 	}
 }

--- a/Tests/SafeDICoreTests/FixableInstantiableErrorTests.swift
+++ b/Tests/SafeDICoreTests/FixableInstantiableErrorTests.swift
@@ -193,4 +193,22 @@ struct FixableInstantiableErrorTests {
 		)
 		#expect(error.fixIt.message == "Promote `enabled` to an external label (rewrite `_ enabled:` as `enabled:`)")
 	}
+
+	@Test
+	func calleeScopeReferenceInDefaultExpression_description_mentionsParameterAndReference() {
+		let error = FixableInstantiableError.calleeScopeReferenceInDefaultExpression(
+			parameterLabel: "name",
+			reference: "Self.defaultName",
+		)
+		#expect(error.description == "Default expression for parameter `name` references `Self.defaultName`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self.defaultName` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.")
+	}
+
+	@Test
+	func calleeScopeReferenceInDefaultExpression_fixIt_describesRemediation() {
+		let error = FixableInstantiableError.calleeScopeReferenceInDefaultExpression(
+			parameterLabel: "name",
+			reference: "Self.defaultName",
+		)
+		#expect(error.fixIt.message == "Remove the default from `name` or move the referenced value to a file-scoped or module-scoped symbol")
+	}
 }

--- a/Tests/SafeDICoreTests/TypeDescriptionTests.swift
+++ b/Tests/SafeDICoreTests/TypeDescriptionTests.swift
@@ -1562,6 +1562,167 @@ struct TypeDescriptionTests {
 			return .skipChildren
 		}
 	}
+
+	// MARK: - containsSelf
+
+	@Test
+	func containsSelf_whenTypeIsBareSelf_returnsTrue() throws {
+		let visitor = TypeIdentifierSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: Self"))
+		let typeDescription = try #require(visitor.typeIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsSimpleNonSelf_returnsFalse() throws {
+		let visitor = TypeIdentifierSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: Int"))
+		let typeDescription = try #require(visitor.typeIdentifier)
+		#expect(!typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenSelfIsNestedInGenerics_returnsTrue() throws {
+		let visitor = TypeIdentifierSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: Optional<Self>"))
+		let typeDescription = try #require(visitor.typeIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenNestedTypeHasSelfParent_returnsTrue() throws {
+		let visitor = MemberTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: Self.Element"))
+		let typeDescription = try #require(visitor.nestedType)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenNestedTypeHasSelfInGenerics_returnsTrue() throws {
+		let visitor = MemberTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: Tree.Node<Self>"))
+		let typeDescription = try #require(visitor.nestedType)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsOptionalSelf_returnsTrue() throws {
+		let visitor = OptionalTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: Self?"))
+		let typeDescription = try #require(visitor.optionalTypeIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsImplicitlyUnwrappedOptionalSelf_returnsTrue() throws {
+		let visitor = ImplicitlyUnwrappedOptionalTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: Self!"))
+		let typeDescription = try #require(visitor.implictlyUnwrappedOptionalTypeIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsSomeSelf_returnsTrue() throws {
+		let visitor = SomeOrAnyTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: some Self"))
+		let typeDescription = try #require(visitor.someOrAnyTypeIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsAnySelf_returnsTrue() throws {
+		let visitor = SomeOrAnyTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: any Self"))
+		let typeDescription = try #require(visitor.someOrAnyTypeIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsArrayOfSelf_returnsTrue() throws {
+		let visitor = ArrayTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: [Self]"))
+		let typeDescription = try #require(visitor.arrayTypeIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsDictionaryWithSelfKey_returnsTrue() throws {
+		let visitor = DictionaryTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: [Self: Int]"))
+		let typeDescription = try #require(visitor.dictionaryTypeIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsDictionaryWithSelfValue_returnsTrue() throws {
+		let visitor = DictionaryTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: [Int: Self]"))
+		let typeDescription = try #require(visitor.dictionaryTypeIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsTupleContainingSelf_returnsTrue() throws {
+		let visitor = TupleTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: (Int, Self)"))
+		let typeDescription = try #require(visitor.tupleTypeIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsCompositionContainingSelf_returnsTrue() throws {
+		let visitor = CompositionTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "protocol P: Hashable & Self {}"))
+		let typeDescription = try #require(visitor.composedTypeIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenClosureReturnsSelf_returnsTrue() throws {
+		let visitor = FunctionTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: (Int) -> Self"))
+		let typeDescription = try #require(visitor.functionIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenClosureArgumentIsSelf_returnsTrue() throws {
+		let visitor = FunctionTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: (Self) -> Void"))
+		let typeDescription = try #require(visitor.functionIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsSelfMetatype_returnsTrue() throws {
+		let visitor = MetatypeTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: Self.Type"))
+		let typeDescription = try #require(visitor.metatypeTypeIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsAttributedSelf_returnsTrue() throws {
+		let visitor = AttributedTypeSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: @escaping (Int) -> Self"))
+		let typeDescription = try #require(visitor.attributedTypeIdentifier)
+		#expect(typeDescription.containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsUnknown_returnsFalse() {
+		// `.unknown` is created for type syntax the parser can't categorize.
+		// The stored `text` is incidental — `containsSelf` never inspects it.
+		#expect(!TypeDescription.unknown(text: "Self").containsSelf)
+	}
+
+	@Test
+	func containsSelf_whenTypeIsVoid_returnsFalse() throws {
+		let visitor = TypeIdentifierSyntaxVisitor(viewMode: .sourceAccurate)
+		visitor.walk(Parser.parse(source: "var x: Void"))
+		let typeDescription = try #require(visitor.typeIdentifier)
+		#expect(!typeDescription.containsSelf)
+	}
 }
 
 extension TypeDescription {

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -5286,6 +5286,109 @@ import Testing
 		}
 
 		@Test
+		func producesNoDiagnostic_whenSecondaryInitDefaultReferencesSelf() {
+			// Only the first `isValid(forFulfilling:)` init is used for mock
+			// construction (see `InstantiableVisitor:377`). Secondary inits
+			// with `Self.*` defaults never reach the override surface, so
+			// diagnosing them would be a false positive.
+			assertMacroExpansion(
+				"""
+				@Instantiable
+				public struct MyType: Instantiable {
+				    public init(service: Service) {
+				        self.service = service
+				    }
+				    public convenience init(title: String = Self.defaultTitle) {
+				        self.init(service: Service())
+				    }
+				    public static let defaultTitle = "fallback"
+				    @Instantiated let service: Service
+				}
+				""",
+				expandedSource: """
+				public struct MyType: Instantiable {
+				    public init(service: Service) {
+				        self.service = service
+				    }
+				    public convenience init(title: String = Self.defaultTitle) {
+				        self.init(service: Service())
+				    }
+				    public static let defaultTitle = "fallback"
+				    let service: Service
+				}
+				""",
+				macros: instantiableTestMacros,
+			)
+		}
+
+		@Test
+		func producesDiagnostic_whenDefaultExpressionReferencesSelfInArrayGeneric() {
+			// `[Self]()` places `Self` inside an `ArrayTypeSyntax` nested in an
+			// expression — caught via `TypeDescription.containsSelf`'s `.array`
+			// recursion.
+			assertMacroExpansion(
+				"""
+				@Instantiable(generateMock: true, customMockName: "customMock")
+				public struct MyType: Instantiable {
+				    public init() {}
+				    public static func customMock(fallback: [MyType] = [Self]()) -> MyType {
+				        MyType()
+				    }
+				}
+				""",
+				expandedSource: """
+				public struct MyType: Instantiable {
+				    public init() {}
+				    public static func customMock(fallback: [MyType] = [Self]()) -> MyType {
+				        MyType()
+				    }
+				}
+				""",
+				diagnostics: [
+					DiagnosticSpec(
+						message: "Default expression for parameter `fallback` references `Self`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self` would resolve against the wrong type. Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
+						line: 4,
+						column: 35,
+					),
+				],
+				macros: instantiableTestMacros,
+			)
+		}
+
+		@Test
+		func producesDiagnostic_whenDefaultExpressionReferencesSelfDotSelf() {
+			// `Self.self` parses as a member access on a `DeclReferenceExpr` —
+			// caught by the `DeclReferenceExprSyntax` visitor.
+			assertMacroExpansion(
+				"""
+				@Instantiable(generateMock: true, customMockName: "customMock")
+				public struct MyType: Instantiable {
+				    public init() {}
+				    public static func customMock(metatype: MyType.Type = Self.self) -> MyType {
+				        MyType()
+				    }
+				}
+				""",
+				expandedSource: """
+				public struct MyType: Instantiable {
+				    public init() {}
+				    public static func customMock(metatype: MyType.Type = Self.self) -> MyType {
+				        MyType()
+				    }
+				}
+				""",
+				diagnostics: [
+					DiagnosticSpec(
+						message: "Default expression for parameter `metatype` references `Self`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self` would resolve against the wrong type. Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
+						line: 4,
+						column: 35,
+					),
+				],
+				macros: instantiableTestMacros,
+			)
+		}
+
+		@Test
 		func producesDiagnostic_whenDefaultExpressionReferencesSelfInTypeExpression() {
 			// `Optional<Self>.none`, `Result<Self, E>.failure(...)`, and
 			// similar defaults place `Self` inside an `IdentifierTypeSyntax`

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -5251,6 +5251,80 @@ import Testing
 		}
 
 		@Test
+		func producesDiagnostic_whenDefaultExpressionCallsSelfAsConstructor() {
+			// `Self()` as a default binds to the decorated type in the callee
+			// but to the caller's type if the default is inlined at the call
+			// site — same failure mode as `Self.member`, caught via the bare
+			// `Self` DeclReferenceExpr match.
+			assertMacroExpansion(
+				"""
+				@Instantiable(generateMock: true, customMockName: "customMock")
+				public struct MyType: Instantiable {
+				    public init() {}
+				    public static func customMock(fallback: MyType = Self()) -> MyType {
+				        MyType()
+				    }
+				}
+				""",
+				expandedSource: """
+				public struct MyType: Instantiable {
+				    public init() {}
+				    public static func customMock(fallback: MyType = Self()) -> MyType {
+				        MyType()
+				    }
+				}
+				""",
+				diagnostics: [
+					DiagnosticSpec(
+						message: "Default expression for parameter `fallback` references `Self`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
+						line: 4,
+						column: 35,
+					),
+				],
+				macros: instantiableTestMacros,
+			)
+		}
+
+		@Test
+		func producesDiagnostic_whenExtensionCustomMockDefaultReferencesSelf() {
+			// Extension-based customMock goes through a different validation
+			// branch than concrete customMock. `Self` on a non-dependency
+			// default must be caught there too.
+			assertMacroExpansion(
+				"""
+				public struct MyType {}
+
+				@Instantiable(generateMock: true, customMockName: "customMock")
+				extension MyType: Instantiable {
+				    public static func instantiate() -> MyType { MyType() }
+				    public static func customMock(fallback: String = Self.defaultName) -> MyType {
+				        MyType()
+				    }
+				    public static let defaultName = "fallback"
+				}
+				""",
+				expandedSource: """
+				public struct MyType {}
+				extension MyType: Instantiable {
+				    public static func instantiate() -> MyType { MyType() }
+				    public static func customMock(fallback: String = Self.defaultName) -> MyType {
+				        MyType()
+				    }
+				    public static let defaultName = "fallback"
+				}
+				""",
+				diagnostics: [
+					DiagnosticSpec(
+						message: "Default expression for parameter `fallback` references `Self.defaultName`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self.defaultName` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
+						line: 6,
+						column: 35,
+					),
+				],
+				macros: instantiableTestMacros,
+			)
+		}
+
+		@Test
 		func producesNoDiagnostic_whenTrailingUnlabeledParametersAllHaveDefaults() {
 			// `init(_ a: Int = 0, _ b: Int = 1)` is fine — both trailing `_`
 			// defaults are elided together as a suffix, call site becomes

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -5086,7 +5086,7 @@ import Testing
 				""",
 				diagnostics: [
 					DiagnosticSpec(
-						message: "Default expression for parameter `name` references `Self.defaultName`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self.defaultName` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
+						message: "Default expression for parameter `name` references `Self`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self` would resolve against the wrong type. Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
 						line: 3,
 						column: 17,
 					),
@@ -5119,7 +5119,7 @@ import Testing
 				""",
 				diagnostics: [
 					DiagnosticSpec(
-						message: "Default expression for parameter `name` references `Self.defaultName`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self.defaultName` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
+						message: "Default expression for parameter `name` references `Self`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self` would resolve against the wrong type. Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
 						line: 5,
 						column: 35,
 					),
@@ -5276,7 +5276,7 @@ import Testing
 				""",
 				diagnostics: [
 					DiagnosticSpec(
-						message: "Default expression for parameter `fallback` references `Self`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
+						message: "Default expression for parameter `fallback` references `Self`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self` would resolve against the wrong type. Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
 						line: 4,
 						column: 35,
 					),
@@ -5313,7 +5313,7 @@ import Testing
 				""",
 				diagnostics: [
 					DiagnosticSpec(
-						message: "Default expression for parameter `fallback` references `Self`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
+						message: "Default expression for parameter `fallback` references `Self`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self` would resolve against the wrong type. Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
 						line: 4,
 						column: 35,
 					),
@@ -5352,7 +5352,7 @@ import Testing
 				""",
 				diagnostics: [
 					DiagnosticSpec(
-						message: "Default expression for parameter `fallback` references `Self.defaultName`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self.defaultName` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
+						message: "Default expression for parameter `fallback` references `Self`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self` would resolve against the wrong type. Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
 						line: 6,
 						column: 35,
 					),

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -5059,6 +5059,106 @@ import Testing
 		}
 
 		@Test
+		func producesDiagnostic_whenDefaultExpressionReferencesSelfOnInit() {
+			// `Self.defaultName` binds to the type under decoration inside the
+			// init, but SafeDI's generated mock may inline the default
+			// expression inside another type's override struct, where `Self`
+			// would bind to the wrong type.
+			assertMacroExpansion(
+				"""
+				@Instantiable
+				public struct MyType: Instantiable {
+				    public init(name: String = Self.defaultName) {
+				        self.name = name
+				    }
+				    public static let defaultName = "fallback"
+				    let name: String
+				}
+				""",
+				expandedSource: """
+				public struct MyType: Instantiable {
+				    public init(name: String = Self.defaultName) {
+				        self.name = name
+				    }
+				    public static let defaultName = "fallback"
+				    let name: String
+				}
+				""",
+				diagnostics: [
+					DiagnosticSpec(
+						message: "Default expression for parameter `name` references `Self.defaultName`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self.defaultName` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
+						line: 3,
+						column: 17,
+					),
+				],
+				macros: instantiableTestMacros,
+			)
+		}
+
+		@Test
+		func producesDiagnostic_whenDefaultExpressionReferencesSelfOnCustomMock() {
+			assertMacroExpansion(
+				"""
+				@Instantiable(generateMock: true, customMockName: "customMock")
+				public struct MyType: Instantiable {
+				    public init() {}
+				    public static let defaultName = "fallback"
+				    public static func customMock(name: String = Self.defaultName) -> MyType {
+				        MyType()
+				    }
+				}
+				""",
+				expandedSource: """
+				public struct MyType: Instantiable {
+				    public init() {}
+				    public static let defaultName = "fallback"
+				    public static func customMock(name: String = Self.defaultName) -> MyType {
+				        MyType()
+				    }
+				}
+				""",
+				diagnostics: [
+					DiagnosticSpec(
+						message: "Default expression for parameter `name` references `Self.defaultName`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self.defaultName` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
+						line: 5,
+						column: 35,
+					),
+				],
+				macros: instantiableTestMacros,
+			)
+		}
+
+		@Test
+		func producesNoDiagnostic_whenDefaultExpressionReferencesFileScopedSymbol() {
+			// Module-scoped and file-scoped references are fine — they resolve
+			// the same way from any caller, including the generated override
+			// struct.
+			assertMacroExpansion(
+				"""
+				public let sharedDefaultName = "fallback"
+
+				@Instantiable
+				public struct MyType: Instantiable {
+				    public init(name: String = sharedDefaultName) {
+				        self.name = name
+				    }
+				    let name: String
+				}
+				""",
+				expandedSource: """
+				public let sharedDefaultName = "fallback"
+				public struct MyType: Instantiable {
+				    public init(name: String = sharedDefaultName) {
+				        self.name = name
+				    }
+				    let name: String
+				}
+				""",
+				macros: instantiableTestMacros,
+			)
+		}
+
+		@Test
 		func producesNoDiagnostic_whenTrailingUnlabeledParametersAllHaveDefaults() {
 			// `init(_ a: Int = 0, _ b: Int = 1)` is fine — both trailing `_`
 			// defaults are elided together as a suffix, call site becomes

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -5325,6 +5325,41 @@ import Testing
 		}
 
 		@Test
+		func producesNoDiagnostic_whenDefaultExpressionReferencesMemberOfModuleType() {
+			// Member access whose base isn't `Self` — e.g., `Config.fallback` —
+			// resolves identically at the caller and the callee, so the
+			// diagnostic must not fire. Exercises the non-`Self` branch of
+			// the MemberAccessExpr visitor.
+			assertMacroExpansion(
+				"""
+				public enum Config {
+				    public static let fallback = "fallback"
+				}
+
+				@Instantiable
+				public struct MyType: Instantiable {
+				    public init(name: String = Config.fallback) {
+				        self.name = name
+				    }
+				    let name: String
+				}
+				""",
+				expandedSource: """
+				public enum Config {
+				    public static let fallback = "fallback"
+				}
+				public struct MyType: Instantiable {
+				    public init(name: String = Config.fallback) {
+				        self.name = name
+				    }
+				    let name: String
+				}
+				""",
+				macros: instantiableTestMacros,
+			)
+		}
+
+		@Test
 		func producesNoDiagnostic_whenTrailingUnlabeledParametersAllHaveDefaults() {
 			// `init(_ a: Int = 0, _ b: Int = 1)` is fine — both trailing `_`
 			// defaults are elided together as a suffix, call site becomes

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -5129,6 +5129,35 @@ import Testing
 		}
 
 		@Test
+		func producesNoDiagnostic_whenDefaultExpressionReferencesSelfOnDependencyParameter() {
+			// Dependency parameters are always threaded explicitly at the mock
+			// call site — their default expressions never reach the override
+			// surface — so `Self.*` inside a dep default is safe.
+			assertMacroExpansion(
+				"""
+				@Instantiable
+				public struct MyType: Instantiable {
+				    public init(service: Service = Self.makeService()) {
+				        self.service = service
+				    }
+				    public static func makeService() -> Service { Service() }
+				    @Instantiated let service: Service
+				}
+				""",
+				expandedSource: """
+				public struct MyType: Instantiable {
+				    public init(service: Service = Self.makeService()) {
+				        self.service = service
+				    }
+				    public static func makeService() -> Service { Service() }
+				    let service: Service
+				}
+				""",
+				macros: instantiableTestMacros,
+			)
+		}
+
+		@Test
 		func producesNoDiagnostic_whenDefaultExpressionReferencesFileScopedSymbol() {
 			// Module-scoped and file-scoped references are fine — they resolve
 			// the same way from any caller, including the generated override

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -5129,6 +5129,38 @@ import Testing
 		}
 
 		@Test
+		func producesNoDiagnostic_whenInitDefaultReferencesSelfButCustomMockExists() {
+			// When the type has a `customMock` method, SafeDI uses the mock
+			// method (not the init) to construct the instance for mocks, so
+			// init defaults never reach the override surface. `Self.*` in an
+			// init default is safe in that case.
+			assertMacroExpansion(
+				"""
+				@Instantiable(generateMock: true, customMockName: "customMock")
+				public struct MyType: Instantiable {
+				    public init(name: String = Self.defaultName) {
+				        self.name = name
+				    }
+				    public static let defaultName = "fallback"
+				    public static func customMock() -> MyType { MyType() }
+				    let name: String
+				}
+				""",
+				expandedSource: """
+				public struct MyType: Instantiable {
+				    public init(name: String = Self.defaultName) {
+				        self.name = name
+				    }
+				    public static let defaultName = "fallback"
+				    public static func customMock() -> MyType { MyType() }
+				    let name: String
+				}
+				""",
+				macros: instantiableTestMacros,
+			)
+		}
+
+		@Test
 		func producesNoDiagnostic_whenDefaultExpressionReferencesSelfOnUnlabeledNonDependency() {
 			// `_`-labeled non-dependency defaults are elided from the mock
 			// call site (`ScopeGenerator.callSiteArguments` filters them and

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -5129,6 +5129,37 @@ import Testing
 		}
 
 		@Test
+		func producesNoDiagnostic_whenDefaultExpressionReferencesSelfOnUnlabeledNonDependency() {
+			// `_`-labeled non-dependency defaults are elided from the mock
+			// call site (`ScopeGenerator.callSiteArguments` filters them and
+			// `rootDefaultParameters` excludes them), so Swift's default-
+			// argument thunk fires in the callee's scope where `Self.*`
+			// resolves correctly.
+			assertMacroExpansion(
+				"""
+				@Instantiable
+				public struct MyType: Instantiable {
+				    public init(_ value: Int = Self.defaultValue) {
+				        self.value = value
+				    }
+				    public static let defaultValue = 42
+				    let value: Int
+				}
+				""",
+				expandedSource: """
+				public struct MyType: Instantiable {
+				    public init(_ value: Int = Self.defaultValue) {
+				        self.value = value
+				    }
+				    public static let defaultValue = 42
+				    let value: Int
+				}
+				""",
+				macros: instantiableTestMacros,
+			)
+		}
+
+		@Test
 		func producesNoDiagnostic_whenDefaultExpressionReferencesSelfOnDependencyParameter() {
 			// Dependency parameters are always threaded explicitly at the mock
 			// call site — their default expressions never reach the override

--- a/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
+++ b/Tests/SafeDIMacrosTests/InstantiableMacroTests.swift
@@ -5286,6 +5286,43 @@ import Testing
 		}
 
 		@Test
+		func producesDiagnostic_whenDefaultExpressionReferencesSelfInTypeExpression() {
+			// `Optional<Self>.none`, `Result<Self, E>.failure(...)`, and
+			// similar defaults place `Self` inside an `IdentifierTypeSyntax`
+			// in a generic argument clause — not an expression-level
+			// `DeclReferenceExpr`. Those must still be flagged so the
+			// override struct's caller-scope `Self` binding doesn't silently
+			// produce the wrong type.
+			assertMacroExpansion(
+				"""
+				@Instantiable(generateMock: true, customMockName: "customMock")
+				public struct MyType: Instantiable {
+				    public init() {}
+				    public static func customMock(fallback: Optional<MyType> = Optional<Self>.none) -> MyType {
+				        MyType()
+				    }
+				}
+				""",
+				expandedSource: """
+				public struct MyType: Instantiable {
+				    public init() {}
+				    public static func customMock(fallback: Optional<MyType> = Optional<Self>.none) -> MyType {
+				        MyType()
+				    }
+				}
+				""",
+				diagnostics: [
+					DiagnosticSpec(
+						message: "Default expression for parameter `fallback` references `Self`, which is resolved in the callee's scope. SafeDI's generated mock code may surface this default on its override struct, where `Self` would resolve against the wrong type (or fail to resolve). Move the referenced value to a file-scoped or module-scoped symbol, or remove the default.",
+						line: 4,
+						column: 35,
+					),
+				],
+				macros: instantiableTestMacros,
+			)
+		}
+
+		@Test
 		func producesDiagnostic_whenExtensionCustomMockDefaultReferencesSelf() {
 			// Extension-based customMock goes through a different validation
 			// branch than concrete customMock. `Self` on a non-dependency


### PR DESCRIPTION
## Summary
- Add `FixableInstantiableError.calleeScopeReferenceInDefaultExpression` and a syntax visitor in `InstantiableMacro` that walks each default-value expression on `init` / `customMock` parameters and diagnoses `Self` references — both `Self.member` member access and bare `Self` in constructor calls / argument positions / subscripts.
- Wired into all three validation sites: concrete init, concrete custom mock, and extension custom mock methods.
- Exemptions, so the diagnostic only fires for defaults that actually reach the override surface:
  - Dependency parameters (always threaded explicitly at the call site).
  - `_`-labeled non-dependency parameters (elided from the call site by `ScopeGenerator`).
  - Concrete `init` defaults when a `customMock` method exists (the mock method takes over construction).
  - On extensions with multiple `Instantiable`s, each mock overload's deps are resolved from the matching return type (mapping `Self` to the extended type) rather than the union across overloads.
- Adds eight macro tests and two unit tests covering the error's description + fix-it message.

## Self-review pass (commit `aab0c76`)
- Broadened `SelfReferenceFinder` to catch bare `Self` (constructor calls, argument positions, subscripts) via a `DeclReferenceExprSyntax` visitor. The member-access visitor returns `.skipChildren` to avoid double-reporting the base.
- Fixed the per-overload dep lookup to map `Self` return types to the extended type (previously fell back to the union).
- Added `producesDiagnostic_whenDefaultExpressionCallsSelfAsConstructor` and `producesDiagnostic_whenExtensionCustomMockDefaultReferencesSelf` to pin the new coverage.

## Why

Default expressions are evaluated in the callee's lexical scope in the production init, so `Self.defaultName` / `Self()` binds to the decorated type. But SafeDI's generated mock code promotes labeled non-dependency defaults onto the caller's `SafeDIOverrides` struct — where `Self` binds to the caller's type — producing the wrong value or failing to typecheck. Silent override-surface mismatch becomes a compile error instead.

## Scope limitation

Unqualified references (`foo` where `foo` is a callee-scope member) cannot be distinguished from module-scoped symbols without type resolution, so the macro only catches explicit `Self` access. The existing elision in `ScopeGenerator.callSiteArguments` / `hasHiddenUnlabeledDefaults` stays in place for `_`-labeled defaults — users who want `Self.*` defaults can opt in by making the parameter unlabeled or by supplying a `customMock` method.

## Test plan
- [x] `swift test --traits sourceBuild` — 852 tests pass
- [x] `./CLI/lint.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)