### PR TITLE
Fix BCR presubmit: declare apple_support and pin host deployment target

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,5 +12,5 @@ common --verbose_failures
 # machine with Xcode 26 produces a SafeDITool binary that dyld
 # refuses to load on a runner with an older macOS. Pattern matches
 # swift-syntax's .bazelrc.
-common --host_macos_minimum_os=14.0
-common --macos_minimum_os=14.0
+common --host_macos_minimum_os=12.0
+common --macos_minimum_os=12.0

--- a/.bazelrc
+++ b/.bazelrc
@@ -5,3 +5,9 @@ common --enable_bzlmod
 
 # Fail loudly on errors — makes CI logs readable.
 common --verbose_failures
+
+# Pin host (exec-config) deployment target so tools like SafeDITool stay
+# runnable on macOS hosts older than the SDK used to build them. Without
+# this, a build on a machine with Xcode 26 produces a SafeDITool binary
+# that dyld refuses to load on a runner with an older macOS.
+common --host_macos_minimum_os=14.0

--- a/.bazelrc
+++ b/.bazelrc
@@ -12,5 +12,5 @@ common --verbose_failures
 # machine with Xcode 26 produces a SafeDITool binary that dyld
 # refuses to load on a runner with an older macOS. Pattern matches
 # swift-syntax's .bazelrc.
-common --host_macos_minimum_os=12.0
-common --macos_minimum_os=12.0
+common --host_macos_minimum_os=11.0
+common --macos_minimum_os=11.0

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,8 +6,11 @@ common --enable_bzlmod
 # Fail loudly on errors — makes CI logs readable.
 common --verbose_failures
 
-# Pin host (exec-config) deployment target so tools like SafeDITool stay
-# runnable on macOS hosts older than the SDK used to build them. Without
-# this, a build on a machine with Xcode 26 produces a SafeDITool binary
-# that dyld refuses to load on a runner with an older macOS.
+# Pin both host (exec-config) and target deployment targets so tools
+# like SafeDITool stay runnable on macOS hosts older than the SDK
+# used to build them. Without --host_macos_minimum_os, a build on a
+# machine with Xcode 26 produces a SafeDITool binary that dyld
+# refuses to load on a runner with an older macOS. Pattern matches
+# swift-syntax's .bazelrc.
 common --host_macos_minimum_os=14.0
+common --macos_minimum_os=14.0

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,25 +1,34 @@
-# BCR presubmit configuration. Mirrors the pattern used by
-# swift-syntax (modules/swift-syntax/603.0.1/presubmit.yml in the
-# bazel-central-registry repo) — same dep shape (swift-syntax +
-# rules_swift on Bazel 9.x with Xcode 26 SDK on an older runner OS),
-# same set of `build_flags` needed.
+# BCR presubmit configuration. Pattern adapted from swift-syntax
+# (modules/swift-syntax/603.0.1/presubmit.yml) and swift-index-store
+# (modules/swift-index-store/1.9.2/presubmit.yml) — same dep shape
+# (swift-syntax + rules_swift on Bazel 9.x with Xcode 26 SDK on an
+# older runner OS).
 #
-# The `build_flags` block is the substantive part:
+# `build_flags` per task:
 #   - --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 #       Stops Bazel from auto-detecting the host CC toolchain; without
 #       this, rules_swift's xcode_swift_toolchain falls through to
 #       `cc_toolchain.target_gnu_system_name` returning "local" on
-#       BCR's runner and analysis fails. (Belt-and-suspenders with the
-#       `apple_support` bazel_dep we register in MODULE.bazel.)
-#   - --host_macos_minimum_os=12.0
+#       BCR's runner and analysis fails. Unanimous across the BCR
+#       Swift modules surveyed (swift-syntax, swift-index-store,
+#       swift-filename-matcher, asc_swift). Belt-and-suspenders with
+#       the `apple_support` bazel_dep we register in MODULE.bazel.
+#   - --host_macos_minimum_os=11.0
 #       Pins the deployment target for tools built under exec config
 #       (e.g. SafeDITool itself), so a binary built with the macOS 26
 #       SDK still runs on BCR's older runner OS. Without this, dyld
 #       refuses to load SafeDITool when the example task tries to
