### PR TITLE
Tests: enable compile verification on five previously-skipped mock tests

### DIFF
--- a/Tests/SafeDIToolTests/SafeDIToolMockGenerationCustomMockTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockGenerationCustomMockTests.swift
@@ -1477,12 +1477,6 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 			],
 			buildSwiftOutputDirectory: true,
 			filesToDelete: &filesToDelete,
-			// FIXME: ChildService's own generated mock() returns ChildService but calls
-			// ChildService.customMock(engine:), which returns ChildServiceProtocol. The
-			// generator must either skip customMock for the Self-returning mock or coerce
-			// the return type. Skipping compile verification until the generator handles
-			// this case.
-			skipCompileVerification: true,
 		)
 
 		#expect(output.mockFiles["Root+SafeDIMock.swift"] == """
@@ -1597,11 +1591,6 @@ struct SafeDIToolMockGenerationCustomMockTests: ~Copyable {
 			],
 			buildSwiftOutputDirectory: true,
 			filesToDelete: &filesToDelete,
-			// FIXME: Same root cause as the sibling ProtocolProperty test — ChildService's
-			// own generated mock() returns ChildService but calls customMock(engine:) which
-			// returns ChildServiceProtocol. Root-level output is fine but ChildService's
-			// mock file fails to compile until the generator handles this case.
-			skipCompileVerification: true,
 		)
 
 		#expect(output.mockFiles["Root+SafeDIMock.swift"] == """

--- a/Tests/SafeDIToolTests/SafeDIToolMockGenerationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockGenerationTests.swift
@@ -8217,8 +8217,6 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 			],
 			buildSwiftOutputDirectory: true,
 			filesToDelete: &filesToDelete,
-			// FIXME: @escaping not applied to mock method.
-			skipCompileVerification: true,
 		)
 
 		#expect(output.mockFiles["Service+SafeDIMock.swift"] == """
@@ -10642,11 +10640,6 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 			],
 			buildSwiftOutputDirectory: true,
 			filesToDelete: &filesToDelete,
-			// FIXME: Fully lazy instantiation cycle produces `SafeDIMockConfiguration`
-			// structs whose default initializer references themselves via the cycle,
-			// which Swift flags as circular. Skipping compile verification until the
-			// generator breaks the cycle.
-			skipCompileVerification: true,
 		)
 
 		#expect(output.mockFiles.count == 4)

--- a/Tests/SafeDIToolTests/SafeDIToolMockOnlyTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockOnlyTests.swift
@@ -831,11 +831,6 @@ struct SafeDIToolMockOnlyTests: ~Copyable {
 			],
 			buildSwiftOutputDirectory: true,
 			filesToDelete: &filesToDelete,
-			// FIXME: Generated code assigns `MockService.mock` (returning MockService)
-			// to a `(() -> AnyService)?` slot without a coercion, so Swift surfaces
-			// a generic-parameter conflict. Skipping compile verification until the
-			// generator coerces the mock return type to the fulfilled slot type.
-			skipCompileVerification: true,
 		)
 
 		// Production code uses ConcreteService (the non-mockOnly type).


### PR DESCRIPTION
## Summary
Five mock-generation tests carried `skipCompileVerification: true` FIXMEs pointing at generator bugs that have since been fixed. Removing the opt-outs confirms the fixes hold end-to-end (fresh parse → generated code → actual swiftc typecheck).

## Changes
Removed the FIXME comments and `skipCompileVerification: true` flag on:

| Test | Bug | Fixed in |
|------|-----|----------|
| `mock_usesMockOnly_whenProductionHasNoMockAndBothFulfillSameAdditionalType` | mockOnly not coerced to fulfilled-slot type | #251 |
| `mock_sendableClosureDependencyProducesValidIdentifier` | `@escaping` dropped on `@Sendable` closure on mock() | #267 |
| `mock_generatedForFullyLazyInstantiationCycle` | Fully-lazy cycles produced self-referential `SafeDIMockConfiguration` defaults | #259 |
| `mock_extensionUserMockReturningAdditionalTypeUsedForProtocolProperty` | customMock return type disagreement between root call site and type's own `mock()` | #266 |
| `mock_extensionUserMockReturningAdditionalTypeNotUsedForConcreteProperty` | Same as above — sibling test | #266 |

## Test plan
- [x] `swift test --traits sourceBuild` — 901 tests pass (up from 901; no tests added, but all five now exercise the compile-verification path)
- [x] `./CLI/lint.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)