### PR TITLE
.bcr/presubmit.yml: target macos_arm64

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["macos"]
+  platform: ["macos_arm64"]
   bazel: ["9.x"]
 
 tasks:

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -16,7 +16,7 @@ tasks:
 bcr_test_module:
   module_path: "Examples/ExampleBazelIntegration"
   matrix:
-    platform: ["macos"]
+    platform: ["macos_arm64"]
     bazel: ["9.x"]
   tasks:
     build_example:


### PR DESCRIPTION
Per @meteorcloudy's review on [bazelbuild/bazel-central-registry#8683](https://github.com/bazelbuild/bazel-central-registry/pull/8683):

> Use `macos_arm64`, macos still uses intel macs.

Switches the matrix platform on both `verify_safedi_build` and `bcr_test_module` from `macos` to `macos_arm64`, so future BCR submissions get this right by default. The matching fix was pushed directly to `dfed/bazel-central-registry`'s `safedi-2.0.0-rc-1` fork branch so the current submission can be re-validated without cutting a new release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)