### PR TITLE
Docs: enable SPI-hosted DocC + landing page + CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,44 @@ jobs:
       - name: Build Framework
         run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination ${{ matrix.platforms }}
 
+  docc:
+    name: Build DocC on Xcode 26
+    runs-on: macos-26
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+      - name: Select Xcode Version
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
+      - name: Resolve Package Dependencies
+        uses: ./.github/actions/retry
+        with:
+          command: xcrun xcodebuild -resolvePackageDependencies -skipPackagePluginValidation -skipMacroValidation -scheme SafeDI-Package
+      # We can't use `OTHER_DOCC_FLAGS='--warnings-as-errors'` because
+      # DocC analyzes the whole target graph — noise from swift-syntax's
+      # internal API surface would always fail the build. And we can't
+      # depend on swift-docc-plugin (which supports per-target scoping)
+      # without exposing that dependency to every consumer of SafeDI.
+      # Instead, we capture the docbuild log and fail only when a warning
+      # points inside our own `.docc` bundle or sources.
+      - name: Build DocC
+        run: |
+          set -o pipefail
+          LOG="$RUNNER_TEMP/docbuild.log"
+          xcrun xcodebuild docbuild \
+            -scheme SafeDI-Package \
+            -skipPackagePluginValidation \
+            -skipMacroValidation \
+            -derivedDataPath "$RUNNER_TEMP/docc-dd" \
+            -destination 'platform=macOS' \
+            2>&1 | tee "$LOG"
+          # Fail on DocC warnings/errors that reference our own files.
+          if grep -E "(SafeDI\.docc/|/Sources/SafeDI/).*:.*(warning|error):" "$LOG"; then
+            echo "::error::DocC emitted warnings or errors in SafeDI's own docs; see log above."
+            exit 1
+          fi
+
   spm-package-integration:
     name: Build Package Integration on Xcode 26
     runs-on: macos-26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,33 +73,14 @@ jobs:
         uses: actions/checkout@v6
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
-      - name: Resolve Package Dependencies
+      # `swift-docc-plugin`'s `--warnings-as-errors` scopes to a single
+      # target, so swift-syntax's internal DocC noise stays out of our
+      # strict build. That scoping isn't available via `xcodebuild
+      # docbuild`, which analyzes the whole target graph.
+      - name: Build DocC
         uses: ./.github/actions/retry
         with:
