### PR TITLE
ci: retry bazel build on transient CDN flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,10 +265,13 @@ jobs:
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_26.0.app/Contents/Developer
       - name: Build Sources
-        run: bazelisk build //Sources/...
+        uses: ./.github/actions/retry
+        with:
+          command: bazelisk build //Sources/...
       - name: Build Example
-        working-directory: Examples/ExampleBazelIntegration
-        run: bazelisk build //Subproject:Subproject //ExampleBazelIntegration:ExampleBazelIntegration
+        uses: ./.github/actions/retry
+        with:
+          command: cd Examples/ExampleBazelIntegration && bazelisk build //Subproject:Subproject //ExampleBazelIntegration:ExampleBazelIntegration
 
   readme-validation:
     name: Check Markdown links

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,17 @@ jobs:
         uses: actions/checkout@v6
       - name: Select Xcode Version
         run: sudo xcode-select --switch /Applications/Xcode_26.0.app/Contents/Developer
+      # Wrapping `bazelisk build` in retry — not just dependency
+      # resolution, like the SPM jobs above — because Bazel resolves
+      # external repos lazily during the build itself. There's no
+      # equivalent to `swift package resolve` we could isolate; a
+      # transient HTTP failure (e.g. on a `rules_swift` transitive
+      # like `MobileNativeFoundation/index-import`) surfaces as a
+      # build failure. Bazel caches successful downloads, so a retry
+      # after a flake is cheap.
+      #
+      # Each command runs in a subshell so a `cd` for the example
+      # build doesn't leak its cwd change into subsequent retries.
       - name: Build Sources
         uses: ./.github/actions/retry
         with:
@@ -271,7 +282,7 @@ jobs:
       - name: Build Example
         uses: ./.github/actions/retry
         with:
-          command: cd Examples/ExampleBazelIntegration && bazelisk build //Subproject:Subproject //ExampleBazelIntegration:ExampleBazelIntegration
+          command: (cd Examples/ExampleBazelIntegration && bazelisk build //Subproject:Subproject //ExampleBazelIntegration:ExampleBazelIntegration)
 
   readme-validation:
     name: Check Markdown links


### PR DESCRIPTION
Mirrors what the `./.github/actions/retry` composite already does for `xcrun swift package resolve` / `xcrun xcodebuild -resolvePackageDependencies`: 6 attempts with exponential backoff (15s → 240s).

## Why

Hit [a `502 Bad Gateway`](https://github.com/dfed/SafeDI/actions/runs/25341849272/job/74300849749) on `main`'s post-merge CI for [#293](https://github.com/dfed/SafeDI/pull/293). Bazel was fetching `MobileNativeFoundation/index-import/releases/download/6.1.0.1/index-import.tar.gz` (a transitive `rules_swift` dependency) and GitHub's CDN flaked. Our other download-flavored CI steps already wrap retry around it; the bazel job didn't.

## What changes

- `.github/workflows/ci.yml` — both `bazelisk build` steps in the `bazel` job now go through `./.github/actions/retry`.
- `Build Example`'s `working-directory: Examples/ExampleBazelIntegration` becomes a `cd …` inside the retry action's `command` (composite-action `uses:` ignores `working-directory`).

## Test plan

- [x] Retry action's behavior unchanged from existing usage; new wiring is identical.
- [ ] CI green on this PR's first run (no need to deliberately trigger a flake — the change just adds tolerance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)