### PR TITLE
Tuist example: bump SafeDI to 2.0.0-rc-2 + move CI to Xcode 26.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,10 +166,6 @@ jobs:
 
   spm-tuist-integration:
     name: Build Tuist Integration on Xcode 26
-    # Pinned to 26.4 (not 26.0) until the SafeDI dependency in
-    # `Tuist/Package.swift` bumps to a release that ships
-    # `swift-tools-version: 6.2`. The current pin still declares 6.3,
-    # which Swift 6.2 rejects when Tuist resolves the manifest.
     runs-on: macos-26
     permissions:
       contents: read
@@ -181,7 +177,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v6
       - name: Select Xcode Version
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app/Contents/Developer
       - name: Install Tuist via mise
         # Keep the pinned Tuist version here in sync with the README.
         run: |

--- a/Examples/ExampleTuistIntegration/README.md
+++ b/Examples/ExampleTuistIntegration/README.md
@@ -54,10 +54,10 @@ recompiles it on the next `xcodebuild`, no `tuist generate` round-trip.
 
 2. In `Tuist/Package.swift`, depend on SafeDI so its runtime library and
    `SafeDIToolBinary` artifact bundle are resolved (the plugin requires
-   `SafeDITool >= 2.0.0-rc-1` for the `--combined-output` flag):
+   `SafeDITool >= 2.0.0-rc-2` for the `--combined-output` flag):
 
    ```swift
-   .package(url: "https://github.com/dfed/SafeDI.git", from: "2.0.0-rc-1"),
+   .package(url: "https://github.com/dfed/SafeDI.git", from: "2.0.0-rc-2"),
    ```
 
 3. In `Project.swift`, `import SafeDITuist` and call the helpers from each

--- a/Examples/ExampleTuistIntegration/Tuist/Package.resolved
+++ b/Examples/ExampleTuistIntegration/Tuist/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "59e87ad67b40e34bea3a59195f023f3d07a79bca708fbceebf501ceecd435139",
+  "originHash" : "4f0641dc90cce4a7f0aaeec52edc677efa38a02c151915e0818c006ca41bc297",
   "pins" : [
     {
       "identity" : "safedi",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dfed/SafeDI.git",
       "state" : {
-        "revision" : "9bfb656b3b4f7ef5a1e4b6869b3bec0f6e8cce11",
-        "version" : "2.0.0-rc-1"
+        "revision" : "b0ff42addf936d7a3455092b639c3c0a372210d7",
+        "version" : "2.0.0-rc-2"
       }
     },
     {

--- a/Examples/ExampleTuistIntegration/Tuist/Package.swift
+++ b/Examples/ExampleTuistIntegration/Tuist/Package.swift
@@ -28,6 +28,6 @@ import PackageDescription
 let package = Package(
 	name: "ExampleTuistIntegration",
 	dependencies: [
-		.package(url: "https://github.com/dfed/SafeDI.git", from: "2.0.0-rc-1"),
+		.package(url: "https://github.com/dfed/SafeDI.git", from: "2.0.0-rc-2"),
 	],
 )


### PR DESCRIPTION
Now that [`2.0.0-rc-2`](https://github.com/dfed/SafeDI/releases/tag/2.0.0-rc-2) is out with `swift-tools-version: 6.2`, the Tuist example's `Tuist/Package.swift` can resolve on Xcode 26.0 (Swift 6.2). Completes the matrix consolidation [#292](https://github.com/dfed/SafeDI/pull/292) deferred.

## Changes

- `Examples/ExampleTuistIntegration/Tuist/Package.swift` — SafeDI pin `from: "2.0.0-rc-1"` → `from: "2.0.0-rc-2"`.
- `Examples/ExampleTuistIntegration/Tuist/Package.resolved` — re-resolved against rc-2.
- `Examples/ExampleTuistIntegration/README.md` — copy-paste snippet + `>= rc-1` mention bumped to rc-2.
- `.github/workflows/ci.yml`:`spm-tuist-integration` switches to Xcode 26.0 and drops the comment explaining the 26.4 carve-out.

## Test plan

- [x] `swift package resolve` against the new pin — pulls rc-2 + the corresponding `SafeDITool.artifactbundle.zip`.
- [x] `./CLI/lint.sh` clean.
- [x] CI green on Xcode 26.0 (now including `spm-tuist-integration`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)