-          command: xcrun xcodebuild -resolvePackageDependencies -skipPackagePluginValidation -skipMacroValidation -scheme SafeDI-Package
-      # We can't use `OTHER_DOCC_FLAGS='--warnings-as-errors'` because
-      # DocC analyzes the whole target graph — noise from swift-syntax's
-      # internal API surface would always fail the build. And we can't
-      # depend on swift-docc-plugin (which supports per-target scoping)
-      # without exposing that dependency to every consumer of SafeDI.
-      # Instead, we capture the docbuild log and fail only when a warning
-      # points inside our own `.docc` bundle or sources.
-      - name: Build DocC
-        run: |
-          set -o pipefail
-          LOG="$RUNNER_TEMP/docbuild.log"
-          xcrun xcodebuild docbuild \
-            -scheme SafeDI-Package \
-            -skipPackagePluginValidation \
-            -skipMacroValidation \
-            -derivedDataPath "$RUNNER_TEMP/docc-dd" \
-            -destination 'platform=macOS' \
-            2>&1 | tee "$LOG"
-          # Fail on DocC warnings/errors that reference our own files.
-          if grep -E "(SafeDI\.docc/|/Sources/SafeDI/).*:.*(warning|error):" "$LOG"; then
-            echo "::error::DocC emitted warnings or errors in SafeDI's own docs; see log above."
-            exit 1
-          fi
+          command: swift package generate-documentation --target SafeDI --warnings-as-errors
 
   spm-package-integration:
     name: Build Package Integration on Xcode 26

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [SafeDI]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ swift test --traits sourceBuild    # Run all tests
 swift test --traits sourceBuild --enable-code-coverage  # Coverage report
 ```
 
-The `sourceBuild` trait is required for local development to compile SafeDITool from source. Without it, the default `prebuilt` trait downloads a prebuilt binary from the artifact bundle.
+The `sourceBuild` trait is required for local development to compile SafeDITool from source. Without it, the plugin uses the prebuilt binary from the artifact bundle.
 
 Always lint before pushing. Always run the full test suite after changes — don't rely on filtered runs alone.
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7c98ba4f35147a33f2d37900b642d5d39416f7732db256250471b890360e98e3",
+  "originHash" : "d1def707d7c34135172a1329d8186f67f22a2b2752e81a3b71052952aee1c3d9",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -8,6 +8,24 @@
       "state" : {
         "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
         "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
+      "state" : {
+        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
+        "version" : "1.4.6"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -37,12 +37,11 @@ let package = Package(
 		),
 	],
 	traits: [
-		.default(enabledTraits: ["prebuilt"]),
-		.trait(name: "prebuilt", description: "Use a prebuilt SafeDITool binary from the artifact bundle (default)."),
-		.trait(name: "sourceBuild", description: "Build SafeDITool from source. Mutually exclusive with 'prebuilt'."),
+		.trait(name: "sourceBuild", description: "Build SafeDITool from source instead of using the prebuilt release binary. Off by default — builds-from-main users and docs tooling (swift-docc-plugin) get the prebuilt binary."),
 	],
 	dependencies: [
 		.package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
+		.package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.3.0"),
 		.package(url: "https://github.com/swiftlang/swift-syntax.git", "603.0.0"..<"605.0.0"),
 	],
 	targets: [
@@ -104,7 +103,12 @@ let package = Package(
 			name: "SafeDIGenerator",
 			capability: .buildTool(),
 			dependencies: [
-				.target(name: "SafeDIToolBinary", condition: .when(traits: ["prebuilt"])),
+				// `SafeDIToolBinary` is unconditional because SPM traits
+				// can't express "when this trait is NOT active." When
+				// `sourceBuild` is on the plugin uses the source-built
+				// `SafeDITool`; otherwise it picks the prebuilt binary
+				// out of the artifact bundle.
+				.target(name: "SafeDIToolBinary"),
 				.target(name: "SafeDITool", condition: .when(traits: ["sourceBuild"])),
 			],
 		),

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,9 @@ let package = Package(
 		),
 	],
 	traits: [
-		.trait(name: "sourceBuild", description: "Build SafeDITool from source instead of using the prebuilt release binary. Off by default — builds-from-main users and docs tooling (swift-docc-plugin) get the prebuilt binary."),
+		.default(enabledTraits: ["prebuilt"]),
+		.trait(name: "prebuilt", description: "Use a prebuilt SafeDITool binary from the artifact bundle (default)."),
+		.trait(name: "sourceBuild", description: "Build SafeDITool from source. Intended for local development and adopting unreleased changes; typically set via `--traits sourceBuild` which replaces the default `prebuilt`."),
 	],
 	dependencies: [
 		.package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
@@ -103,12 +105,7 @@ let package = Package(
 			name: "SafeDIGenerator",
 			capability: .buildTool(),
 			dependencies: [
-				// `SafeDIToolBinary` is unconditional because SPM traits
-				// can't express "when this trait is NOT active." When
-				// `sourceBuild` is on the plugin uses the source-built
-				// `SafeDITool`; otherwise it picks the prebuilt binary
-				// out of the artifact bundle.
-				.target(name: "SafeDIToolBinary"),
+				.target(name: "SafeDIToolBinary", condition: .when(traits: ["prebuilt"])),
 				.target(name: "SafeDITool", condition: .when(traits: ["sourceBuild"])),
 			],
 		),

--- a/Sources/SafeDI/Decorators/SafeDIConfiguration.swift
+++ b/Sources/SafeDI/Decorators/SafeDIConfiguration.swift
@@ -18,6 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#if prebuilt && sourceBuild
+	#warning("Both 'prebuilt' and 'sourceBuild' SafeDI Package Traits are enabled. The prebuilt binary will be used and changes to SafeDITool source will be ignored. Enable only one trait. (This warning also fires during swift-docc-plugin documentation builds, where it is harmless — DocC does not invoke the SafeDIGenerator build-tool plugin.)")
+#endif
+
 /// Provides build-time configuration for SafeDI's code generation plugin.
 ///
 /// `#SafeDIConfiguration` is a freestanding declaration macro that must appear at the top level of a Swift file (not nested inside a type).

