### PR TITLE
Docs: flag additionalDirectoriesToInclude as SPM-Xcode only

### DIFF
--- a/Documentation/Manual.md
+++ b/Documentation/Manual.md
@@ -42,7 +42,7 @@ import SafeDI
 
 The `additionalDirectoriesToInclude` parameter specifies folders outside of your module that SafeDI will scan for Swift source files. Paths must be relative to the executing directory (the directory containing the `.xcodeproj` for Xcode integrations). Use this parameter to specify the paths to dependent modules’ source directories, since Xcode project plugins cannot discover these automatically. You can see [an example of this configuration](../Examples/ExampleMultiProjectIntegration/ExampleMultiProjectIntegration/SafeDIConfiguration.swift) in the [ExampleMultiProjectIntegration](../Examples/ExampleMultiProjectIntegration) project.
 
-> **Note:** `additionalDirectoriesToInclude` is only honored by the SPM build-tool plugin (i.e. `swift build` or Xcode building an SPM package). The Bazel and Tuist integrations enumerate every input up front (Bazel via declared rule inputs; Tuist via the build phase's `inputPaths`), so files reached only through `additionalDirectoriesToInclude` won't be visible to SafeDITool at build time and won't trigger incremental rebuilds. Under those integrations, list every Swift source you want SafeDI to see directly via the build target.
+> **Note:** `additionalDirectoriesToInclude` is only honored by the SPM build-tool plugin. The Bazel and Tuist integrations enumerate every input up front (Bazel via declared rule inputs; Tuist via the build phase's `inputPaths`), so files reached only through `additionalDirectoriesToInclude` won't be visible to SafeDITool at build time and won't trigger incremental rebuilds. Under those integrations, list every Swift source you want SafeDI to see directly via the build target.
 
 ##### Installing the prebuilt SafeDITool binary
 
@@ -441,7 +441,7 @@ public struct FeedView: Instantiable {
 **Parameters:**
 
 - `additionalImportedModules`: Module names to import in the generated dependency tree, in addition to the import statements found in files that declare `@Instantiable` types. Default: `[]`.
-- `additionalDirectoriesToInclude`: Directories containing Swift files to include, relative to the executing directory. Only honored by the SPM build-tool plugin (i.e. `swift build` or Xcode building an SPM package). The Bazel and Tuist integrations enumerate inputs up front and ignore this parameter — list every Swift source via the build target itself instead. Default: `[]`.
+- `additionalDirectoriesToInclude`: Directories containing Swift files to include, relative to the executing directory. Only honored by the SPM build-tool plugin. The Bazel and Tuist integrations enumerate inputs up front and ignore this parameter — list every Swift source via the build target itself instead. Default: `[]`.
 - `additionalMocksToGenerate`: Type names from dependent modules to generate `mock()` methods for in this module. The types must be `@Instantiable` in their home module. See [Cross-module mock generation](#cross-module-mock-generation). Default: `[]`.
 - `mockConditionalCompilation`: The conditional compilation flag to wrap generated mock code in (e.g. `"DEBUG"`). Set to `nil` to generate mocks without conditional compilation. Default: `"DEBUG"`.
 

--- a/Documentation/Manual.md
+++ b/Documentation/Manual.md
@@ -42,6 +42,8 @@ import SafeDI
 
 The `additionalDirectoriesToInclude` parameter specifies folders outside of your module that SafeDI will scan for Swift source files. Paths must be relative to the executing directory (the directory containing the `.xcodeproj` for Xcode integrations). Use this parameter to specify the paths to dependent modules’ source directories, since Xcode project plugins cannot discover these automatically. You can see [an example of this configuration](../Examples/ExampleMultiProjectIntegration/ExampleMultiProjectIntegration/SafeDIConfiguration.swift) in the [ExampleMultiProjectIntegration](../Examples/ExampleMultiProjectIntegration) project.
 
+> **Note:** `additionalDirectoriesToInclude` is only honored by the SPM build-tool plugin running inside an Xcode project. The Bazel and Tuist integrations enumerate every input up front (Bazel via declared rule inputs; Tuist via the build phase's `inputPaths`), so files reached only through `additionalDirectoriesToInclude` won't be visible to SafeDITool at build time and won't trigger incremental rebuilds. Under those integrations, list every Swift source you want SafeDI to see directly via the build target.
+
 ##### Installing the prebuilt SafeDITool binary
 
 If you see a build warning that starts with **"SafeDI's build-tool plugin is falling back to a regex-based output scanner..."** — installing the prebuilt tool fixes it.
@@ -439,7 +441,7 @@ public struct FeedView: Instantiable {
 **Parameters:**
 
 - `additionalImportedModules`: Module names to import in the generated dependency tree, in addition to the import statements found in files that declare `@Instantiable` types. Default: `[]`.
-- `additionalDirectoriesToInclude`: Directories containing Swift files to include, relative to the executing directory. This parameter only applies to SafeDI repos that utilize the SPM plugin via an Xcode project. Default: `[]`.
+- `additionalDirectoriesToInclude`: Directories containing Swift files to include, relative to the executing directory. Only honored by the SPM build-tool plugin in an Xcode project. The Bazel and Tuist integrations enumerate inputs up front and ignore this parameter — list every Swift source via the build target itself instead. Default: `[]`.
 - `additionalMocksToGenerate`: Type names from dependent modules to generate `mock()` methods for in this module. The types must be `@Instantiable` in their home module. See [Cross-module mock generation](#cross-module-mock-generation). Default: `[]`.
 - `mockConditionalCompilation`: The conditional compilation flag to wrap generated mock code in (e.g. `"DEBUG"`). Set to `nil` to generate mocks without conditional compilation. Default: `"DEBUG"`.
 

--- a/Documentation/Manual.md
+++ b/Documentation/Manual.md
@@ -42,7 +42,7 @@ import SafeDI
 
 The `additionalDirectoriesToInclude` parameter specifies folders outside of your module that SafeDI will scan for Swift source files. Paths must be relative to the executing directory (the directory containing the `.xcodeproj` for Xcode integrations). Use this parameter to specify the paths to dependent modules’ source directories, since Xcode project plugins cannot discover these automatically. You can see [an example of this configuration](../Examples/ExampleMultiProjectIntegration/ExampleMultiProjectIntegration/SafeDIConfiguration.swift) in the [ExampleMultiProjectIntegration](../Examples/ExampleMultiProjectIntegration) project.
 
-> **Note:** `additionalDirectoriesToInclude` is only honored by the SPM build-tool plugin running inside an Xcode project. The Bazel and Tuist integrations enumerate every input up front (Bazel via declared rule inputs; Tuist via the build phase's `inputPaths`), so files reached only through `additionalDirectoriesToInclude` won't be visible to SafeDITool at build time and won't trigger incremental rebuilds. Under those integrations, list every Swift source you want SafeDI to see directly via the build target.
+> **Note:** `additionalDirectoriesToInclude` is only honored by the SPM build-tool plugin (i.e. `swift build` or Xcode building an SPM package). The Bazel and Tuist integrations enumerate every input up front (Bazel via declared rule inputs; Tuist via the build phase's `inputPaths`), so files reached only through `additionalDirectoriesToInclude` won't be visible to SafeDITool at build time and won't trigger incremental rebuilds. Under those integrations, list every Swift source you want SafeDI to see directly via the build target.
 
 ##### Installing the prebuilt SafeDITool binary
 
@@ -441,7 +441,7 @@ public struct FeedView: Instantiable {
 **Parameters:**
 
 - `additionalImportedModules`: Module names to import in the generated dependency tree, in addition to the import statements found in files that declare `@Instantiable` types. Default: `[]`.
-- `additionalDirectoriesToInclude`: Directories containing Swift files to include, relative to the executing directory. Only honored by the SPM build-tool plugin in an Xcode project. The Bazel and Tuist integrations enumerate inputs up front and ignore this parameter — list every Swift source via the build target itself instead. Default: `[]`.
+- `additionalDirectoriesToInclude`: Directories containing Swift files to include, relative to the executing directory. Only honored by the SPM build-tool plugin (i.e. `swift build` or Xcode building an SPM package). The Bazel and Tuist integrations enumerate inputs up front and ignore this parameter — list every Swift source via the build target itself instead. Default: `[]`.
 - `additionalMocksToGenerate`: Type names from dependent modules to generate `mock()` methods for in this module. The types must be `@Instantiable` in their home module. See [Cross-module mock generation](#cross-module-mock-generation). Default: `[]`.
 - `mockConditionalCompilation`: The conditional compilation flag to wrap generated mock code in (e.g. `"DEBUG"`). Set to `nil` to generate mocks without conditional compilation. Default: `"DEBUG"`.
 

--- a/Sources/SafeDI/Decorators/SafeDIConfiguration.swift
+++ b/Sources/SafeDI/Decorators/SafeDIConfiguration.swift
@@ -29,7 +29,7 @@
 ///
 /// - Parameters:
 ///   - additionalImportedModules: Module names to import in the generated dependency tree, in addition to the import statements found in files that declare `@Instantiable` types.
-///   - additionalDirectoriesToInclude: Directories containing Swift files to include, relative to the executing directory. This property only applies to SafeDI repos that utilize the SPM plugin via an Xcode project.
+///   - additionalDirectoriesToInclude: Directories containing Swift files to include, relative to the executing directory. Only supported when SafeDI runs via the SPM build-tool plugin in an Xcode project. The Bazel and Tuist integrations enumerate inputs up front and therefore cannot honor this parameter — list every Swift source via the build target itself instead.
 ///   - additionalMocksToGenerate: Type names from dependent modules to generate `mock()` methods for in this module. The types must be decorated with `@Instantiable` in their home module. See the "Cross-module mock generation" section of the manual.
 ///   - mockConditionalCompilation: The conditional compilation flag to wrap generated mock code in (e.g. `"DEBUG"`). Set to `nil` to generate mocks without conditional compilation.
 ///

--- a/Sources/SafeDI/Decorators/SafeDIConfiguration.swift
+++ b/Sources/SafeDI/Decorators/SafeDIConfiguration.swift
@@ -29,7 +29,7 @@
 ///
 /// - Parameters:
 ///   - additionalImportedModules: Module names to import in the generated dependency tree, in addition to the import statements found in files that declare `@Instantiable` types.
-///   - additionalDirectoriesToInclude: Directories containing Swift files to include, relative to the executing directory. Only supported when SafeDI runs via the SPM build-tool plugin in an Xcode project. The Bazel and Tuist integrations enumerate inputs up front and therefore cannot honor this parameter — list every Swift source via the build target itself instead.
+///   - additionalDirectoriesToInclude: Directories containing Swift files to include, relative to the executing directory. Only honored by the SPM build-tool plugin (i.e. `swift build` or Xcode building an SPM package). The Bazel and Tuist integrations enumerate inputs up front and therefore ignore this parameter — list every Swift source via the build target itself instead.
 ///   - additionalMocksToGenerate: Type names from dependent modules to generate `mock()` methods for in this module. The types must be decorated with `@Instantiable` in their home module. See the "Cross-module mock generation" section of the manual.
 ///   - mockConditionalCompilation: The conditional compilation flag to wrap generated mock code in (e.g. `"DEBUG"`). Set to `nil` to generate mocks without conditional compilation.
 ///

--- a/Sources/SafeDI/Decorators/SafeDIConfiguration.swift
+++ b/Sources/SafeDI/Decorators/SafeDIConfiguration.swift
@@ -29,7 +29,7 @@
 ///
 /// - Parameters:
 ///   - additionalImportedModules: Module names to import in the generated dependency tree, in addition to the import statements found in files that declare `@Instantiable` types.
-///   - additionalDirectoriesToInclude: Directories containing Swift files to include, relative to the executing directory. Only honored by the SPM build-tool plugin (i.e. `swift build` or Xcode building an SPM package). The Bazel and Tuist integrations enumerate inputs up front and therefore ignore this parameter — list every Swift source via the build target itself instead.
+///   - additionalDirectoriesToInclude: Directories containing Swift files to include, relative to the executing directory. Only honored by the SPM build-tool plugin. The Bazel and Tuist integrations enumerate inputs up front and therefore ignore this parameter — list every Swift source via the build target itself instead.
 ///   - additionalMocksToGenerate: Type names from dependent modules to generate `mock()` methods for in this module. The types must be decorated with `@Instantiable` in their home module. See the "Cross-module mock generation" section of the manual.
 ///   - mockConditionalCompilation: The conditional compilation flag to wrap generated mock code in (e.g. `"DEBUG"`). Set to `nil` to generate mocks without conditional compilation.
 ///


### PR DESCRIPTION
## Summary

Adds a callout to `#SafeDIConfiguration`'s docs noting that `additionalDirectoriesToInclude` is incompatible with the Bazel and Tuist integrations.

## Why

The flag walks directories at SafeDITool runtime. The SPM build-tool plugin under Xcode allows that, but Bazel and Tuist enumerate every input up front (Bazel via declared rule inputs; Tuist via the build phase's `inputPaths`). Files reached only through `additionalDirectoriesToInclude` end up invisible at build time *and* don't trigger incremental rebuilds.

The existing language ("only applies to SafeDI repos that utilize the SPM plugin via an Xcode project") was already a negative claim about Bazel/Tuist by implication, but readers won't reliably make that leap. Calling out both integrations by name makes the incompatibility actionable.

## What changes

- `Sources/SafeDI/Decorators/SafeDIConfiguration.swift` — parameter doc.
- `Documentation/Manual.md` — `additionalDirectoriesToInclude` prose gets a `> Note` callout.
- `Documentation/Manual.md` — `#SafeDIConfiguration` parameter list updated to match.

## Test plan

- [x] `./CLI/lint.sh` clean.
- [x] DocC source still builds (no syntax change to the macro doc comment, only prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)