### PR TITLE
README: remove phantom Features-table header + drop 'Or skip ahead'

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Three steps to integrate:
 2. Attach the `SafeDIGenerator` build tool plugin to your first-party target(s).
 3. Decorate your app’s root type with `@Instantiable(isRoot: true)` and add `@Instantiable` to the dependencies it reaches.
 
-Or skip ahead: working sample projects live in the [Examples folder](Examples/) — clone, open, and build. The [Manual](Documentation/Manual.md#installation) covers Xcode projects, multi-module packages, custom build systems, and prebuild scripts in depth.
+Working sample projects live in the [Examples folder](Examples/) — clone, open, and build. The [Manual](Documentation/Manual.md#installation) covers Xcode projects, multi-module packages, custom build systems, and prebuild scripts in depth.
 
 If you are migrating an existing project to SafeDI, follow our [migration guide](Documentation/Manual.md#migrating-to-safedi). If you are upgrading from SafeDI 1.x, follow the [1.x → 2.x migration guide](Documentation/Manual.md#migrating-from-safedi-1x-to-2x).
 

--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ For previews and tests that need real data, pass forwarded values directly and u
 
 ## Features
 
-| | | |
-|---|---|---|
-| ✓ Compile-time safe | ✓ Thread safe | ✓ Hierarchical dependency scoping |
-| ✓ Constructor injection | ✓ Multi-module support | ✓ Dependency inversion support |
-| ✓ Transitive dependency solving | ✓ Cycle detection | ✓ Architecture independent |
-| ✓ No DI-specific types or generics required | ✓ Full-graph mocks | ✓ Clear errors: never debug generated code |
+<table>
+<tr><td>✓ Compile-time safe</td><td>✓ Thread safe</td><td>✓ Hierarchical dependency scoping</td></tr>
+<tr><td>✓ Constructor injection</td><td>✓ Multi-module support</td><td>✓ Dependency inversion support</td></tr>
+<tr><td>✓ Transitive dependency solving</td><td>✓ Cycle detection</td><td>✓ Architecture independent</td></tr>
+<tr><td>✓ No DI-specific types or generics required</td><td>✓ Full-graph mocks</td><td>✓ Clear errors: never debug generated code</td></tr>
+</table>
 
 ## Getting started
 


### PR DESCRIPTION
Two small README polishes:

1. **Phantom Features header.** The Features table used a markdown `| | | |` header row — empty on purpose, since every cell is a standalone feature — but GitHub renders that blank header as an empty bar above the grid. Switched to an HTML `<table>` without `<thead>` so the grid layout survives without the phantom row.

2. **"Or skip ahead" flow.** The sentence about Examples/Manual is now direct — the prefix implied readers should skip the three-step integration list, which wasn't the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)