### PR TITLE
BCR: automate publishing SafeDI to the Bazel Central Registry

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,1 @@
+# Empty — all BCR publish config lives in presubmit.yml / metadata.template.json / source.template.json.

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+  "homepage": "https://github.com/dfed/SafeDI",
+  "maintainers": [
+    {
+      "name": "Dan Federman",
+      "email": "dan@portola.ai",
+      "github": "dfed"
+    }
+  ],
+  "repository": [
+    "github:dfed/SafeDI"
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,28 @@
+matrix:
+  platform: ["macos"]
+  bazel: ["9.x"]
+
+tasks:
+  verify_safedi_build:
+    name: "Build SafeDI targets (${{ platform }}, Bazel ${{ bazel }})"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@safedi//Sources/SafeDI:SafeDI"
+      - "@safedi//Sources/SafeDICore:SafeDICore"
+      - "@safedi//Sources/SafeDIMacros:SafeDIMacros"
+      - "@safedi//Sources/SafeDITool:SafeDITool"
+
+bcr_test_module:
+  module_path: "Examples/ExampleBazelIntegration"
+  matrix:
+    platform: ["macos"]
+    bazel: ["9.x"]
+  tasks:
+    build_example:
+      name: "Build downstream example (${{ platform }}, Bazel ${{ bazel }})"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "//Subproject:Subproject"
+        - "//ExampleBazelIntegration:ExampleBazelIntegration"

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+}

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{VERSION}.tar.gz"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
         # an unquoted inline `{` trips the YAML parser.
         run: |
           grep -A 2 'var safeDIVersion: String {' Plugins/Shared.swift | grep -q '"99.99.99-test"'
+      - name: Verify MODULE.bazel version was updated
+        # Scope to the top-level module() block so bazel_dep lines that
+        # also carry `version = "X"` can't false-positive.
+        run: |
+          awk '/^module\(/,/^\)/' MODULE.bazel | grep -q 'version = "99.99.99-test"'
 
   xcodebuild:
     name: Build with xcodebuild on Xcode 26

--- a/.github/workflows/publish-to-bcr.yml
+++ b/.github/workflows/publish-to-bcr.yml
@@ -1,0 +1,34 @@
+name: Publish to BCR
+
+# Fires on every GitHub release (including pre-releases — BCR accepts
+# beta versions; consumers can pin whatever they want via bazel_dep).
+# The publish workflow that creates the release commits a version-
+# stamped MODULE.bazel ahead of tagging, so the tag's source archive
+# has the right `module(version = "X.Y.Z")` for BCR to ingest.
+on:
+  release:
+    types:
+      - published
+
+  # Manual retry escape hatch if the release-triggered run needs to be
+  # replayed (e.g. after fixing a template bug).
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag of an already-published release to mirror to BCR"
+        type: string
+        required: true
+
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0
+    with:
+      tag_name: ${{ github.event.release.tag_name || inputs.tag_name }}
+      registry_fork: dfed/bazel-central-registry
+      attest: true
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_PAT }}

--- a/.github/workflows/publish-to-bcr.yml
+++ b/.github/workflows/publish-to-bcr.yml
@@ -25,10 +25,12 @@ jobs:
     with:
       tag_name: ${{ github.event.release.tag_name || inputs.tag_name }}
       registry_fork: dfed/bazel-central-registry
-      attest: true
+      # Our release is produced by .github/workflows/publish.yml, not
+      # bazel-contrib/.github's release_ruleset — so the attestations
+      # publish-to-bcr wants to verify don't exist. Leave off until a
+      # release-workflow migration makes them available.
+      attest: false
     permissions:
       contents: write
