### PR TITLE
Lower swift-tools-version to 6.2 for BCR compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,7 @@ jobs:
 
   xcodebuild:
     name: Build with xcodebuild on Xcode 26.0
-    # Pinned to Xcode 26.0 (Swift 6.2) — the lowest Swift toolchain
-    # we support, matching what BCR's macos_arm64 runners ship.
-    # Verifies SafeDI's Package.swift parses + compiles on the
-    # baseline Swift version. Examples + the publish workflow stay
-    # on the latest Xcode.
+    # Pinned to Xcode 26.0 — matches BCR's macos_arm64 runners.
     runs-on: macos-26
     strategy:
       matrix:
@@ -99,8 +95,16 @@ jobs:
         with:
           command: swift package generate-documentation --target SafeDI --warnings-as-errors
 
+  # Example CI jobs below pick their Xcode version based on whether
+  # the example uses package traits: Xcode 26.4 was the first Xcode
+  # to support package traits, so any example whose Package.swift /
+  # `.xcodeproj` declares them needs 26.4. Examples that only consume
+  # SafeDI via its default trait (no explicit `traits:` syntax) run
+  # on Xcode 26.0 — same baseline as the SafeDI-core jobs above.
+
   spm-package-integration:
-    name: Build Package Integration on Xcode 26
+    name: Build Package Integration on Xcode 26.4
+    # Uses `.package(traits: ["sourceBuild"])`.
     runs-on: macos-26
     permissions:
       contents: read
@@ -123,7 +127,8 @@ jobs:
         run: pushd "Examples/Example Package Integration"; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExamplePackageIntegration -destination "generic/platform=iOS"; popd
 
   spm-project-integration:
-    name: Build Project Integration on Xcode 26
+    name: Build Project Integration on Xcode 26.4
+    # Project file declares package traits.
     runs-on: macos-26
     permissions:
       contents: read
@@ -143,7 +148,8 @@ jobs:
         run: pushd Examples/ExampleProjectIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExampleProjectIntegration; popd
 
   spm-multi-project-integration:
-    name: Build Multi Project Integration on Xcode 26
+    name: Build Multi Project Integration on Xcode 26.4
+    # Project file declares package traits.
     runs-on: macos-26
     permissions:
       contents: read
@@ -163,7 +169,8 @@ jobs:
         run: pushd Examples/ExampleMultiProjectIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExampleMultiProjectIntegration; popd
 
   spm-tuist-integration:
-    name: Build Tuist Integration on Xcode 26
+    name: Build Tuist Integration on Xcode 26.0
+    # Tuist example doesn't declare package traits.
     runs-on: macos-26
     permissions:
       contents: read
@@ -175,7 +182,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app/Contents/Developer
       - name: Install Tuist via mise
         # Keep the pinned Tuist version here in sync with the README.
         run: |
@@ -193,9 +200,7 @@ jobs:
 
   spm:
     name: Build and Test on Xcode 26.0
-    # Pinned to Xcode 26.0 (Swift 6.2) — see the `xcodebuild` job
-    # comment above for rationale. Coverage on the latest toolchain
-    # is provided by the Linux job (Swift 6.3 docker).
+    # Pinned to Xcode 26.0 — matches BCR's macos_arm64 runners.
     runs-on: macos-26
     permissions:
       contents: read
@@ -226,7 +231,7 @@ jobs:
   linux:
     name: Build and Test on Linux
     runs-on: ubuntu-latest
-    container: swift:6.3
+    container: swift:6.2
     permissions:
       contents: read
     steps:
@@ -255,9 +260,7 @@ jobs:
 
   bazel:
     name: Bazel Build on Xcode 26.0
-    # Pinned to Xcode 26.0 (Swift 6.2) to mirror BCR's macos_arm64
-    # runners — that's the toolchain SafeDI's BCR submission has to
-    # build under, so our local Bazel CI should match.
+    # Pinned to Xcode 26.0 — matches BCR's macos_arm64 runners.
     runs-on: macos-26
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,14 @@ jobs:
         uses: actions/checkout@v6
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_26.0.app/Contents/Developer
+      - name: Download iOS Platform
+        # macos-26 runners only ship the iOS SDK pinned to the
+        # default Xcode (26.4); switching to 26.0 means we need to
+        # download iOS 26.0 explicitly before xcodebuild can target
+        # `generic/platform=iOS`.
+        run: |
+          sudo xcodebuild -runFirstLaunch
+          sudo xcodebuild -downloadPlatform iOS
       - name: Resolve Package Dependencies
         uses: ./.github/actions/retry
         with:
@@ -233,7 +241,10 @@ jobs:
   linux:
     name: Build and Test on Linux
     runs-on: ubuntu-latest
-    container: swift:6.2
+    # `-jammy` (Ubuntu 22.04) is more stable than the default
+    # `noble` tag for apt — the curl install we need for the
+    # codecov uploader has hit transient noble-mirror timeouts.
+    container: swift:6.2-jammy
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,12 @@ jobs:
         # macos-26 runners only ship the iOS SDK pinned to the
         # default Xcode (26.4); switching to 26.0 means we need to
         # download iOS 26.0 explicitly before xcodebuild can target
-        # `generic/platform=iOS`.
+        # `generic/platform=iOS`. The `simctl list` warms up the
+        # simulator service — without it `-downloadPlatform` flakes
+        # with "Unable to connect to simulator".
         run: |
           sudo xcodebuild -runFirstLaunch
+          sudo xcrun simctl list
           sudo xcodebuild -downloadPlatform iOS
       - name: Resolve Package Dependencies
         uses: ./.github/actions/retry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,10 @@ jobs:
           os: linux
 
   bazel:
-    name: Bazel Build on macOS
+    name: Bazel Build on Xcode 26.0
+    # Pinned to Xcode 26.0 (Swift 6.2) to mirror BCR's macos_arm64
+    # runners — that's the toolchain SafeDI's BCR submission has to
+    # build under, so our local Bazel CI should match.
     runs-on: macos-26
     permissions:
       contents: read
@@ -262,7 +265,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app/Contents/Developer
       - name: Build Sources
         run: bazelisk build //Sources/...
       - name: Build Example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,8 +182,13 @@ jobs:
         run: pushd Examples/ExampleMultiProjectIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExampleMultiProjectIntegration; popd
 
   spm-tuist-integration:
-    name: Build Tuist Integration on Xcode 26.0
-    # Tuist example doesn't declare package traits.
+    name: Build Tuist Integration on Xcode 26.4
+    # Pinned to 26.4 (not 26.0) until the SafeDI dep in
+    # `Tuist/Package.swift` bumps to a release that ships
+    # `swift-tools-version: 6.2`. The current pin
+    # (`from: "2.0.0-beta-6"`) still declares 6.3, which Swift 6.2
+    # rejects when Tuist resolves the manifest. Move to 26.0 after
+    # the next SafeDI release.
     runs-on: macos-26
     permissions:
       contents: read
@@ -195,7 +200,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_26.0.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
       - name: Install Tuist via mise
         # Keep the pinned Tuist version here in sync with the README.
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
         run: pushd Examples/ExampleTuistIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -workspace ExampleTuistIntegration.xcworkspace -scheme ExampleTuistIntegration; popd
 
   spm:
-    name: Build and Test on Xcode 26.0
+    name: Build and Test on Xcode 26
     # Pinned to Xcode 26.0 — matches BCR's macos_arm64 runners.
     runs-on: macos-26
     permissions:
@@ -258,7 +258,7 @@ jobs:
           os: linux
 
   bazel:
-    name: Bazel Build on Xcode 26.0
+    name: Bazel Build on macOS
     # Pinned to Xcode 26.0 — matches BCR's macos_arm64 runners.
     runs-on: macos-26
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,16 +96,17 @@ jobs:
         with:
           command: swift package generate-documentation --target SafeDI --warnings-as-errors
 
-  # Example CI jobs below pick their Xcode version based on whether
-  # the example uses package traits: Xcode 26.4 was the first Xcode
-  # to support package traits, so any example whose Package.swift /
-  # `.xcodeproj` declares them needs 26.4. Examples that only consume
-  # SafeDI via its default trait (no explicit `traits:` syntax) run
-  # on Xcode 26.0 — same baseline as the SafeDI-core jobs above.
+  # Example CI jobs below pick their Xcode version based on where
+  # they declare package traits: Xcode 26.4 was the first Xcode to
+  # surface package traits in `.xcodeproj` (`traits = (…)` in the
+  # project file), so examples that declare traits there need 26.4.
+  # Examples that declare traits only in `Package.swift` via
+  # `.package(…, traits: …)` — or don't declare traits at all — run
+  # on Xcode 26.0 (same baseline as the SafeDI-core jobs above).
 
   spm-package-integration:
-    name: Build Package Integration on Xcode 26.4
-    # Uses `.package(traits: ["sourceBuild"])`.
+    name: Build Package Integration on Xcode 26.0
+    # Declares traits in Package.swift (not the project file).
     runs-on: macos-26
     permissions:
       contents: read
@@ -113,7 +114,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app/Contents/Developer
       - name: Resolve Package Dependencies
         uses: ./.github/actions/retry
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,6 @@ jobs:
 
   spm:
     name: Build and Test on Xcode 26
-    # Pinned to Xcode 26.0 — matches BCR's macos_arm64 runners.
     runs-on: macos-26
     permissions:
       contents: read
@@ -259,7 +258,9 @@ jobs:
 
   bazel:
     name: Bazel Build on macOS
-    # Pinned to Xcode 26.0 — matches BCR's macos_arm64 runners.
+    # Pinned to Xcode 26.0 — matches BCR's `macos_arm64` runner
+    # platform defined at
+    # https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazelci.py
     runs-on: macos-26
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,8 +259,7 @@ jobs:
   bazel:
     name: Bazel Build on macOS
     # Pinned to Xcode 26.0 — matches BCR's `macos_arm64` runner
-    # platform defined at
-    # https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazelci.py
+    # platform defined at https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazelci.py
     runs-on: macos-26
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,12 @@ jobs:
           awk '/^module\(/,/^\)/' MODULE.bazel | grep -q 'version = "99.99.99-test"'
 
   xcodebuild:
-    name: Build with xcodebuild on Xcode 26
+    name: Build with xcodebuild on Xcode 26.0
+    # Pinned to Xcode 26.0 (Swift 6.2) — the lowest Swift toolchain
+    # we support, matching what BCR's macos_arm64 runners ship.
+    # Verifies SafeDI's Package.swift parses + compiles on the
+    # baseline Swift version. Examples + the publish workflow stay
+    # on the latest Xcode.
     runs-on: macos-26
     strategy:
       matrix:
@@ -60,7 +65,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app/Contents/Developer
       - name: Download Platform
         if: matrix.platforms != 'platform=macOS'
         run: |
@@ -187,7 +192,10 @@ jobs:
         run: pushd Examples/ExampleTuistIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -workspace ExampleTuistIntegration.xcworkspace -scheme ExampleTuistIntegration; popd
 
   spm:
-    name: Build and Test on Xcode 26
+    name: Build and Test on Xcode 26.0
+    # Pinned to Xcode 26.0 (Swift 6.2) — see the `xcodebuild` job
+    # comment above for rationale. Coverage on the latest toolchain
+    # is provided by the Linux job (Swift 6.3 docker).
     runs-on: macos-26
     permissions:
       contents: read
@@ -195,7 +203,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app/Contents/Developer
       - name: Resolve Package Dependencies
         uses: ./.github/actions/retry
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
         run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination ${{ matrix.platforms }}
 
   docc:
-    name: Build DocC on Xcode 26
+    name: Build DocC on Xcode 26.0
+    # Pinned to Xcode 26.0 — matches BCR's macos_arm64 runners.
     runs-on: macos-26
     permissions:
       contents: read
@@ -85,7 +86,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app/Contents/Developer
       # `swift-docc-plugin`'s `--warnings-as-errors` scopes to a single
       # target, so swift-syntax's internal DocC noise stays out of our
       # strict build. That scoping isn't available via `xcodebuild

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,7 @@ jobs:
           awk '/^module\(/,/^\)/' MODULE.bazel | grep -q 'version = "99.99.99-test"'
 
   xcodebuild:
-    name: Build with xcodebuild on Xcode 26.0
-    # Pinned to Xcode 26.0 — matches BCR's macos_arm64 runners.
+    name: Build with xcodebuild on Xcode 26
     runs-on: macos-26
     strategy:
       matrix:
@@ -77,8 +76,7 @@ jobs:
         run: xcrun xcodebuild -skipMacroValidation -skipPackagePluginValidation build -scheme SafeDI-Package -destination ${{ matrix.platforms }}
 
   docc:
-    name: Build DocC on Xcode 26.0
-    # Pinned to Xcode 26.0 — matches BCR's macos_arm64 runners.
+    name: Build DocC on Xcode 26
     runs-on: macos-26
     permissions:
       contents: read
@@ -96,17 +94,13 @@ jobs:
         with:
           command: swift package generate-documentation --target SafeDI --warnings-as-errors
 
-  # Example CI jobs below pick their Xcode version based on where
-  # they declare package traits: Xcode 26.4 was the first Xcode to
-  # surface package traits in `.xcodeproj` (`traits = (…)` in the
-  # project file), so examples that declare traits there need 26.4.
-  # Examples that declare traits only in `Package.swift` via
-  # `.package(…, traits: …)` — or don't declare traits at all — run
-  # on Xcode 26.0 (same baseline as the SafeDI-core jobs above).
+  # Example jobs that declare package traits in their .xcodeproj
+  # (`traits = (…)`) need Xcode 26.4 — the first Xcode that
+  # surfaces traits in the project file. Other examples run on the
+  # same baseline as the SafeDI-core jobs above.
 
   spm-package-integration:
-    name: Build Package Integration on Xcode 26.0
-    # Declares traits in Package.swift (not the project file).
+    name: Build Package Integration on Xcode 26
     runs-on: macos-26
     permissions:
       contents: read
@@ -115,17 +109,6 @@ jobs:
         uses: actions/checkout@v6
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_26.0.app/Contents/Developer
-      - name: Download iOS Platform
-        # macos-26 runners only ship the iOS SDK pinned to the
-        # default Xcode (26.4); switching to 26.0 means we need to
-        # download iOS 26.0 explicitly before xcodebuild can target
-        # `generic/platform=iOS`. The `simctl list` warms up the
-        # simulator service — without it `-downloadPlatform` flakes
-        # with "Unable to connect to simulator".
-        run: |
-          sudo xcodebuild -runFirstLaunch
-          sudo xcrun simctl list
-          sudo xcodebuild -downloadPlatform iOS
       - name: Resolve Package Dependencies
         uses: ./.github/actions/retry
         with:
@@ -137,11 +120,11 @@ jobs:
       # path would make Xcode IDE builds fail while the swift build above
       # still passes.
       - name: Build Package Integration (xcodebuild)
-        run: pushd "Examples/Example Package Integration"; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExamplePackageIntegration -destination "generic/platform=iOS"; popd
+        run: pushd "Examples/Example Package Integration"; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExamplePackageIntegration -destination "platform=macOS"; popd
 
   spm-project-integration:
-    name: Build Project Integration on Xcode 26.4
-    # Project file declares package traits.
+    name: Build Project Integration on Xcode 26
+    # Pinned to 26.4 — project file declares package traits.
     runs-on: macos-26
     permissions:
       contents: read
@@ -161,8 +144,8 @@ jobs:
         run: pushd Examples/ExampleProjectIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExampleProjectIntegration; popd
 
   spm-multi-project-integration:
-    name: Build Multi Project Integration on Xcode 26.4
-    # Project file declares package traits.
+    name: Build Multi Project Integration on Xcode 26
+    # Pinned to 26.4 — project file declares package traits.
     runs-on: macos-26
     permissions:
       contents: read
@@ -182,13 +165,11 @@ jobs:
         run: pushd Examples/ExampleMultiProjectIntegration; xcrun xcodebuild build -skipPackagePluginValidation -skipMacroValidation -scheme ExampleMultiProjectIntegration; popd
 
   spm-tuist-integration:
-    name: Build Tuist Integration on Xcode 26.4
-    # Pinned to 26.4 (not 26.0) until the SafeDI dep in
+    name: Build Tuist Integration on Xcode 26
+    # Pinned to 26.4 (not 26.0) until the SafeDI dependency in
     # `Tuist/Package.swift` bumps to a release that ships
