### PR TITLE
Clarify mock API buckets in manual

### DIFF
--- a/Documentation/Manual.md
+++ b/Documentation/Manual.md
@@ -623,6 +623,14 @@ Your user-defined `mock()` method must be `public` (or `open`) and must accept p
 
 ### Overriding dependencies
 
+It can be helpful to think of a generated `mock()` as having three buckets:
+
+1. Flat `mock()` parameters for values the caller owns directly at the root.
+2. The `safeDIOverrides` parameter, whose `SafeDIOverrides` value lets you customize values that SafeDI surfaces through the generated dependency tree.
+3. Nested `SafeDIMockConfiguration` values inside `SafeDIOverrides` when a child has its own subtree or default-valued construction inputs.
+
+In practice, that means values that belong directly to the mocked root stay as flat parameters, while values that customize the generated dependency tree flow through `safeDIOverrides`.
+
 When a type has `@Instantiated` dependencies, the generated `mock()` accepts a `safeDIOverrides` argument that lets you override any dependency in the tree. Each entry on `SafeDIOverrides` is either a closure whose parameters match the resolved values of that dependency’s own inputs, or a nested `SafeDIMockConfiguration` struct when the dependency has its own `@Instantiated` subtree or default-valued init parameters.
 
 Closure-shaped entries apply when the dependency has nothing further to configure. Pass any closure whose parameters match the dependency's resolved inputs — a literal, or an `init` reference when its signature already matches:
@@ -658,6 +666,20 @@ Closure fields on `SafeDIMockConfiguration` are plain (non-`@Sendable`) by defau
 
 A type generates its own `SafeDIOverrides` struct when it has `@Instantiated` dependencies or `@Received(onlyIfAvailable: true)` dependencies. A type whose only dependencies are required `@Received` or `@Forwarded` uses flat parameters on its `mock()` method.
 
+Here is all three buckets together in one call:
+
+```swift
+LoggedInView.mock(
+    user: User(name: "dfed"),
+    safeDIOverrides: .init(
+        userService: StubUserService.init,
+        noteStorage: .init(defaultNote: "dfed says hello")
+    )
+)
+```
+
+In that example, `user` is a flat `mock()` parameter, `userService` is overridden directly on `SafeDIOverrides`, and `noteStorage` uses a nested `SafeDIMockConfiguration` because it has its own configurable construction input.
+
 ### Mock visibility
 
 Generated mocks have `internal` visibility. They are accessible within the module where they are generated but not from other modules. This avoids cross-module extension conflicts when multiple modules generate mocks for the same types.
