### PR TITLE
Install: follow-up style cleanup for InstallSafeDITool + Xcode build plugin

### DIFF
--- a/Plugins/InstallSafeDITool/InstallSafeDITool.swift
+++ b/Plugins/InstallSafeDITool/InstallSafeDITool.swift
@@ -141,14 +141,14 @@ private func downloadTool(
 		// `URLSession.download(for:)` reports success for HTTP error pages
 		// (404, 500, etc.), so without this check we'd `chmod +x` and install
 		// the error body as the tool — the next build would fail opaquely.
-		if let httpResponse = response as? HTTPURLResponse,
-		   !(200..<300).contains(httpResponse.statusCode)
-		{
-			try? FileManager.default.removeItem(at: downloadedURL)
-			throw DownloadFailedError(
-				url: githubDownloadURL,
-				statusCode: httpResponse.statusCode,
-			)
+		if let httpResponse = response as? HTTPURLResponse {
+			guard (200..<300).contains(httpResponse.statusCode) else {
+				try? FileManager.default.removeItem(at: downloadedURL)
+				throw DownloadFailedError(
+					url: githubDownloadURL,
+					statusCode: httpResponse.statusCode,
+				)
+			}
 		}
 		let downloadedFileAttributes = try FileManager.default.attributesOfItem(atPath: downloadedURL.path(percentEncoded: false))
 		guard let currentPermissions = downloadedFileAttributes[.posixPermissions] as? NSNumber,

--- a/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
+++ b/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
@@ -234,69 +234,107 @@ extension Target {
 			let manifestFile = context.pluginWorkDirectoryURL.appending(path: "SafeDIManifest.json")
 
 			// With a downloaded prebuilt tool we can invoke the real scan
-			// subcommand, which produces an authoritative manifest. Without
-			// one, fall through to the lightweight PluginScanner.
-			if runsRealScan {
-				do {
-					try runSafeDITool(
-						at: tool,
-						arguments: [
-							"scan",
-							"--input-sources-file", inputSourcesFile.path(percentEncoded: false),
-							"--project-root", projectRoot.path(percentEncoded: false),
-							"--output-directory", outputDirectory.path(percentEncoded: false),
-							"--manifest-file", manifestFile.path(percentEncoded: false),
-							"--mock-scoped-files",
-						] + inputSwiftFiles.map { $0.path(percentEncoded: false) },
-					)
-					let manifest = try JSONDecoder().decode(
-						ScanManifest.self,
-						from: Data(contentsOf: manifestFile),
-					)
-					let outputFiles = (manifest.dependencyTreeGeneration + manifest.mockGeneration)
-						.map { URL(fileURLWithPath: $0.outputFilePath) }
-						+ (manifest.mockConfigurationOutputFilePath.map { [URL(fileURLWithPath: $0)] } ?? [])
-					let additionalInputFiles = manifest.additionalInputFiles.map { URL(fileURLWithPath: $0) }
-					guard !outputFiles.isEmpty else {
-						return []
-					}
-					return [
-						.buildCommand(
-							displayName: "SafeDIGenerateDependencyTree",
-							executable: tool,
-							arguments: [
-								inputSourcesFile.path(percentEncoded: false),
-								"--swift-manifest",
-								manifestFile.path(percentEncoded: false),
-							],
-							environment: [:],
-							inputFiles: inputSwiftFiles + additionalInputFiles,
-							outputFiles: outputFiles,
-						),
-					]
-				} catch let error as SafeDIToolLaunchError {
-					// Binary couldn't launch (wrong platform, corrupted, etc).
-					// This is the recoverable case — fall through to the
-					// in-process `PluginScanner` below.
-					Diagnostics.warning("SafeDITool could not be launched during plugin setup (\(error)). Falling back to in-process scan.")
-				}
-				// SafeDIToolProcessError (scan ran but exited non-zero —
-				// parse errors, validation failures, etc.) intentionally
-				// bubbles up. Falling back to a regex-based scanner would
-				// mask the real error and produce silently-wrong output.
+			// subcommand, which produces an authoritative manifest.
+			// `buildCommandsUsingRealScan` returns nil on a recoverable
+			// launch failure (wrong platform, corrupted binary) — in that
+			// case we fall back to the lightweight in-process `PluginScanner`.
+			// SafeDITool process-level errors (parse / validation failures)
+			// bubble up from the helper without masking.
+			if runsRealScan,
+			   let commands = try buildCommandsUsingRealScan(
+			   	tool: tool,
+			   	inputSwiftFiles: inputSwiftFiles,
+			   	inputSourcesFile: inputSourcesFile,
+			   	projectRoot: projectRoot,
+			   	outputDirectory: outputDirectory,
+			   	manifestFile: manifestFile,
+			   )
+			{
+				return commands
+			} else {
+				return buildCommandsUsingPluginScanner(
+					tool: tool,
+					inputSwiftFiles: inputSwiftFiles,
+					inputSourcesFile: inputSourcesFile,
+					projectRoot: projectRoot,
+					outputDirectory: outputDirectory,
+				)
 			}
+		}
 
+		private func buildCommandsUsingRealScan(
+			tool: URL,
+			inputSwiftFiles: [URL],
+			inputSourcesFile: URL,
+			projectRoot: URL,
+			outputDirectory: URL,
+			manifestFile: URL,
+		) throws -> [PackagePlugin.Command]? {
+			do {
+				try runSafeDITool(
+					at: tool,
+					arguments: [
+						"scan",
+						"--input-sources-file", inputSourcesFile.path(percentEncoded: false),
+						"--project-root", projectRoot.path(percentEncoded: false),
+						"--output-directory", outputDirectory.path(percentEncoded: false),
+						"--manifest-file", manifestFile.path(percentEncoded: false),
+						"--mock-scoped-files",
+					] + inputSwiftFiles.map { $0.path(percentEncoded: false) },
+				)
+			} catch let error as SafeDIToolLaunchError {
+				// Binary couldn't launch (wrong platform, corrupted, etc).
+				// Signal to the caller that the PluginScanner fallback
+				// should run by returning nil. SafeDIToolProcessError
+				// (scan exited non-zero — parse/validation error) is not
+				// caught here; it propagates so real errors surface
+				// instead of being masked by a regex-based fallback.
+				Diagnostics.warning("SafeDITool could not be launched during plugin setup (\(error)). Falling back to in-process scan.")
+				return nil
+			}
+			let manifest = try JSONDecoder().decode(
+				ScanManifest.self,
+				from: Data(contentsOf: manifestFile),
+			)
+			let outputFiles = (manifest.dependencyTreeGeneration + manifest.mockGeneration)
+				.map { URL(fileURLWithPath: $0.outputFilePath) }
+				+ (manifest.mockConfigurationOutputFilePath.map { [URL(fileURLWithPath: $0)] } ?? [])
+			let additionalInputFiles = manifest.additionalInputFiles.map { URL(fileURLWithPath: $0) }
+			guard !outputFiles.isEmpty else {
+				return []
+			}
+			return [
+				.buildCommand(
+					displayName: "SafeDIGenerateDependencyTree",
+					executable: tool,
+					arguments: [
+						inputSourcesFile.path(percentEncoded: false),
+						"--swift-manifest",
+						manifestFile.path(percentEncoded: false),
+					],
+					environment: [:],
+					inputFiles: inputSwiftFiles + additionalInputFiles,
+					outputFiles: outputFiles,
+				),
+			]
+		}
+
+		private func buildCommandsUsingPluginScanner(
+			tool: URL,
+			inputSwiftFiles: [URL],
+			inputSourcesFile: URL,
+			projectRoot: URL,
+			outputDirectory: URL,
+		) -> [PackagePlugin.Command] {
 			let scanResult = PluginScanner.scan(
 				swiftFiles: inputSwiftFiles,
 				mockScopedSwiftFiles: inputSwiftFiles,
 				relativeTo: projectRoot,
 				outputDirectory: outputDirectory,
 			)
-
 			guard !scanResult.outputFiles.isEmpty else {
 				return []
 			}
-
 			return [
 				.buildCommand(
 					displayName: "SafeDIGenerateDependencyTree",


### PR DESCRIPTION
## Summary
Style-guide follow-up to #273. CLAUDE.md bars bare \`if { return|throw }\` patterns with implicit fall-through — the non-returning path has to sit in an explicit \`else\`.

## Changes
- **\`Plugins/InstallSafeDITool/InstallSafeDITool.swift\`** — HTTP status check for the downloaded asset. The old
  \`\`\`swift
  if let httpResponse = response as? HTTPURLResponse,
     !(200..<300).contains(httpResponse.statusCode)
  {
      throw DownloadFailedError(...)
  }
  \`\`\`
  falls through on 2xx. Restructured to
  \`\`\`swift
  if let httpResponse = response as? HTTPURLResponse {
      guard (200..<300).contains(httpResponse.statusCode) else { throw ... }
  }
  \`\`\`
  Same runtime behavior.

- **\`Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift\`** — Xcode variant's real-scan / \`PluginScanner\` split. The old \`if runsRealScan { do-return-catch } ...\` block returned from inside the \`if\` and fell through on \`SafeDIToolLaunchError\`. Extracted:
  - \`buildCommandsUsingRealScan(...)\` — returns \`nil\` on recoverable launch failure, lets \`SafeDIToolProcessError\` propagate
  - \`buildCommandsUsingPluginScanner(...)\` — regex-based fallback
  
  Caller is now
  \`\`\`swift
  if runsRealScan, let commands = try buildCommandsUsingRealScan(...) {
      return commands
  } else {
      return buildCommandsUsingPluginScanner(...)
  }
  \`\`\`
  Both branches return. Runtime behavior unchanged: \`ProcessError\` still surfaces, \`LaunchError\` still warns + falls to scanner.

## What this doesn't do
- Binary checksum / code signature verification for the downloaded tool (codex P1 on #273). Current controls are Gatekeeper (macOS signing + notarization at \`Process.run\` time) and the \`--version\` match in \`verifiedDownloadedToolLocation\`. A full checksum-pin would mirror \`SafeDIToolBinary\`'s checksum and needs publish-workflow coordination — separate PR.

## Test plan
- [x] \`swift build --traits sourceBuild\` — builds clean
- [x] \`./CLI/lint.sh\`
- [x] Plugin code is non-unit-testable; no test changes. Existing CI covers the \`buildCommandsUsingPluginScanner\` path via \`spm-project-integration\` and \`spm-multi-project-integration\` (they exercise the Xcode build plugin through \`xcodebuild\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)