### PR TITLE
Install: rename verb back to safedi-release-install (matches 1.x)

### DIFF
--- a/Documentation/Manual.md
+++ b/Documentation/Manual.md
@@ -46,7 +46,7 @@ The `additionalDirectoriesToInclude` parameter specifies folders outside of your
 
 If you see a build warning that starts with **"SafeDI's build-tool plugin is falling back to a regex-based output scanner..."** — installing the prebuilt tool fixes it.
 
-In Xcode, right-click your project in the navigator and choose **SafeDI → Safedi Install Tool**. Approve the network-access and write-to-package-directory prompts. Xcode runs the command and downloads the prebuilt SafeDITool release binary for your SafeDI version into `.safedi/<version>/safeditool` next to your `.xcodeproj`. The build plugin picks it up automatically on subsequent builds.
+In Xcode, right-click your project in the navigator and choose **SafeDI → Safedi Release Install**. Approve the network-access and write-to-package-directory prompts. Xcode runs the command and downloads the prebuilt SafeDITool release binary for your SafeDI version into `.safedi/<version>/safeditool` next to your `.xcodeproj`. The build plugin picks it up automatically on subsequent builds.
 
 **Why this step is required in Xcode:** Xcode’ implementation of Swift package build-tool plugins does not give plugins access to real tool locations within derived data – paths include placeholders whose values are not available to the plugin. SafeDI's plugin therefore can’t execute the real parser during setup and falls back to a regex-based output scanner. Installing the `SafeDITool` to a well-known location allows the plugin to execute the prebuilt tool. The install command is a one-time step per project (re-run it after a SafeDI version bump if the warning reappears). The plugin only runs inside Xcode — `swift build` users get the prebuilt binary through the default `prebuilt` trait already.
 
@@ -793,7 +793,7 @@ This plugin will:
 
 ### Plugin changes
 
-The `SafeDIPrebuiltGenerator` plugin and `InstallSafeDITool` command plugin have been removed in SafeDI 2.x. `SafeDIGenerator` is now the only build tool plugin and uses a prebuilt binary by default. If you were previously using `SafeDIPrebuiltGenerator` or the `safedi-release-install` command, switch to `SafeDIGenerator`.
+The `SafeDIPrebuiltGenerator` plugin has been removed in SafeDI 2.x. `SafeDIGenerator` is now the only build tool plugin and uses a prebuilt binary by default. If you were previously using `SafeDIPrebuiltGenerator`, switch to `SafeDIGenerator`. The `InstallSafeDITool` command plugin (verb `safedi-release-install`, matching 1.x) still exists as an Xcode-only helper for the prebuilt-tool install flow described under _Installing the prebuilt SafeDITool binary_ above.
 
 ### Migrating prebuild scripts or custom build system integrations
 

--- a/Documentation/Manual.md
+++ b/Documentation/Manual.md
@@ -793,7 +793,7 @@ This plugin will:
 
 ### Plugin changes
 
-The `SafeDIPrebuiltGenerator` plugin has been removed in SafeDI 2.x. `SafeDIGenerator` is now the only build tool plugin and uses a prebuilt binary by default. If you were previously using `SafeDIPrebuiltGenerator`, switch to `SafeDIGenerator`. The `InstallSafeDITool` command plugin (verb `safedi-release-install`, matching 1.x) still exists as an Xcode-only helper for the prebuilt-tool install flow described under _Installing the prebuilt SafeDITool binary_ above.
+The `SafeDIPrebuiltGenerator` plugin has been removed in SafeDI 2.x. `SafeDIGenerator` is now the only build tool plugin and uses a prebuilt binary by default. If you were previously using `SafeDIPrebuiltGenerator`, switch to `SafeDIGenerator`. For users of the Xcode build plugin: the `InstallSafeDITool` command plugin still exists as an Xcode-only helper for the prebuilt-tool install flow described under _Installing the prebuilt SafeDITool binary_ above.
 
 ### Migrating prebuild scripts or custom build system integrations
 

--- a/Package.swift
+++ b/Package.swift
@@ -113,7 +113,7 @@ let package = Package(
 			name: "InstallSafeDITool",
 			capability: .command(
 				intent: .custom(
-					verb: "safedi-install-tool",
+					verb: "safedi-release-install",
 					description: "Xcode-only: downloads the SafeDITool prebuilt release binary for the current SafeDI version into .safedi/<version>/safeditool next to the .xcodeproj. swift build users get the prebuilt tool via the default `prebuilt` trait and don't need this.",
 				),
 				permissions: [

--- a/Plugins/InstallSafeDITool/InstallSafeDITool.swift
+++ b/Plugins/InstallSafeDITool/InstallSafeDITool.swift
@@ -39,7 +39,7 @@ struct InstallSafeDITool: CommandPlugin {
 		context _: PackagePlugin.PluginContext,
 		arguments _: [String],
 	) async throws {
-		Diagnostics.error("safedi-install-tool is an Xcode-only command plugin. swift build users get the prebuilt binary via the default `prebuilt` trait, and `--traits sourceBuild` builds SafeDITool from source on purpose.")
+		Diagnostics.error("safedi-release-install is an Xcode-only command plugin. swift build users get the prebuilt binary via the default `prebuilt` trait, and `--traits sourceBuild` builds SafeDITool from source on purpose.")
 		exit(1)
 	}
 }

--- a/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
+++ b/Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift
@@ -211,7 +211,7 @@ extension Target {
 				scanner because the SPM-provided SafeDITool path contains unresolved \
 				Xcode build variables at plugin-setup time. To install the prebuilt \
 				SafeDITool binary for version \(context.safeDIVersion), right-click \
-				the project in Xcode and choose SafeDI → Safedi Install Tool.
+				the project in Xcode and choose SafeDI → Safedi Release Install.
 				""")
 			}
 			let inputSwiftFiles = target


### PR DESCRIPTION
## Summary
Rename the \`InstallSafeDITool\` command plugin verb from \`safedi-install-tool\` (introduced in #273) back to \`safedi-release-install\` (matches the 1.x verb). Removes migration friction for users upgrading from 1.x and drops a clarifying note in the manual that called out the drift.

Safe to rename: #273 hasn't shipped in any published release yet (only the \`2.0.0-alpha-18-xcode-plugin-test\` test tag), so no consumer has scripted around the 2.x verb.

## Changes
- \`Package.swift\`: verb string updated
- \`Plugins/InstallSafeDITool/InstallSafeDITool.swift\`: SPM-path error message mentions the new verb
- \`Plugins/SafeDIGenerator/SafeDIGenerateDependencyTree.swift\`: fallback warning now points users at \`SafeDI → Safedi Release Install\` (Xcode-rendered capitalization)
- \`Documentation/Manual.md\`: install instructions + migration note both updated; the \"1.x verb was X\" clarifying note is gone now that they match

## Test plan
- [x] \`swift build --traits sourceBuild\` — builds clean
- [x] \`./CLI/lint.sh\`
- [x] \`grep -rn "safedi-install-tool|Safedi Install Tool"\` — no stale references

🤖 Generated with [Claude Code](https://claude.com/claude-code)