@@ -666,7 +688,13 @@ To use a mock from another module in your tests, see [Cross-module mock generati
 
 ### Dependency kinds in the generated mock
 
-Each dependency kind surfaces in a predictable place on `mock()` and `SafeDIOverrides`:
+The three buckets above map cleanly onto the generated API surface:
+
+- Flat `mock()` parameters: values the caller supplies directly to the root.
+- `SafeDIOverrides`: root-level access to the generated dependency subtree.
+- `SafeDIMockConfiguration`: per-child customization when a child has its own subtree or default-valued construction inputs.
+
+The table below shows where each dependency kind lands:
 
 | Dependency kind | Shape in the mock | Default |
 | --- | --- | --- |

--- a/Documentation/Manual.md
+++ b/Documentation/Manual.md
@@ -631,6 +631,20 @@ It can be helpful to think of a generated `mock()` as having three buckets:
 
 In practice, that means values that belong directly to the mocked root stay as flat parameters, while values that customize the generated dependency tree flow through `safeDIOverrides`.
 
+Here is all three buckets together in one call:
+
+```swift
+LoggedInView.mock(
+    user: User(name: "dfed"),
+    safeDIOverrides: .init(
+        userService: StubUserService.init,
+        noteStorage: .init(defaultNote: "dfed says hello")
+    )
+)
+```
+
+In that example, `user` is a flat `mock()` parameter, `userService` is overridden directly on `SafeDIOverrides`, and `noteStorage` uses a nested `SafeDIMockConfiguration` because it has its own configurable construction input.
+
 When a type has `@Instantiated` dependencies, the generated `mock()` accepts a `safeDIOverrides` argument that lets you override any dependency in the tree. Each entry on `SafeDIOverrides` is either a closure whose parameters match the resolved values of that dependency’s own inputs, or a nested `SafeDIMockConfiguration` struct when the dependency has its own `@Instantiated` subtree or default-valued init parameters.
 
 Closure-shaped entries apply when the dependency has nothing further to configure. Pass any closure whose parameters match the dependency's resolved inputs — a literal, or an `init` reference when its signature already matches:
@@ -666,35 +680,9 @@ Closure fields on `SafeDIMockConfiguration` are plain (non-`@Sendable`) by defau
 
 A type generates its own `SafeDIOverrides` struct when it has `@Instantiated` dependencies or `@Received(onlyIfAvailable: true)` dependencies. A type whose only dependencies are required `@Received` or `@Forwarded` uses flat parameters on its `mock()` method.
 
-Here is all three buckets together in one call:
+#### Dependency kinds in the generated mock
 
-```swift
-LoggedInView.mock(
-    user: User(name: "dfed"),
-    safeDIOverrides: .init(
-        userService: StubUserService.init,
-        noteStorage: .init(defaultNote: "dfed says hello")
-    )
-)
-```
-
-In that example, `user` is a flat `mock()` parameter, `userService` is overridden directly on `SafeDIOverrides`, and `noteStorage` uses a nested `SafeDIMockConfiguration` because it has its own configurable construction input.
-
-### Mock visibility
-
-Generated mocks have `internal` visibility. They are accessible within the module where they are generated but not from other modules. This avoids cross-module extension conflicts when multiple modules generate mocks for the same types.
-
-To use a mock from another module in your tests, see [Cross-module mock generation](#cross-module-mock-generation).
-
-### Dependency kinds in the generated mock
-
-The three buckets above map cleanly onto the generated API surface:
-
-- Flat `mock()` parameters: values the caller supplies directly to the root.
-- `SafeDIOverrides`: root-level access to the generated dependency subtree.
-- `SafeDIMockConfiguration`: per-child customization when a child has its own subtree or default-valued construction inputs.
-
-The table below shows where each dependency kind lands:
+The table below shows where each dependency kind lands in the three buckets above. The main wrinkle is `@Received(onlyIfAvailable: true)`: it appears on `SafeDIOverrides` and defaults to `nil`.
 
 | Dependency kind | Shape in the mock | Default |
 | --- | --- | --- |
@@ -704,23 +692,11 @@ The table below shows where each dependency kind lands:
 | `@Received(onlyIfAvailable: true)` | Entry on `SafeDIOverrides`, typed as optional | `nil` |
 | Default-valued non-DI init parameter | Flat `mock()` parameter on a direct mock, or a nested `SafeDIMockConfiguration` field when reached through a parent | The parameter’s original default expression |
 
-```swift
-// @Forwarded → flat parameter:
-let view = LoggedInView.mock(user: User(name: "dfed"))
+### Mock visibility
 
-// @Received(onlyIfAvailable: true) → SafeDIOverrides, defaults to nil:
-FeedView.mock(safeDIOverrides: .init(
-    user: .mock()
-))
+Generated mocks have `internal` visibility. They are accessible within the module where they are generated but not from other modules. This avoids cross-module extension conflicts when multiple modules generate mocks for the same types.
 
-// Default-valued init parameter → nested SafeDIMockConfiguration when mocking a parent:
-LoggedInView.mock(
-    user: User(name: "dfed"),
-    safeDIOverrides: .init(
-        noteStorage: .init(defaultNote: "dfed says hello")
-    )
-)
-```
+To use a mock from another module in your tests, see [Cross-module mock generation](#cross-module-mock-generation).
 
 ### The `mockAttributes` parameter
 


### PR DESCRIPTION
## Summary
- explain the generated mock API in the manual using a three-bucket mental model
- reorder the examples so one canonical example comes first and later examples build on it
- collapse dependency-kind material into a reference subsection and remove duplicate examples

## Why
- the mock surface is powerful, but it becomes easier to learn when the narrative builds from one example instead of repeating similar call sites
- the dependency-kind table works better as lookup material than as a second tutorial section

## Validation
- docs-only change; not run