-      id-token: write
-      attestations: write
     secrets:
       publish_token: ${{ secrets.BCR_PUBLISH_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -209,6 +209,10 @@ jobs:
         run: |
           echo "=== Package.swift changes ==="
           git diff Package.swift
+          echo "=== Plugins/Shared.swift changes ==="
+          git diff Plugins/Shared.swift
+          echo "=== MODULE.bazel changes ==="
+          git diff MODULE.bazel
           echo "=== Checksum: ${{ steps.checksum.outputs.checksum }} ==="
 
       - name: Upload artifact bundle
@@ -221,7 +225,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Package.swift Plugins/Shared.swift
+          git add Package.swift Plugins/Shared.swift MODULE.bazel
           git commit -m "Release ${{ inputs.version }}"
 
       - name: Upload release commit patch (dry run)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -251,6 +251,22 @@ jobs:
           git tag "${{ inputs.version }}"
           git push origin "${{ github.ref_name }}" --tags
 
+      # Produce a source tarball for the BCR entry. `git archive` from
+      # the just-created tag gives a reproducible archive whose contents
+      # are rooted at `SafeDI-<version>/` — matching `strip_prefix` in
+      # `.bcr/source.template.json`. We upload this as a release asset
+      # so BCR can reference a stable `releases/download/...` URL
+      # instead of GitHub's auto-generated `archive/...` URL (which
+      # BCR presubmit flags as unstable).
+      - name: Create source tarball
+        if: ${{ !inputs.dry-run }}
+        run: |
+          git archive \
+            --format=tar.gz \
+            --prefix="SafeDI-${{ inputs.version }}/" \
+            -o "SafeDI-${{ inputs.version }}.tar.gz" \
+            "${{ inputs.version }}"
+
       - name: Create GitHub Release
         if: ${{ !inputs.dry-run }}
         env:
@@ -264,4 +280,5 @@ jobs:
             SafeDITool-macos-arm64 \
             SafeDITool-macos-x86_64 \
             SafeDITool-linux-x86_64 \
-            SafeDITool-linux-arm64
+            SafeDITool-linux-arm64 \
+            "SafeDI-${{ inputs.version }}.tar.gz"

--- a/Scripts/update-version.sh
+++ b/Scripts/update-version.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Updates the artifact bundle URL and checksum in Package.swift, and
-# the InstallSafeDITool plugin's hardcoded SafeDI version in
-# Plugins/Shared.swift. Used by the publish workflow after building the
-# artifact bundle.
+# Updates the artifact bundle URL and checksum in Package.swift, the
+# InstallSafeDITool plugin's hardcoded SafeDI version in
+# Plugins/Shared.swift, and the Bazel module version in MODULE.bazel.
+# Used by the publish workflow after building the artifact bundle.
 #
 # Usage: ./Scripts/update-version.sh <version> <checksum>
 # Example: ./Scripts/update-version.sh 2.0.0 abc123def456
@@ -37,4 +37,11 @@ echo "  Package.swift: URL and checksum updated"
 sed -i '' -E "/var safeDIVersion: String \{/,/\}/ s|\"[^\"]+\"|\"${VERSION}\"|" Plugins/Shared.swift
 
 echo "  Plugins/Shared.swift: safeDIVersion updated"
+
+# Update the Bazel module version. Scope the replacement to the
+# `module(…)` block so the top-level version line is the only match
+# (bazel_dep's `version = "X"` lines elsewhere in the file stay put).
+sed -i '' -E "/^module\(/,/^\)/ s|version = \"[^\"]*\"|version = \"${VERSION}\"|" MODULE.bazel
+
+echo "  MODULE.bazel: module version updated"
 echo "Done."


### PR DESCRIPTION
## Summary

Ties SafeDI's release flow into the Bazel Central Registry via `bazel-contrib/publish-to-bcr`. Every GitHub release (beta or stable) now files a PR to BCR adding a new version entry.

## What's in it

### `.bcr/` templates

- `metadata.template.json` — module metadata (homepage, maintainer, repo).
- `source.template.json` — points at a release-asset source tarball (`releases/download/{TAG}/{REPO}-{VERSION}.tar.gz`). BCR flags GitHub's auto-generated `archive/...` URLs as unstable, so we upload a reproducible tarball ourselves.
- `presubmit.yml` — two validation stages:
  - `verify_safedi_build` — builds the four SafeDI targets (`@safedi//Sources/{SafeDI,SafeDICore,SafeDIMacros,SafeDITool}`).
  - `bcr_test_module` — points BCR at `Examples/ExampleBazelIntegration` for a downstream smoke test. The example's `local_path_override` is ignored when not root, so BCR resolves `safedi` from the registry and proves the consumer path works.
- `config.yml` — intentionally empty.

### `.github/workflows/publish-to-bcr.yml`

- Triggers on `release.published` (every release, including betas) plus a `workflow_dispatch` retry hatch.
- Delegates to `bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0`.
- `registry_fork: dfed/bazel-central-registry`, auth via `BCR_PUBLISH_PAT` classic PAT.
- `attest: false` because our release is produced by the custom `publish.yml`, not bazel-contrib's `release_ruleset` — there are no upstream source-artifact attestations to chain.

### Source tarball + version stamping

- `.github/workflows/publish.yml` — produces `SafeDI-<version>.tar.gz` via `git archive --prefix=SafeDI-<version>/` from the just-created tag and uploads it as a release asset. Stable URL for BCR's `releases/download/...` reference.
- `Scripts/update-version.sh` — now also stamps `MODULE.bazel`'s top-level `module(version = "…")`. Scoped to the `module(…)` block via sed's address-range so `bazel_dep` version lines elsewhere stay put.
- `.github/workflows/publish.yml` — adds `MODULE.bazel` to the commit step and shows its diff.
- `.github/workflows/ci.yml` — `update-version-check` job verifies the stamping end-to-end via the matching awk-range idiom.

## Release flow end-to-end

1. Operator runs the existing `Publish` workflow with a version.
2. Build jobs produce SafeDITool binaries → `assemble-and-publish` bundles + checksums + stamps `Package.swift` / `Plugins/Shared.swift` / `MODULE.bazel` + commits + tags + creates the GitHub release with the source tarball + tool binaries attached.
3. `release.published` event fires `publish-to-bcr.yml` → reusable workflow reads `.bcr/`, generates the entry, pushes to `dfed/bazel-central-registry`, opens a PR upstream.
4. BCR presubmit validates + maintainers merge → downstream Bazel users can `bazel_dep(name = "safedi", version = "X")`.

## Not in it (blocked on first BCR merge)

- README / Manual section for Bazel consumption — writing "install via `bazel_dep(name = "safedi", ...)`" is premature until the BCR entry actually exists. Add in a follow-up PR once the first submission lands.

## Test plan

- [x] `./Scripts/update-version.sh 99.99.99-test abc123…` stamps all three files correctly, verified locally.
- [x] `update-version-check` CI step catches the `MODULE.bazel` stamp via `awk '/^module\(/,/^\)/' ... | grep -q ...`.
- [x] `git archive --prefix=SafeDI-test/ -o /tmp/test.tar.gz HEAD` produces the right layout (verified locally).
- [ ] First publish-to-bcr run on next release.
- [ ] BCR presubmit passes (validated by BCR maintainers when reviewing our first submission PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)