### PR TITLE
Add required initializers to README and DocC examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,16 @@ SafeDI reads your code, validates your dependencies, and generates production an
 Opting a type into the SafeDI dependency tree is simple: add the `@Instantiable` macro to your type declaration, and decorate each dependency with a macro that indicates its lifecycle. Here is what a notes app might look like in SafeDI:
 
 ```swift
-// `NotesApp` is the root of the dependency graph.
-// SafeDI generates its public `init()`, so you do not write one yourself.
+// `NotesApp` is the root of the dependency graph. SafeDI generates its public `init()`.
 @Instantiable(isRoot: true) @main
 public struct NotesApp: App, Instantiable {
+    public init(
+        userService: UserService,
+        stringStorage: StringStorage,
+        nameEntryViewBuilder: Instantiator<NameEntryView>,
+        loggedInViewBuilder: Instantiator<LoggedInView>
+    ) { … }
+
     public var body: some Scene {
         WindowGroup {
             if let user = userService.user {
@@ -40,6 +46,7 @@ public struct NotesApp: App, Instantiable {
     }
 
     @ObservedObject @Instantiated private var userService: UserService
+    @Instantiated private let stringStorage: StringStorage
     @Instantiated private let nameEntryViewBuilder: Instantiator<NameEntryView>
     @Instantiated private let loggedInViewBuilder: Instantiator<LoggedInView>
 }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ public struct LoggedInView: View, Instantiable {
 
 @Instantiable
 public final class NoteStorage: Instantiable {
-    public init(user: User, stringStorage: StringStorage, defaultNote: String = "") { … }
+    public init(user: User, stringStorage: StringStorage) { … }
 
     // `user` and `stringStorage` are received from ancestors in the tree.
     @Received private let user: User

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ SafeDI reads your code, validates your dependencies, and generates production an
 Opting a type into the SafeDI dependency tree is simple: add the `@Instantiable` macro to your type declaration, and decorate each dependency with a macro that indicates its lifecycle. Here is what a notes app might look like in SafeDI:
 
 ```swift