--- a/Sources/SafeDI/Decorators/SafeDIConfiguration.swift
+++ b/Sources/SafeDI/Decorators/SafeDIConfiguration.swift
@@ -18,10 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#if prebuilt && sourceBuild
-	#error("The 'prebuilt' and 'sourceBuild' Package Traits are mutually exclusive. Enable only one.")
-#endif
-
 /// Provides build-time configuration for SafeDI's code generation plugin.
 ///
 /// `#SafeDIConfiguration` is a freestanding declaration macro that must appear at the top level of a Swift file (not nested inside a type).

--- a/Sources/SafeDI/SafeDI.docc/SafeDI.md
+++ b/Sources/SafeDI/SafeDI.docc/SafeDI.md
@@ -30,7 +30,7 @@ public struct NotesApp: App, Instantiable {
 
 @Instantiable
 public struct LoggedInView: View, Instantiable {
-    public var body: some View { … }
+    public var body: some View { /* ... */ }
 
     // `user` is a runtime value forwarded in at this boundary.
     @Forwarded private let user: User

--- a/Sources/SafeDI/SafeDI.docc/SafeDI.md
+++ b/Sources/SafeDI/SafeDI.docc/SafeDI.md
@@ -1,0 +1,76 @@
+#  ``SafeDI``
+
+Compile-time-safe dependency injection without the boilerplate. No containers. No service locators. No hand-written DI types.
+
+## Overview
+
+SafeDI reads your code, validates your dependencies, and generates production and mock dependency trees during project compilation. If the code compiles, the dependency graph is valid.
+
+Opting a type into the SafeDI dependency tree is simple: add `@Instantiable` to your type declaration, and decorate each dependency with a macro that indicates its lifecycle. Here is what a notes app might look like in SafeDI:
+
+```swift
+// `NotesApp` is the root of the dependency graph. SafeDI generates its public `init()`.
+@Instantiable(isRoot: true) @main
+public struct NotesApp: App, Instantiable {
+    public var body: some Scene {
+        WindowGroup {
+            if let user = userService.user {
+                // Forward the authenticated user into the logged-in subtree.
+                loggedInViewBuilder.instantiate(user)
+            } else {
+                nameEntryViewBuilder.instantiate()
+            }
+        }
+    }
+
+    @ObservedObject @Instantiated private var userService: UserService
+    @Instantiated private let nameEntryViewBuilder: Instantiator<NameEntryView>
+    @Instantiated private let loggedInViewBuilder: Instantiator<LoggedInView>
+}
+
+@Instantiable
+public struct LoggedInView: View, Instantiable {
+    public var body: some View { … }
+
+    // `user` is a runtime value forwarded in at this boundary.
+    @Forwarded private let user: User
+    // `userService` is received from an ancestor in the tree.
+    @Received private let userService: UserService
+    // `noteStorage` is created by `LoggedInView` and lives for its lifetime.
+    @Instantiated private let noteStorage: NoteStorage
+}
+```
+
+`User` is a runtime-derived value. It is forwarded once at the logged-in boundary and received later by the types that need it — non-optional, scoped to the subtree where it exists.
+
+## Getting Started
+
+Three steps to integrate:
+
+1. Add `.package(url: "https://github.com/dfed/SafeDI.git", from: "2.0.0")` to your `Package.swift` dependencies.
+2. Attach the `SafeDIGenerator` build tool plugin to your first-party target(s).
+3. Decorate your app's root type with `@Instantiable(isRoot: true)` and add `@Instantiable` to the dependencies it reaches.
+
+Working sample projects live in the [Examples folder](https://github.com/dfed/SafeDI/tree/main/Examples) — clone, open, and build. The [Manual](https://github.com/dfed/SafeDI/blob/main/Documentation/Manual.md) covers Xcode projects, multi-module packages, custom build systems, and prebuild scripts in depth.
+
+## Topics
+
+### Decorator macros
+
+- ``Instantiable(isRoot:fulfillingAdditionalTypes:conformsElsewhere:mockOnly:mockAttributes:generateMock:customMockName:)``
+- ``Instantiated()``
+- ``Instantiated(fulfilledByType:erasedToConcreteExistential:)``
+- ``Received(onlyIfAvailable:)``
+- ``Received(fulfilledByDependencyNamed:ofType:erasedToConcreteExistential:onlyIfAvailable:)``
+- ``Forwarded()``
+
+### Configuration
+
+- ``SafeDIConfiguration(additionalImportedModules:additionalDirectoriesToInclude:additionalMocksToGenerate:mockConditionalCompilation:)``
+
+### Delayed instantiation
+
+- ``Instantiator``
+- ``SendableInstantiator``
+- ``ErasedInstantiator``
+- ``SendableErasedInstantiator``


### PR DESCRIPTION
## Summary
Turns on Swift Package Index's DocC hosting for SafeDI and adds a CI job that fails when our own doc rot creeps in. Downgrades the `prebuilt`/`sourceBuild` mutual-exclusion `#error` to a `#warning` so we can depend on `swift-docc-plugin`.

## Changes

### Mutual-exclusion `#error` → `#warning`
The previous \`#if prebuilt && sourceBuild #error(\"...\")\` in \`Sources/SafeDI/Decorators/SafeDIConfiguration.swift\` tripped whenever a dependency activated all traits during resolution — notably \`swift-docc-plugin\`. Downgrading to \`#warning\` keeps the diagnostic for users who explicitly enable both (e.g. \`swift build --traits prebuilt,sourceBuild\`) while letting swift-docc-plugin's symbol extraction succeed.

**What actually happens with both traits enabled:** the prebuilt binary wins the tool-name collision (both the artifact bundle's \`SafeDITool\` and the source target named \`SafeDITool\` are visible to \`context.tool(named:)\`, and SPM resolves to the binary). Source edits are silently ignored. The warning tells the user about this instead of leaving it as a mystery.

**Normal paths:**
- \`swift build\` (default): only \`prebuilt\` active → binary, no warning.
- \`swift build --traits sourceBuild\`: \`--traits\` *replaces* defaults, so only \`sourceBuild\` active → source-built tool, no warning.
- \`swift package generate-documentation\`: activates all traits → warning fires, but the collision is moot because DocC doesn't invoke build-tool plugins; \`--warnings-as-errors\` on \`swift-docc-plugin\` scopes to DocC's own doc warnings, not swift compile warnings, so strict mode still passes.

### `Sources/SafeDI/SafeDI.docc/SafeDI.md`
Minimal landing page, adapted from the README pitch:
- \`## Overview\` — what-is-SafeDI + code sample
- \`## Getting Started\` — three-step integration pointing to the Manual for depth
- \`## Topics\` — organizes the auto-generated API reference into decorator macros, configuration, and delayed-instantiation types

DocC harvests \`///\` comments for every public symbol automatically, so this one file unlocks the whole reference tree.

### `.spi.yml`
Opts us into SPI's DocC hosting. Only \`SafeDI\` is documented — \`SafeDIMacros\` is a compiler plugin (not user-facing); \`SafeDITool\` is a build tool (not library). Leaving platform unpinned lets SPI build on whatever works.

### CI `docc` job
Uses \`swift-docc-plugin\` directly: \`swift package generate-documentation --target SafeDI --warnings-as-errors\`. The plugin's per-target scoping keeps swift-syntax's internal DocC noise out of strict mode, which \`xcodebuild docbuild\` can't do (it walks the whole target graph).

## What this doesn't do
- **Doesn't delete Manual.md.** The Manual stays on GitHub; SPI-hosted DocC complements it.
- **Doesn't add README links to the SPI URL yet.** Per plan discussed: wait for SPI to successfully build once before wiring up README links. A follow-up PR adds them + adds \`swiftpackageindex.com\` to the markdown link-check exclusion list.
- **Doesn't migrate the Manual into DocC articles.** That's a separate, larger decision.

## Verification
- [x] \`swift build\` (default traits, \`prebuilt\` active) — plugin uses the prebuilt binary; no warning (verified with a local sentinel-in-generated-output test)
- [x] \`swift build --traits sourceBuild\` — plugin uses the source-built \`SafeDITool\`; no warning (verified with the same sentinel test)
- [x] \`swift build --traits prebuilt,sourceBuild\` — warning fires, build succeeds, binary wins
- [x] \`swift test --traits sourceBuild\` — 885 tests pass
- [x] \`./CLI/lint.sh\`
- [x] Local \`swift package generate-documentation --target SafeDI --warnings-as-errors\` succeeds (the #warning fires during symbol extraction but doesn't fail DocC's strict mode)

## Next steps (separate PRs)
1. After this lands and SPI picks it up, verify the hosted URL loads cleanly.
2. Tag a release (SPI documents the latest tagged version, not \`main\`).
3. Add README badge/link to the hosted docs + add \`swiftpackageindex.com\` to link-check exclusions.
4. Optional: migrate sections of Manual.md into DocC articles piecewise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)