### PR TITLE
Docs: consolidate closure override examples

### DIFF
--- a/Documentation/Manual.md
+++ b/Documentation/Manual.md
@@ -629,7 +629,7 @@ Closure-shaped entries apply when the dependency has nothing further to configur
 
 ```swift
 LoggedInView.mock(safeDIOverrides: .init(
-    // Literal closure — `StringStorage` has no inputs of its own, so its closure takes nothing:
+    // Literal closure — `StringStorage` has no inputs of its own, so its closure has no parameters:
     stringStorage: { InMemoryStorage() },
     // Init reference — `StubUserService.init(stringStorage:)` is already `(StringStorage) -> UserService`:
     userService: StubUserService.init

--- a/Documentation/Manual.md
+++ b/Documentation/Manual.md
@@ -625,17 +625,13 @@ Your user-defined `mock()` method must be `public` (or `open`) and must accept p
 
 When a type has `@Instantiated` dependencies, the generated `mock()` accepts a `safeDIOverrides` argument that lets you override any dependency in the tree. Each entry on `SafeDIOverrides` is either a closure whose parameters match the resolved values of that dependency’s own inputs, or a nested `SafeDIMockConfiguration` struct when the dependency has its own `@Instantiated` subtree or default-valued init parameters.
 
-Closure-shaped entries apply when the dependency has nothing further to configure:
+Closure-shaped entries apply when the dependency has nothing further to configure. Pass any closure whose parameters match the dependency's resolved inputs — a literal, or an `init` reference when its signature already matches:
 
 ```swift
-// Override a leaf dependency — UserDefaults.instantiate() takes nothing, so its closure takes nothing:
 LoggedInView.mock(safeDIOverrides: .init(
-    stringStorage: { InMemoryStorage() }
-))
-
-// `StubUserService.init(stringStorage:)` already matches the override closure's shape
-// — `(StringStorage) -> UserService` — so the initializer can be passed directly:
-LoggedInView.mock(safeDIOverrides: .init(
+    // Literal closure — `StringStorage` has no inputs of its own, so its closure takes nothing:
+    stringStorage: { InMemoryStorage() },
+    // Init reference — `StubUserService.init(stringStorage:)` is already `(StringStorage) -> UserService`:
     userService: StubUserService.init
 ))
 ```


### PR DESCRIPTION
## Summary
- The \"Overriding dependencies\" section of the manual had two closure-shaped-entry examples that didn't carve nature at a joint — both demonstrated \"closure-shaped entry, filled with a closure,\" just with different closure arities. `{ InMemoryStorage() }` could equally be written `InMemoryStorage.init`, so the arity variance wasn't the teaching moment.
- Collapsed them into one example that shows both the closure-literal form and the `init`-reference shorthand side-by-side, with prose that names the shorthand explicitly.

## Test plan
- [x] Manual re-read — the example now carries both forms in one block and the prose explains when each applies