-#       execute it during code generation.
-#   - --macos_minimum_os=12.0
-#       Same idea for target-config builds. Matches swift-syntax's
-#       configuration for consistency.
+#       execute it during code generation. 11.0 matches SafeDI's
+#       Package.swift declared platform — lowest reasonable value,
+#       and SafeDITool only needs to run, not exercise newer APIs.
+#   - --macos_minimum_os=<value>
+#       Target-config deployment target. Differs per task:
+#       * verify_safedi_build: 11.0 — matches Package.swift, what
+#         SafeDI as a library claims to support.
+#       * bcr_test_module.build_example: 14.0 — the example app
+#         uses macOS 14+ SwiftUI APIs (LoggedInView's onChange,
+#         NameEntryView's TextField init), so it can't compile
+#         lower. This is the example app's requirement, not SafeDI's.
 matrix:
   platform: ["macos_arm64"]
   bazel: ["9.x"]
@@ -31,8 +40,8 @@ tasks:
     bazel: ${{ bazel }}
     build_flags:
       - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
-      - "--host_macos_minimum_os=12.0"
-      - "--macos_minimum_os=12.0"
+      - "--host_macos_minimum_os=11.0"
+      - "--macos_minimum_os=11.0"
     build_targets:
       - "@safedi//Sources/SafeDI:SafeDI"
       - "@safedi//Sources/SafeDICore:SafeDICore"
@@ -51,8 +60,8 @@ bcr_test_module:
       bazel: ${{ bazel }}
       build_flags:
         - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
-        - "--host_macos_minimum_os=12.0"
-        - "--macos_minimum_os=12.0"
+        - "--host_macos_minimum_os=11.0"
+        - "--macos_minimum_os=14.0"
       build_targets:
         - "//Subproject:Subproject"
         - "//ExampleBazelIntegration:ExampleBazelIntegration"

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,3 +1,25 @@
+# BCR presubmit configuration. Mirrors the pattern used by
+# swift-syntax (modules/swift-syntax/603.0.1/presubmit.yml in the
+# bazel-central-registry repo) — same dep shape (swift-syntax +
+# rules_swift on Bazel 9.x with Xcode 26 SDK on an older runner OS),
+# same set of `build_flags` needed.
+#
+# The `build_flags` block is the substantive part:
+#   - --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+#       Stops Bazel from auto-detecting the host CC toolchain; without
+#       this, rules_swift's xcode_swift_toolchain falls through to
+#       `cc_toolchain.target_gnu_system_name` returning "local" on
+#       BCR's runner and analysis fails. (Belt-and-suspenders with the
+#       `apple_support` bazel_dep we register in MODULE.bazel.)
+#   - --host_macos_minimum_os=14.0
+#       Pins the deployment target for tools built under exec config
+#       (e.g. SafeDITool itself), so a binary built with the macOS 26
+#       SDK still runs on BCR's older runner OS. Without this, dyld
+#       refuses to load SafeDITool when the example task tries to
+#       execute it during code generation.
+#   - --macos_minimum_os=14.0
+#       Same idea for target-config builds. Matches swift-syntax's
+#       configuration for consistency.
 matrix:
   platform: ["macos_arm64"]
   bazel: ["9.x"]
@@ -7,6 +29,10 @@ tasks:
     name: "Build SafeDI targets (${{ platform }}, Bazel ${{ bazel }})"
     platform: ${{ platform }}
     bazel: ${{ bazel }}
+    build_flags:
+      - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
+      - "--host_macos_minimum_os=14.0"
+      - "--macos_minimum_os=14.0"
     build_targets:
       - "@safedi//Sources/SafeDI:SafeDI"
       - "@safedi//Sources/SafeDICore:SafeDICore"
@@ -23,6 +49,10 @@ bcr_test_module:
       name: "Build downstream example (${{ platform }}, Bazel ${{ bazel }})"
       platform: ${{ platform }}
       bazel: ${{ bazel }}
+      build_flags:
+        - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
+        - "--host_macos_minimum_os=14.0"
+        - "--macos_minimum_os=14.0"
       build_targets:
         - "//Subproject:Subproject"
         - "//ExampleBazelIntegration:ExampleBazelIntegration"

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -11,13 +11,13 @@
 #       `cc_toolchain.target_gnu_system_name` returning "local" on
 #       BCR's runner and analysis fails. (Belt-and-suspenders with the
 #       `apple_support` bazel_dep we register in MODULE.bazel.)