-    # `swift-tools-version: 6.2`. The current pin
-    # (`from: "2.0.0-beta-6"`) still declares 6.3, which Swift 6.2
-    # rejects when Tuist resolves the manifest. Move to 26.0 after
-    # the next SafeDI release.
+    # `swift-tools-version: 6.2`. The current pin still declares 6.3,
+    # which Swift 6.2 rejects when Tuist resolves the manifest.
     runs-on: macos-26
     permissions:
       contents: read
@@ -249,10 +230,7 @@ jobs:
   linux:
     name: Build and Test on Linux
     runs-on: ubuntu-latest
-    # `-jammy` (Ubuntu 22.04) is more stable than the default
-    # `noble` tag for apt — the curl install we need for the
-    # codecov uploader has hit transient noble-mirror timeouts.
-    container: swift:6.2-jammy
+    container: swift:6.2
     permissions:
       contents: read
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,13 @@ on:
         default: false
 
 jobs:
+  # Publish builds SafeDITool against the *latest* Swift toolchain,
+  # not the project's minimum. SafeDITool ships as a prebuilt that
+  # consumers run through the SafeDIGenerator plugin, so it has to
+  # handle source written for any Swift version downstream consumers
+  # are on. Building against the latest swift-syntax keeps the
+  # prebuilt tolerant of newer constructs; an older build would
+  # parse-fail on newer consumer code.
   build-macos:
     name: Build macOS
     runs-on: macos-26

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,12 +19,14 @@ on:
 
 jobs:
   # Publish builds SafeDITool against the *latest* Swift toolchain,
-  # not the project's minimum. SafeDITool ships as a prebuilt that
-  # consumers run through the SafeDIGenerator plugin, so it has to
-  # handle source written for any Swift version downstream consumers
-  # are on. Building against the latest swift-syntax keeps the
-  # prebuilt tolerant of newer constructs; an older build would
-  # parse-fail on newer consumer code.
+  # not the project's minimum (declared in Package.swift's
+  # `swift-tools-version` at the top of
+  # https://github.com/dfed/SafeDI/blob/main/Package.swift). SafeDITool
+  # ships as a prebuilt that consumers run through the SafeDIGenerator
+  # plugin, so it has to handle source written for any Swift version
+  # downstream consumers are on. Building against the latest
+  # swift-syntax keeps the prebuilt tolerant of newer constructs;
+  # an older build would parse-fail on newer consumer code.
   build-macos:
     name: Build macOS
     runs-on: macos-26

--- a/Documentation/Manual.md
+++ b/Documentation/Manual.md
@@ -781,7 +781,7 @@ UIKit applications’ natural root is the `UIApplicationDelegate`-conforming app
 
 ## Migrating from SafeDI 1.x to 2.x
 
-SafeDI 2.x requires Swift 6.3 or later and does not support CocoaPods. Projects using an earlier Swift version or CocoaPods should use SafeDI 1.x.
+SafeDI 2.x requires Swift 6.2 or later and does not support CocoaPods. Projects using an earlier Swift version or CocoaPods should use SafeDI 1.x.
 
 SafeDI 2.x also removes support for CSV-based configuration files (`.safedi/configuration/include.csv` and `.safedi/configuration/additionalImportedModules.csv`). Configuration is now done via the `#SafeDIConfiguration` macro.
 
@@ -794,14 +794,14 @@ swift package plugin safedi-v1-to-v2 --target <YourRootTarget>
 ```
 
 This plugin will:
-1. Verify your `swift-tools-version` is 6.3 or later
+1. Verify your `swift-tools-version` is 6.2 or later
 2. Create a `SafeDIConfiguration.swift` file in your target’s source directory
 3. Migrate any existing CSV configuration values into the new `#SafeDIConfiguration` macro
 4. Delete the obsolete CSV files
 
 ### Manual migration
 
-1. Update your `swift-tools-version` to 6.3 or later
+1. Update your `swift-tools-version` to 6.2 or later
 2. Update your SafeDI dependency to `from: "2.0.0"`
 3. If you have `.safedi/configuration/include.csv` or `.safedi/configuration/additionalImportedModules.csv`, add a `#SafeDIConfiguration` in your root module with the equivalent values and delete the CSV files
 4. If you don’t have CSV configuration files and do not need other SafeDI configuration options, no `#SafeDIConfiguration()` declaration is required