-// `NotesApp` is the root of the dependency graph. SafeDI generates its public `init()`.
+// `NotesApp` is the root of the dependency graph. SafeDI generates its `public init()`.
 @Instantiable(isRoot: true) @main
 public struct NotesApp: App, Instantiable {
     public init(

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ public struct NotesApp: App, Instantiable {
 
 @Instantiable
 public struct LoggedInView: View, Instantiable {
+    public init(user: User, userService: UserService, noteStorage: NoteStorage) {
+        self.user = user
+        self.userService = userService
+        self.noteStorage = noteStorage
+    }
+
     public var body: some View { … }
 
     // `user` is a runtime value forwarded in at this boundary.
@@ -57,9 +63,17 @@ public struct LoggedInView: View, Instantiable {
 
 @Instantiable
 public final class NoteStorage: Instantiable {
+    public init(user: User, stringStorage: StringStorage, defaultNote: String = "") {
+        self.user = user
+        self.stringStorage = stringStorage
+        self.defaultNote = defaultNote
+    }
+
     // `user` and `stringStorage` are received from ancestors in the tree.
     @Received private let user: User
     @Received private let stringStorage: StringStorage
+
+    private let defaultNote: String
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ SafeDI reads your code, validates your dependencies, and generates production an
 Opting a type into the SafeDI dependency tree is simple: add the `@Instantiable` macro to your type declaration, and decorate each dependency with a macro that indicates its lifecycle. Here is what a notes app might look like in SafeDI:
 
 ```swift
-// `NotesApp` is the root of the dependency graph. SafeDI generates its public `init()`.
+// `NotesApp` is the root of the dependency graph.
+// SafeDI generates its public `init()`, so you do not write one yourself.
 @Instantiable(isRoot: true) @main
 public struct NotesApp: App, Instantiable {
     public var body: some Scene {
@@ -45,11 +46,7 @@ public struct NotesApp: App, Instantiable {
 
 @Instantiable
 public struct LoggedInView: View, Instantiable {
-    public init(user: User, userService: UserService, noteStorage: NoteStorage) {
-        self.user = user
-        self.userService = userService
-        self.noteStorage = noteStorage
-    }
+    public init(user: User, userService: UserService, noteStorage: NoteStorage) { … }
 
     public var body: some View { … }
 
@@ -63,17 +60,11 @@ public struct LoggedInView: View, Instantiable {
 
 @Instantiable
 public final class NoteStorage: Instantiable {
-    public init(user: User, stringStorage: StringStorage, defaultNote: String = "") {
-        self.user = user
-        self.stringStorage = stringStorage
-        self.defaultNote = defaultNote
-    }
+    public init(user: User, stringStorage: StringStorage, defaultNote: String = "") { … }
 
     // `user` and `stringStorage` are received from ancestors in the tree.
     @Received private let user: User
     @Received private let stringStorage: StringStorage
-
-    private let defaultNote: String
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Opting a type into the SafeDI dependency tree is simple: add the `@Instantiable`
 public struct NotesApp: App, Instantiable {
     public init(
         userService: UserService,
-        stringStorage: StringStorage,
         nameEntryViewBuilder: Instantiator<NameEntryView>,
         loggedInViewBuilder: Instantiator<LoggedInView>
     ) { … }
@@ -46,7 +45,6 @@ public struct NotesApp: App, Instantiable {
     }
 
     @ObservedObject @Instantiated private var userService: UserService
-    @Instantiated private let stringStorage: StringStorage
     @Instantiated private let nameEntryViewBuilder: Instantiator<NameEntryView>
     @Instantiated private let loggedInViewBuilder: Instantiator<LoggedInView>
 }
@@ -63,15 +61,6 @@ public struct LoggedInView: View, Instantiable {
     @Received private let userService: UserService
     // `noteStorage` is created by `LoggedInView` and lives for its lifetime.
     @Instantiated private let noteStorage: NoteStorage
-}
-
-@Instantiable
-public final class NoteStorage: Instantiable {
-    public init(user: User, stringStorage: StringStorage) { … }
-
-    // `user` and `stringStorage` are received from ancestors in the tree.
-    @Received private let user: User
-    @Received private let stringStorage: StringStorage
 }
 ```
 

--- a/Sources/SafeDI/SafeDI.docc/SafeDI.md
+++ b/Sources/SafeDI/SafeDI.docc/SafeDI.md
@@ -52,7 +52,7 @@ public struct LoggedInView: View, Instantiable {
 
 @Instantiable
 public final class NoteStorage: Instantiable {
-    public init(user: User, stringStorage: StringStorage, defaultNote: String = "") { /* ... */ }
+    public init(user: User, stringStorage: StringStorage) { /* ... */ }
 
     // `user` and `stringStorage` are received from ancestors in the tree.
     @Received private let user: User

--- a/Sources/SafeDI/SafeDI.docc/SafeDI.md
+++ b/Sources/SafeDI/SafeDI.docc/SafeDI.md
@@ -9,7 +9,8 @@ SafeDI reads your code, validates your dependencies, and generates production an
 Opting a type into the SafeDI dependency tree is simple: add `@Instantiable` to your type declaration, and decorate each dependency with a macro that indicates its lifecycle. Here is what a notes app might look like in SafeDI:
 
 ```swift
-// `NotesApp` is the root of the dependency graph. SafeDI generates its public `init()`.
+// `NotesApp` is the root of the dependency graph.
+// SafeDI generates its public `init()`, so you do not write one yourself.
 @Instantiable(isRoot: true) @main
 public struct NotesApp: App, Instantiable {
     public var body: some Scene {
@@ -30,11 +31,7 @@ public struct NotesApp: App, Instantiable {
 
 @Instantiable
 public struct LoggedInView: View, Instantiable {
-    public init(user: User, userService: UserService, noteStorage: NoteStorage) {
-        self.user = user
-        self.userService = userService
-        self.noteStorage = noteStorage
-    }
+    public init(user: User, userService: UserService, noteStorage: NoteStorage) { /* ... */ }
 
     public var body: some View { /* ... */ }
 
@@ -48,17 +45,11 @@ public struct LoggedInView: View, Instantiable {
 
 @Instantiable
 public final class NoteStorage: Instantiable {
-    public init(user: User, stringStorage: StringStorage, defaultNote: String = "") {
-        self.user = user
-        self.stringStorage = stringStorage
-        self.defaultNote = defaultNote
-    }
+    public init(user: User, stringStorage: StringStorage, defaultNote: String = "") { /* ... */ }
 
     // `user` and `stringStorage` are received from ancestors in the tree.
     @Received private let user: User
     @Received private let stringStorage: StringStorage
-
-    private let defaultNote: String
 }
 ```
 

--- a/Sources/SafeDI/SafeDI.docc/SafeDI.md
+++ b/Sources/SafeDI/SafeDI.docc/SafeDI.md
@@ -30,6 +30,12 @@ public struct NotesApp: App, Instantiable {
 
 @Instantiable
 public struct LoggedInView: View, Instantiable {
+    public init(user: User, userService: UserService, noteStorage: NoteStorage) {
+        self.user = user
+        self.userService = userService
+        self.noteStorage = noteStorage
+    }
+
     public var body: some View { /* ... */ }
 
     // `user` is a runtime value forwarded in at this boundary.
@@ -38,6 +44,21 @@ public struct LoggedInView: View, Instantiable {
     @Received private let userService: UserService
     // `noteStorage` is created by `LoggedInView` and lives for its lifetime.
     @Instantiated private let noteStorage: NoteStorage
+}
+
+@Instantiable
+public final class NoteStorage: Instantiable {
+    public init(user: User, stringStorage: StringStorage, defaultNote: String = "") {
+        self.user = user
+        self.stringStorage = stringStorage
+        self.defaultNote = defaultNote
+    }
+
+    // `user` and `stringStorage` are received from ancestors in the tree.
+    @Received private let user: User
+    @Received private let stringStorage: StringStorage
+
+    private let defaultNote: String
 }
 ```
 

--- a/Sources/SafeDI/SafeDI.docc/SafeDI.md
+++ b/Sources/SafeDI/SafeDI.docc/SafeDI.md
@@ -14,7 +14,6 @@ Opting a type into the SafeDI dependency tree is simple: add `@Instantiable` to 
 public struct NotesApp: App, Instantiable {
     public init(
         userService: UserService,
-        stringStorage: StringStorage,
         nameEntryViewBuilder: Instantiator<NameEntryView>,
         loggedInViewBuilder: Instantiator<LoggedInView>
     ) { /* ... */ }
@@ -31,7 +30,6 @@ public struct NotesApp: App, Instantiable {
     }
 
     @ObservedObject @Instantiated private var userService: UserService
-    @Instantiated private let stringStorage: StringStorage
     @Instantiated private let nameEntryViewBuilder: Instantiator<NameEntryView>
     @Instantiated private let loggedInViewBuilder: Instantiator<LoggedInView>
 }
@@ -48,15 +46,6 @@ public struct LoggedInView: View, Instantiable {
     @Received private let userService: UserService
     // `noteStorage` is created by `LoggedInView` and lives for its lifetime.
     @Instantiated private let noteStorage: NoteStorage
-}
-
-@Instantiable
-public final class NoteStorage: Instantiable {
-    public init(user: User, stringStorage: StringStorage) { /* ... */ }
-
-    // `user` and `stringStorage` are received from ancestors in the tree.
-    @Received private let user: User
-    @Received private let stringStorage: StringStorage
 }
 ```
 

--- a/Sources/SafeDI/SafeDI.docc/SafeDI.md
+++ b/Sources/SafeDI/SafeDI.docc/SafeDI.md
@@ -9,7 +9,7 @@ SafeDI reads your code, validates your dependencies, and generates production an
 Opting a type into the SafeDI dependency tree is simple: add `@Instantiable` to your type declaration, and decorate each dependency with a macro that indicates its lifecycle. Here is what a notes app might look like in SafeDI:
 
 ```swift
-// `NotesApp` is the root of the dependency graph. SafeDI generates its public `init()`.
+// `NotesApp` is the root of the dependency graph. SafeDI generates its `public init()`.
 @Instantiable(isRoot: true) @main
 public struct NotesApp: App, Instantiable {
     public init(

--- a/Sources/SafeDI/SafeDI.docc/SafeDI.md
+++ b/Sources/SafeDI/SafeDI.docc/SafeDI.md
@@ -9,10 +9,16 @@ SafeDI reads your code, validates your dependencies, and generates production an
 Opting a type into the SafeDI dependency tree is simple: add `@Instantiable` to your type declaration, and decorate each dependency with a macro that indicates its lifecycle. Here is what a notes app might look like in SafeDI:
 
 ```swift
-// `NotesApp` is the root of the dependency graph.
-// SafeDI generates its public `init()`, so you do not write one yourself.
+// `NotesApp` is the root of the dependency graph. SafeDI generates its public `init()`.
 @Instantiable(isRoot: true) @main
 public struct NotesApp: App, Instantiable {
+    public init(
+        userService: UserService,
+        stringStorage: StringStorage,
+        nameEntryViewBuilder: Instantiator<NameEntryView>,
+        loggedInViewBuilder: Instantiator<LoggedInView>
+    ) { /* ... */ }
+
     public var body: some Scene {
         WindowGroup {
             if let user = userService.user {
@@ -25,6 +31,7 @@ public struct NotesApp: App, Instantiable {
     }
 
     @ObservedObject @Instantiated private var userService: UserService
+    @Instantiated private let stringStorage: StringStorage
     @Instantiated private let nameEntryViewBuilder: Instantiator<NameEntryView>
     @Instantiated private let loggedInViewBuilder: Instantiator<LoggedInView>
 }


### PR DESCRIPTION
## Summary
- add the required public initializers to the README and top-level DocC starter examples
- keep the overview focused on the root and first child instead of expanding into deeper dependency definitions
- simplify the initializer bodies so the examples stay focused on dependency shape rather than implementation detail

## Why
- the starter examples should match SafeDI's actual requirements for `@Instantiable` types
- newcomers should be able to see which initializers are required without extra downstream detail competing for attention

## Validation
- docs-only change; not run