-#   - --host_macos_minimum_os=14.0
+#   - --host_macos_minimum_os=12.0
 #       Pins the deployment target for tools built under exec config
 #       (e.g. SafeDITool itself), so a binary built with the macOS 26
 #       SDK still runs on BCR's older runner OS. Without this, dyld
 #       refuses to load SafeDITool when the example task tries to
 #       execute it during code generation.
-#   - --macos_minimum_os=14.0
+#   - --macos_minimum_os=12.0
 #       Same idea for target-config builds. Matches swift-syntax's
 #       configuration for consistency.
 matrix:
@@ -31,8 +31,8 @@ tasks:
     bazel: ${{ bazel }}
     build_flags:
       - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
-      - "--host_macos_minimum_os=14.0"
-      - "--macos_minimum_os=14.0"
+      - "--host_macos_minimum_os=12.0"
+      - "--macos_minimum_os=12.0"
     build_targets:
       - "@safedi//Sources/SafeDI:SafeDI"
       - "@safedi//Sources/SafeDICore:SafeDICore"
@@ -51,8 +51,8 @@ bcr_test_module:
       bazel: ${{ bazel }}
       build_flags:
         - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
-        - "--host_macos_minimum_os=14.0"
-        - "--macos_minimum_os=14.0"
+        - "--host_macos_minimum_os=12.0"
+        - "--macos_minimum_os=12.0"
       build_targets:
         - "//Subproject:Subproject"
         - "//ExampleBazelIntegration:ExampleBazelIntegration"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,8 +254,16 @@ jobs:
 
   bazel:
     name: Bazel Build on macOS
-    # Pinned to Xcode 26.0 — matches BCR's `macos_arm64` runner
-    # platform defined at https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazelci.py
+    # This job mirrors BCR's presubmit so issues that block our BCR
+    # publish (https://registry.bazel.build/modules/safedi) surface
+    # here first. Keep it in sync with `.bcr/presubmit.yml`:
+    #   - Bazel version: matches `.bazelversion` (consumed by bazelisk)
+    #     and BCR's `bazel: ["9.x"]` matrix entry.
+    #   - Xcode 26.0 — matches BCR's `macos_arm64` runner platform
+    #     defined at https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazelci.py
+    #   - `build_targets` here mirror the two BCR tasks
+    #     (`verify_safedi_build` and `bcr_test_module.build_example`).
+    # If you change BCR's matrix or task list, update this job too.
     runs-on: macos-26
     permissions:
       contents: read
@@ -275,11 +283,16 @@ jobs:
       #
       # Each command runs in a subshell so a `cd` for the example
       # build doesn't leak its cwd change into subsequent retries.
-      - name: Build Sources
+      - name: Build SafeDI targets (mirrors BCR `verify_safedi_build`)
         uses: ./.github/actions/retry
         with:
-          command: bazelisk build //Sources/...
-      - name: Build Example
+          command: |
+            bazelisk build \
+              //Sources/SafeDI:SafeDI \
+              //Sources/SafeDICore:SafeDICore \
+              //Sources/SafeDIMacros:SafeDIMacros \
+              //Sources/SafeDITool:SafeDITool
+      - name: Build downstream example (mirrors BCR `bcr_test_module.build_example`)
         uses: ./.github/actions/retry
         with:
           command: (cd Examples/ExampleBazelIntegration && bazelisk build //Subproject:Subproject //ExampleBazelIntegration:ExampleBazelIntegration)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,13 +258,22 @@ jobs:
     # publish (https://registry.bazel.build/modules/safedi) surface
     # here first. Keep it in sync with `.bcr/presubmit.yml`:
     #   - Bazel version: matches `.bazelversion` (consumed by bazelisk)
-    #     and BCR's `bazel: ["9.x"]` matrix entry.
+    #     and BCR's `bazel: ["9.x"]` matrix entry. NOTE: `9.x` resolves
+    #     to whatever 9.x point release is current; we pin a specific
+    #     version. If BCR ships a newer 9.x before we bump, drift is
+    #     possible — bump `.bazelversion` when you notice the gap.
     #   - Xcode 26.0 — matches BCR's `macos_arm64` runner platform
     #     defined at https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazelci.py
+    #   - Runner OS: `macos-15` (Sequoia), NOT `macos-26`. BCR's
+    #     `macos_arm64` runs an OS older than the Xcode 26 SDK it has
+    #     installed, so a binary built for macOS 26 deployment target
+    #     fails dyld at execution time. Running on `macos-26` masks
+    #     that failure (SDK == runner OS); `macos-15` reproduces the
+    #     SDK-vs-runner gap so we catch it locally.
     #   - `build_targets` here mirror the two BCR tasks
     #     (`verify_safedi_build` and `bcr_test_module.build_example`).
     # If you change BCR's matrix or task list, update this job too.
-    runs-on: macos-26
+    runs-on: macos-15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,12 +286,11 @@ jobs:
       - name: Build SafeDI targets (mirrors BCR `verify_safedi_build`)
         uses: ./.github/actions/retry
         with:
-          command: |
-            bazelisk build \
-              //Sources/SafeDI:SafeDI \
-              //Sources/SafeDICore:SafeDICore \
-              //Sources/SafeDIMacros:SafeDIMacros \
-              //Sources/SafeDITool:SafeDITool
+          # Kept on one line — the retry composite action splices
+          # `${{ inputs.command }}` directly into a bash `for` loop
+          # and tacks ` && break` onto the same source line, so a
+          # multi-line YAML command leaves `&& break` orphaned.
+          command: bazelisk build //Sources/SafeDI:SafeDI //Sources/SafeDICore:SafeDICore //Sources/SafeDIMacros:SafeDIMacros //Sources/SafeDITool:SafeDITool
       - name: Build downstream example (mirrors BCR `bcr_test_module.build_example`)
         uses: ./.github/actions/retry
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,26 +254,23 @@ jobs:
 
   bazel:
     name: Bazel Build on macOS
-    # This job mirrors BCR's presubmit so issues that block our BCR
-    # publish (https://registry.bazel.build/modules/safedi) surface
-    # here first. Keep it in sync with `.bcr/presubmit.yml`:
-    #   - Bazel version: matches `.bazelversion` (consumed by bazelisk)
-    #     and BCR's `bazel: ["9.x"]` matrix entry. NOTE: `9.x` resolves
-    #     to whatever 9.x point release is current; we pin a specific
-    #     version. If BCR ships a newer 9.x before we bump, drift is
-    #     possible — bump `.bazelversion` when you notice the gap.
-    #   - Xcode 26.0 — matches BCR's `macos_arm64` runner platform
-    #     defined at https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazelci.py
-    #   - Runner OS: `macos-15` (Sequoia), NOT `macos-26`. BCR's
-    #     `macos_arm64` runs an OS older than the Xcode 26 SDK it has
-    #     installed, so a binary built for macOS 26 deployment target
-    #     fails dyld at execution time. Running on `macos-26` masks
-    #     that failure (SDK == runner OS); `macos-15` reproduces the
-    #     SDK-vs-runner gap so we catch it locally.
-    #   - `build_targets` here mirror the two BCR tasks
-    #     (`verify_safedi_build` and `bcr_test_module.build_example`).
-    # If you change BCR's matrix or task list, update this job too.
-    runs-on: macos-15
+    # General bazel sanity check on every PR. We can't perfectly
+    # mirror BCR's presubmit (https://registry.bazel.build/modules/safedi):
+    # BazelCI's BuildKite infrastructure is closed to non-`bazelbuild`
+    # projects (https://github.com/bazelbuild/continuous-integration/blob/main/.github/ISSUE_TEMPLATE/adding-your-project-to-bazel-ci.md),
+    # and any GH Actions runner we pick differs from BCR's image in
+    # ways we can't fully control (CC toolchain auto-detection,
+    # SDK-vs-runner-OS gap, exact Bazel point release). So treat BCR
+    # as the canonical macOS-on-older-OS check; this job catches
+    # general regressions before we publish.
+    #
+    # Keep `build_targets` aligned with `.bcr/presubmit.yml` so a
+    # divergence is visible in review. If you change BCR's task list,
+    # update this job too.
+    #
+    # Pinned to Xcode 26.0 — matches BCR's `macos_arm64` runner
+    # platform defined at https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/bazelci.py
+    runs-on: macos-26
     permissions:
       contents: read
     steps:

--- a/Examples/ExampleBazelIntegration/.bazelrc
+++ b/Examples/ExampleBazelIntegration/.bazelrc
@@ -6,5 +6,5 @@ common --enable_bzlmod
 # with Xcode 26 but executes on an older macOS, so an unpinned
 # default makes dyld refuse the binary. Pattern matches
 # swift-syntax's .bazelrc.
-common --host_macos_minimum_os=14.0
-common --macos_minimum_os=14.0
+common --host_macos_minimum_os=12.0
+common --macos_minimum_os=12.0

--- a/Examples/ExampleBazelIntegration/.bazelrc
+++ b/Examples/ExampleBazelIntegration/.bazelrc
@@ -1,10 +1,12 @@
 common --enable_bzlmod
 
-# Pin both host (exec-config) and target deployment targets so
-# SafeDITool — built fresh under this module's exec config — stays
-# runnable on hosts older than the SDK. The BCR macOS runner builds
-# with Xcode 26 but executes on an older macOS, so an unpinned
-# default makes dyld refuse the binary. Pattern matches
-# swift-syntax's .bazelrc.
-common --host_macos_minimum_os=12.0
-common --macos_minimum_os=12.0
+# Pin host (exec-config) deployment target low (11.0, matching
+# SafeDI's Package.swift) so SafeDITool — built fresh under this
+# module's exec config — stays runnable on hosts older than the
+# SDK. The BCR macOS runner builds with Xcode 26 but executes on
+# an older macOS; an unpinned default makes dyld refuse the binary.
+common --host_macos_minimum_os=11.0
+# Target deployment target (14.0) is driven by the example app's
+# own source: LoggedInView and NameEntryView use macOS 14+ APIs.
+# This is the example app's requirement, not SafeDI's.
+common --macos_minimum_os=14.0

--- a/Examples/ExampleBazelIntegration/.bazelrc
+++ b/Examples/ExampleBazelIntegration/.bazelrc
@@ -1,1 +1,7 @@
 common --enable_bzlmod
+
+# Pin host (exec-config) deployment target so SafeDITool — built fresh
+# under this module's exec config — stays runnable on hosts older than
+# the SDK. The BCR macOS runner builds with Xcode 26 but executes on an
+# older macOS, so an unpinned default makes dyld refuse the binary.
+common --host_macos_minimum_os=14.0

--- a/Examples/ExampleBazelIntegration/.bazelrc
+++ b/Examples/ExampleBazelIntegration/.bazelrc
@@ -1,7 +1,10 @@
 common --enable_bzlmod
 
-# Pin host (exec-config) deployment target so SafeDITool — built fresh
-# under this module's exec config — stays runnable on hosts older than
-# the SDK. The BCR macOS runner builds with Xcode 26 but executes on an
-# older macOS, so an unpinned default makes dyld refuse the binary.
+# Pin both host (exec-config) and target deployment targets so
+# SafeDITool — built fresh under this module's exec config — stays
+# runnable on hosts older than the SDK. The BCR macOS runner builds
+# with Xcode 26 but executes on an older macOS, so an unpinned
+# default makes dyld refuse the binary. Pattern matches
+# swift-syntax's .bazelrc.
 common --host_macos_minimum_os=14.0
+common --macos_minimum_os=14.0

--- a/Examples/ExampleBazelIntegration/MODULE.bazel.lock
+++ b/Examples/ExampleBazelIntegration/MODULE.bazel.lock
@@ -567,7 +567,7 @@
     "@@rules_swift_package_manager+//:extensions.bzl%swift_deps": {
       "general": {
         "bzlTransitiveDigest": "QPzonOjYtXIWyUjGi44AUsRd7aYzf/8r9Sn0ghJjwRk=",
-        "usagesDigest": "pQmj+Q+/edkevpSUCxREEcjQ29wuwHQKQwYUL/4vx/8=",
+        "usagesDigest": "HHSBXogfC27ANWGaOy8xxo1Wthz5SbilpIUNFnD00Dw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_swift_package_manager+,bazel_skylib bazel_skylib+",
           "REPO_MAPPING:rules_swift_package_manager+,bazel_tools bazel_tools",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,6 +15,7 @@ module(
 
 bazel_dep(name = "rules_swift", version = "3.6.0", repo_name = "build_bazel_rules_swift")
 bazel_dep(name = "rules_swift_package_manager", version = "1.15.0")
+bazel_dep(name = "apple_support", version = "1.24.2", repo_name = "build_bazel_apple_support")
 
 # Translate SPM dependencies into Bazel targets. The resulting
 # @swiftpkg_* repos are referenced from per-module BUILD.bazel files.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -530,7 +530,7 @@
     "@@rules_swift_package_manager+//:extensions.bzl%swift_deps": {
       "general": {
         "bzlTransitiveDigest": "QPzonOjYtXIWyUjGi44AUsRd7aYzf/8r9Sn0ghJjwRk=",
-        "usagesDigest": "Inz16quqqq9sQ7gZ28Q7sfWU1B/K9/hDAtYlxQOcJnA=",
+        "usagesDigest": "Cqv8otPjpwbQp42uEGj5z8Zkn1QTMFEkit5F8KDG2Ok=",
         "recordedInputs": [
           "REPO_MAPPING:rules_swift_package_manager+,bazel_skylib bazel_skylib+",
           "REPO_MAPPING:rules_swift_package_manager+,bazel_tools bazel_tools",


### PR DESCRIPTION
## Summary

BCR presubmit ([bazelbuild/bazel-central-registry#8711](https://github.com/bazelbuild/bazel-central-registry/pull/8711)) failed in two ways. Both are well-trodden ground for BCR-published Swift modules — surveyed five of them and adopted the unanimously-used flags. This PR carries the substantive config fixes; the surrounding meta-changes (CI mirror attempts, retry-action workaround) are documented at the bottom.

## Substantive fixes

### Failure 1 — `Build SafeDI targets` (CC toolchain analysis error)

```
ERROR: ... in xcode_swift_toolchain rule ...
Invalid target triple: local, this likely means you're using the wrong CC toolchain,
make sure you include apple_support in your project
```

`rules_swift`'s `xcode_swift_toolchain` falls through to `cc_toolchain.target_gnu_system_name`, which returns the literal string `"local"` on BCR's runner because Bazel auto-detects a non-Apple-aware CC toolchain.

**Fix (both belt and suspenders, both have prior art):**
- `bazel_dep(name = "apple_support", version = "1.24.2", ...)` in root `MODULE.bazel`. Matches what swift-syntax, swift-index-store, and rules_xcodeproj all do — apple_support's bazel_dep registers a proper Apple-aware CC toolchain so the auto-detect fallback isn't reached.
- `--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1` in `.bcr/presubmit.yml` `build_flags`. This is unanimous across all five BCR Swift modules I surveyed — it tells Bazel to skip CC auto-detection entirely, so the broken fallback can't run regardless of toolchain registration.

### Failure 2 — `Build downstream example` (dyld at execution)

```
SafeDITool failed: ...
dyld: Library not loaded: /usr/lib/swift/libswift_DarwinFoundation2.dylib
  Referenced from: ... SafeDITool (built for macOS 26.0 which is newer than running OS)
```

SafeDITool gets compiled fresh under exec config with Xcode 26's SDK, which pins macOS 26 as the deployment target. BCR's runner has Xcode 26 installed but runs an older OS, so dyld refuses the binary.

**Fix:** Pin host *and* target deployment targets in `.bcr/presubmit.yml` `build_flags` and the corresponding `.bazelrc` files. Values match the actual support requirements rather than picking a single number for everything:

| Flag | Where | Value | Why |
|---|---|---|---|
| `--host_macos_minimum_os` | everywhere | `11.0` | SafeDITool only needs to *run*, not exercise newer APIs. Lowest reasonable value — matches `Package.swift`'s `.macOS(.v11)`. Ensures the binary loads on whatever older macOS BCR's runner happens to be on. |
| `--macos_minimum_os` (root SafeDI) | root `.bazelrc`, `verify_safedi_build` BCR task | `11.0` | Matches Package.swift — what SafeDI as a library claims to support. |
| `--macos_minimum_os` (example app) | example `.bazelrc`, `bcr_test_module.build_example` BCR task | `14.0` | The example app's source requires it: `LoggedInView`'s `onChange(of:initial:_:)` is macOS 14+, `NameEntryView`'s `TextField` init is macOS 12+. The example app's deployment requirements are independent of SafeDI's. |

Verified locally: `otool -l SafeDITool` reports `minos 11.0` in `LC_BUILD_VERSION`. The flag actually takes effect in the binary, independent of runner OS. (Earlier iterations of this PR set the host target at 12.0 then 14.0 — both wrong: 12.0 was a guess, 14.0 was higher than Package.swift's claim.)

## Prior art surveyed

| Module | `BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN` | `--macos_minimum_os` | apple_support in MODULE.bazel | Tool runs during BCR test? |
|---|---|---|---|---|
| swift-syntax 603.0.1 | ✅ | `13.0` | ✅ | No |
| swift-index-store 1.9.2 | ✅ | `12.0` | ✅ | No |
| swift-filename-matcher 2.0.1 | ✅ | — | ✅ | No |
| asc_swift 1.6.0 | ✅ | — | ✅ | No |
| rules_xcodeproj 4.0.1 | — | — | ✅ | No |

Every flag we use has prior art — except `--host_macos_minimum_os` in `.bcr/presubmit.yml` `build_flags`. **None of the surveyed modules execute their tool during the BCR test** (they only build it). SafeDI is genuinely uncommon: our `bcr_test_module.build_example` task uses `safedi_compile`, which actually invokes SafeDITool, so dyld fires there. The `--host_macos_minimum_os` flag is the principled exec-config analogue of `--macos_minimum_os` — same flag family, same Bazel concept — but its specific use in BCR `build_flags` is our derivation, not directly observed elsewhere.

## Confidence

| Claim | Confidence | Why |
|---|---|---|
| `apple_support` + `BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN` fixes Failure 1 | **High** | Unanimous across five surveyed BCR Swift modules. |
| `--host_macos_minimum_os` keeps SafeDITool runnable on older OS | **Verified** | `otool -l` confirmed `minos 11.0` in `LC_BUILD_VERSION`, independent of host. |
| Deployment target values match actual support requirements | **High** | 11.0 matches Package.swift; 14.0 for the example matches its actual API usage. |
| `--host_macos_minimum_os` belongs in BCR `build_flags` | **Medium** | Principled extension of `--macos_minimum_os` to exec config. No direct prior art because no surveyed module exec's a tool during BCR. Hard to raise without actually running on BCR's runner. |
| Local CI passing implies BCR will pass | Low | Established earlier — local CI can't reproduce BCR's environment. BCR remains canonical. |

## Why we didn't catch this in our CI, and why we're not going to chase it

Initially tried switching the `bazel` job to `macos-15` to reproduce BCR's SDK-vs-runner-OS gap. The right way to actually mirror BCR is `.bazelci/presubmit.yml` on BuildKite — same infrastructure rules_swift / rules_apple use — but [BazelCI is closed](https://github.com/bazelbuild/continuous-integration/blob/main/.github/ISSUE_TEMPLATE/adding-your-project-to-bazel-ci.md) to non-`bazelbuild` projects that aren't rules. Any GH Actions mirror we hand-build will still drift from BCR's image (CC toolchain auto-detection, exact Bazel point release).

Reverted that switch. The bazel job stays on `macos-26` as a general sanity gate, with `build_targets` aligned to `.bcr/presubmit.yml` so divergence is at least visible in review. **BCR's presubmit is treated as the canonical macOS-on-older-OS check.**

## Note on the retry composite action

A first iteration tried to use a multi-line YAML `|` block scalar for the new explicit `bazelisk build` command. That broke `.github/actions/retry/action.yml`, which splices `${{ inputs.command }}` straight into a bash loop and tacks ` && break` onto the same source line — a multi-line command leaves `&& break` orphaned. Fixed by keeping the command on a single line, with a comment in `ci.yml` explaining why.

## Release note

These fixes ship in **2.0.0-rc-3**. The existing BCR PR for 2.0.0-rc-2 is built from the published tarball and can't pick them up retroactively — it'll need to be replaced with a new submission targeting rc-3.

## Test plan

- [x] `bazelisk build //Sources/SafeDI:SafeDI //Sources/SafeDICore:SafeDICore //Sources/SafeDIMacros:SafeDIMacros //Sources/SafeDITool:SafeDITool` from repo root — passes locally
- [x] `(cd Examples/ExampleBazelIntegration && bazelisk build //Subproject:Subproject //ExampleBazelIntegration:ExampleBazelIntegration)` — passes locally
- [x] `otool -l <SafeDITool>` shows `minos 11.0` — deployment-target flag verified in `LC_BUILD_VERSION`
- [x] `./CLI/lint.sh` — clean
- [x] CI green
- [ ] After merge + 2.0.0-rc-3 release, replace BCR PR #8711 with one targeting rc-3 and confirm BCR presubmit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)