--- a/Examples/Example Package Integration/Package.swift
+++ b/Examples/Example Package Integration/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Examples/ExampleBazelIntegration/README.md
+++ b/Examples/ExampleBazelIntegration/README.md
@@ -10,12 +10,6 @@ system.
 [`rules_apple`](https://github.com/bazelbuild/rules_apple) macOS
 toolchain). The SafeDI rules themselves are platform-agnostic.
 
-**Toolchain:** Swift 6.2 or later (Xcode 26.0+). SafeDI's
-`Package.swift` declares `swift-tools-version: 6.2`, which is what
-the Bazel Central Registry's `macos_arm64` runners ship with;
-trying to consume SafeDI from a Bazel build that uses an older
-Swift toolchain will fail at the swift-syntax compile step.
-
 ## What it demonstrates
 
 - **Two `swift_library` targets** (`//Subproject:Subproject`,

--- a/Examples/ExampleBazelIntegration/README.md
+++ b/Examples/ExampleBazelIntegration/README.md
@@ -10,6 +10,12 @@ system.
 [`rules_apple`](https://github.com/bazelbuild/rules_apple) macOS
 toolchain). The SafeDI rules themselves are platform-agnostic.
 
+**Toolchain:** Swift 6.2 or later (Xcode 26.0+). SafeDI's
+`Package.swift` declares `swift-tools-version: 6.2`, which is what
+the Bazel Central Registry's `macos_arm64` runners ship with;
+trying to consume SafeDI from a Bazel build that uses an older
+Swift toolchain will fail at the swift-syntax compile step.
+
 ## What it demonstrates
 
 - **Two `swift_library` targets** (`//Subproject:Subproject`,

--- a/Examples/ExampleTuistIntegration/README.md
+++ b/Examples/ExampleTuistIntegration/README.md
@@ -54,10 +54,10 @@ recompiles it on the next `xcodebuild`, no `tuist generate` round-trip.
 
 2. In `Tuist/Package.swift`, depend on SafeDI so its runtime library and
    `SafeDIToolBinary` artifact bundle are resolved (the plugin requires
-   `SafeDITool >= 2.0.0-beta-6` for the `--combined-output` flag):
+   `SafeDITool >= 2.0.0-rc-1` for the `--combined-output` flag):
 
    ```swift
-   .package(url: "https://github.com/dfed/SafeDI.git", from: "2.0.0-beta-6"),
+   .package(url: "https://github.com/dfed/SafeDI.git", from: "2.0.0-rc-1"),
    ```
 
 3. In `Project.swift`, `import SafeDITuist` and call the helpers from each

--- a/Examples/ExampleTuistIntegration/README.md
+++ b/Examples/ExampleTuistIntegration/README.md
@@ -96,9 +96,9 @@ arbitrary input/output paths.
 
 | Tool | Notes |
 |------|-------|
-| macOS with Xcode 26.0+ | This example pins Swift 6.3 / Xcode 26.4 (matches the rest of SafeDI's example CI), but SafeDI itself supports Swift 6.2 / Xcode 26.0 minimum — bump the example down if you need to test against the baseline. |
+| macOS with Xcode 26.0 | Matches the rest of SafeDI's CI. |
 | [Tuist](https://tuist.dev) 4.x | Install via [mise](https://mise.jdx.dev). Tuist no longer publishes a Homebrew formula. |
-| Swift 6.3 toolchain | Ships with Xcode 26.4. SafeDI itself supports Swift 6.2+; this example tracks the latest. |
+| Swift 6.2 toolchain | Ships with Xcode 26.0 |
 
 ### Installing Tuist
 

--- a/Examples/ExampleTuistIntegration/README.md
+++ b/Examples/ExampleTuistIntegration/README.md
@@ -96,9 +96,9 @@ arbitrary input/output paths.
 
 | Tool | Notes |
 |------|-------|
-| macOS with Xcode 26.4 | Matches the rest of SafeDI's CI. |
+| macOS with Xcode 26.0+ | This example pins Swift 6.3 / Xcode 26.4 (matches the rest of SafeDI's example CI), but SafeDI itself supports Swift 6.2 / Xcode 26.0 minimum — bump the example down if you need to test against the baseline. |
 | [Tuist](https://tuist.dev) 4.x | Install via [mise](https://mise.jdx.dev). Tuist no longer publishes a Homebrew formula. |
-| Swift 6.3 toolchain | Ships with Xcode 26.4 |
+| Swift 6.3 toolchain | Ships with Xcode 26.4. SafeDI itself supports Swift 6.2+; this example tracks the latest. |
 
 ### Installing Tuist
 

--- a/Examples/ExampleTuistIntegration/README.md
+++ b/Examples/ExampleTuistIntegration/README.md
@@ -96,9 +96,9 @@ arbitrary input/output paths.
 
 | Tool | Notes |
 |------|-------|
-| macOS with Xcode 26.0 | Matches the rest of SafeDI's CI. |
+| macOS with Xcode 26.4 | Matches the rest of SafeDI's CI. |
 | [Tuist](https://tuist.dev) 4.x | Install via [mise](https://mise.jdx.dev). Tuist no longer publishes a Homebrew formula. |
-| Swift 6.2 toolchain | Ships with Xcode 26.0 |
+| Swift 6.3 toolchain | Ships with Xcode 26.4 |
 
 ### Installing Tuist
 

--- a/Examples/ExampleTuistIntegration/Tuist/Package.resolved
+++ b/Examples/ExampleTuistIntegration/Tuist/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "9a2ba39e37a37d1d62f1851c54a858c308e03a1cff41b420f5453a288eb6e38c",
+  "originHash" : "59e87ad67b40e34bea3a59195f023f3d07a79bca708fbceebf501ceecd435139",
   "pins" : [
     {
       "identity" : "safedi",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dfed/SafeDI.git",
       "state" : {
-        "revision" : "f9a1738fd4cfd882d94b9417f1461dafc91d4e78",
-        "version" : "2.0.0-beta-6"
+        "revision" : "9bfb656b3b4f7ef5a1e4b6869b3bec0f6e8cce11",
+        "version" : "2.0.0-rc-1"
       }
     },
     {

--- a/Examples/ExampleTuistIntegration/Tuist/Package.swift
+++ b/Examples/ExampleTuistIntegration/Tuist/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.2
 //
 // Consumed by `tuist install`, which invokes SPM to resolve this
 // manifest. Declaring SafeDI here gives Tuist's SPM integration a

--- a/Examples/ExampleTuistIntegration/Tuist/Package.swift
+++ b/Examples/ExampleTuistIntegration/Tuist/Package.swift
@@ -28,6 +28,6 @@ import PackageDescription
 let package = Package(
 	name: "ExampleTuistIntegration",
 	dependencies: [
-		.package(url: "https://github.com/dfed/SafeDI.git", from: "2.0.0-beta-6"),
+		.package(url: "https://github.com/dfed/SafeDI.git", from: "2.0.0-rc-1"),
 	],
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import CompilerPluginSupport
@@ -48,7 +48,7 @@ let package = Package(
 	dependencies: [
 		.package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
 		.package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.3.0"),
-		.package(url: "https://github.com/swiftlang/swift-syntax.git", "603.0.0"..<"605.0.0"),
+		.package(url: "https://github.com/swiftlang/swift-syntax.git", "602.0.0"..<"605.0.0"),
 	],
 	targets: [
 		// Macros

--- a/Plugins/MigrateSafeDIFromVersionOne/MigrateSafeDIFromVersionOne.swift
+++ b/Plugins/MigrateSafeDIFromVersionOne/MigrateSafeDIFromVersionOne.swift
@@ -52,8 +52,8 @@ struct MigrateSafeDIFromVersionOne: CommandPlugin {
 			Diagnostics.error("Could not parse swift-tools-version from Package.swift")
 			return
 		}
-		guard major > 6 || (major == 6 && minor >= 3) else {
-			Diagnostics.error("SafeDI 2.x requires swift-tools-version 6.3 or later. Found \(major).\(minor). Update your Package.swift before migrating.")
+		guard major > 6 || (major == 6 && minor >= 2) else {
+			Diagnostics.error("SafeDI 2.x requires swift-tools-version 6.2 or later. Found \(major).\(minor). Update your Package.swift before migrating.")
 			return
 		}
 


### PR DESCRIPTION
## Why

[BCR PR #8683](https://github.com/bazelbuild/bazel-central-registry/pull/8683) failed because BCR's `macos_arm64` runners ship Xcode 26.0 (Swift 6.2), but our `Package.swift` declared `swift-tools-version: 6.3`. SwiftPM rejects the manifest before `rules_swift_package_manager` can translate it. We don't use any 6.3-only features (the `traits:` field is 6.1+), so the floor can drop with no functional change.

## What's in it

### Source

- **`Package.swift`** — `swift-tools-version: 6.3` → `6.2`; `swift-syntax` range widened from `"603.0.0"..<"605.0.0"` to `"602.0.0"..<"605.0.0"` so SPM can resolve a 6.2-compatible swift-syntax on the older toolchain.
- **`MigrateSafeDIFromVersionOne` plugin** — version-floor check + error message → `6.2`.
- **`Documentation/Manual.md`** — three "requires Swift 6.3" mentions in the migration guide → `6.2`.
- **`Examples/Example Package Integration/Package.swift`** — `swift-tools-version: 6.3` → `6.2`.
- **`Examples/ExampleTuistIntegration/Tuist/Package.swift`** — `swift-tools-version: 6.3` → `6.2`; SafeDI dep bumped from `from: "2.0.0-beta-6"` → `from: "2.0.0-rc-1"`. README + `Package.resolved` updated to match.

### CI

- **All Swift-compile jobs that build SafeDI itself** — `xcodebuild` matrix, `docc`, `spm`, `bazel` — pinned to Xcode 26.0 (Swift 6.2). Validates the new floor against the actual BCR-relevant toolchain.
- **`spm-package-integration`** — Xcode 26.0. Switched the xcodebuild build's destination from `generic/platform=iOS` to `platform=macOS` to avoid needing the iOS SDK download on Xcode 26.0; the test still exercises the same plugin scanner code path.
- **`spm-tuist-integration`** — stays on Xcode 26.4 because the Tuist example's `Tuist/Package.swift` pulls in the released SafeDI (`from: "2.0.0-rc-1"`), which still declares `swift-tools-version: 6.3`. After this PR ships in `2.0.0-rc-2`, that pin (and this CI job) can move to 26.0.
- **`spm-project-integration` / `spm-multi-project-integration`** — stay on Xcode 26.4 because their `.xcodeproj` files declare `traits = (…)`, and Xcode 26.4 was the first Xcode to surface package traits in project files.
- **`linux`** — Docker container `swift:6.3` → `swift:6.2`. Default tag tracks the latest base.
- **`publish.yml`** stays on the latest Xcode (26.4 / Swift 6.3), with a comment explaining why: the prebuilt SafeDITool's bundled swift-syntax has to handle source written for any Swift version downstream consumers are on. Built-against-latest keeps the prebuilt tolerant of newer constructs; an older build would parse-fail on newer consumer code.

### Documentation

- **`Examples/ExampleBazelIntegration/README.md`** — no changes (the Bazel example doesn't pin a SafeDI version, so toolchain is whatever the consumer brings).
- **`Examples/ExampleTuistIntegration/README.md`** — SafeDI pin bumped to `2.0.0-rc-1` in the copy-paste snippet.
- **`Documentation/Manual.md`** — minimum-Swift mentions updated to 6.2 (in the migration guide).

## Test plan

- [x] `swift build --traits sourceBuild` — green locally.
- [x] `./CLI/lint.sh` — clean.
- [x] CI green on Xcode 26.0 (xcodebuild matrix + docc + spm test + bazel build + Package Integration).
- [x] CI green on Xcode 26.4 (Project Integration + Multi Project Integration + Tuist Integration + DocC).
- [x] CI green on `swift:6.2` Linux container.

## Follow-up after merge

1. Cut `2.0.0-rc-2` via the `Publish` workflow → fires fresh BCR PR with both `macos_arm64` and `swift-tools-version: 6.2` baked in (replaces [BCR #8683](https://github.com/bazelbuild/bazel-central-registry/pull/8683)).
2. Bump `Examples/ExampleTuistIntegration/Tuist/Package.swift` to `from: "2.0.0-rc-2"` and move `spm-tuist-integration` to Xcode 26.0 — completes the matrix.
3. Close [BCR PR #8683](https://github.com/bazelbuild/bazel-central-registry/pull/8683) once rc-2's submission is in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)