### PR TITLE
Fail closed on conditional SafeDI scanning

### DIFF
--- a/Sources/SafeDICore/Models/SafeDIToolManifest.swift
+++ b/Sources/SafeDICore/Models/SafeDIToolManifest.swift
@@ -22,6 +22,16 @@
 /// All input file paths are relative to the working directory where the tool is invoked.
 /// Output file paths may be absolute or relative to the working directory.
 public struct SafeDIToolManifest: Codable, Sendable {
+	private enum CodingKeys: String, CodingKey {
+		case dependencyTreeGeneration
+		case mockGeneration
+		case configurationFilePaths
+		case mockConfigurationOutputFilePath
+		case additionalMocksToGenerate
+		case additionalInputFiles
+		case activeCompilationConditions
+	}
+
 	/// A mapping from an input Swift file to an output file.
 	public struct InputOutputMap: Codable, Sendable {
 		/// The path to the input Swift file containing one or more root `@Instantiable` declarations.
@@ -65,6 +75,9 @@ public struct SafeDIToolManifest: Codable, Sendable {
 	/// Only populated by the `scan` subcommand; ignored by `generate`.
 	public var additionalInputFiles: [String]
 
+	/// Active conditional compilation flags used while scanning SafeDI declarations.
+	public var activeCompilationConditions: [String]
+
 	public init(
 		dependencyTreeGeneration: [InputOutputMap],
 		mockGeneration: [InputOutputMap] = [],
@@ -72,6 +85,7 @@ public struct SafeDIToolManifest: Codable, Sendable {
 		mockConfigurationOutputFilePath: String? = nil,
 		additionalMocksToGenerate: [String] = [],
 		additionalInputFiles: [String] = [],
+		activeCompilationConditions: [String] = [],
 	) {
 		self.dependencyTreeGeneration = dependencyTreeGeneration
 		self.mockGeneration = mockGeneration
@@ -79,5 +93,19 @@ public struct SafeDIToolManifest: Codable, Sendable {
 		self.mockConfigurationOutputFilePath = mockConfigurationOutputFilePath
 		self.additionalMocksToGenerate = additionalMocksToGenerate
 		self.additionalInputFiles = additionalInputFiles
+		self.activeCompilationConditions = activeCompilationConditions
+	}
+
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		self.init(
+			dependencyTreeGeneration: try container.decode([InputOutputMap].self, forKey: .dependencyTreeGeneration),
+			mockGeneration: try container.decodeIfPresent([InputOutputMap].self, forKey: .mockGeneration) ?? [],
+			configurationFilePaths: try container.decodeIfPresent([String].self, forKey: .configurationFilePaths) ?? [],
+			mockConfigurationOutputFilePath: try container.decodeIfPresent(String.self, forKey: .mockConfigurationOutputFilePath),
+			additionalMocksToGenerate: try container.decodeIfPresent([String].self, forKey: .additionalMocksToGenerate) ?? [],
+			additionalInputFiles: try container.decodeIfPresent([String].self, forKey: .additionalInputFiles) ?? [],
+			activeCompilationConditions: try container.decodeIfPresent([String].self, forKey: .activeCompilationConditions) ?? [],
+		)
 	}
 }

--- a/Sources/SafeDICore/Models/UnevaluableConditionalCompilationConditionError.swift
+++ b/Sources/SafeDICore/Models/UnevaluableConditionalCompilationConditionError.swift
@@ -1,0 +1,40 @@
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+public struct UnevaluableConditionalCompilationConditionError: Error, CustomStringConvertible, Equatable, Sendable {
+	public let condition: String
+	public let suggestedActiveCondition: String?
+
+	public init(
+		condition: String,
+		suggestedActiveCondition: String? = nil,
+	) {
+		self.condition = condition
+		self.suggestedActiveCondition = suggestedActiveCondition
+	}
+
+	public var description: String {
+		if let suggestedActiveCondition {
+			"Unable to evaluate conditional compilation condition `\(condition)` while scanning SafeDI declarations. Pass the active condition to SafeDITool with `--active-compilation-conditions \(suggestedActiveCondition)`, or remove the SafeDI declaration from the conditional branch."
+		} else {
+			"Unable to evaluate conditional compilation condition `\(condition)` while scanning SafeDI declarations. SafeDITool can only evaluate boolean literals, `!`, `&&`, `||`, parentheses, and active custom compilation conditions while scanning SafeDI declarations."
+		}
+	}
+}

--- a/Sources/SafeDICore/Visitors/ConditionalCompilationEvaluator.swift
+++ b/Sources/SafeDICore/Visitors/ConditionalCompilationEvaluator.swift
@@ -1,0 +1,347 @@
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftSyntax
+
+/// Selects the `#if` branch SafeDITool should scan without pretending to know
+/// compiler flags the caller did not provide.
+struct ConditionalCompilationEvaluator {
+	let activeCompilationConditions: Set<String>
+
+	func activeClause(in node: IfConfigDeclSyntax) -> ConditionalCompilationClauseSelection {
+		for clause in node.clauses {
+			guard let condition = clause.condition else {
+				return .active(clause)
+			}
+
+			switch evaluate(condition) {
+			case let .known(isActive):
+				if isActive {
+					return .active(clause)
+				}
+			case let .unknown(error):
+				return .unevaluable(error)
+			}
+		}
+		return .active(nil)
+	}
+
+	func evaluate(_ condition: ExprSyntax) -> ConditionalCompilationEvaluation {
+		if let boolLiteral = BooleanLiteralExprSyntax(condition) {
+			return .known(boolLiteral.literal.tokenKind == .keyword(.true))
+		}
+
+		if let identifier = DeclReferenceExprSyntax(condition) {
+			let name = identifier.baseName.text
+			if activeCompilationConditions.contains(name) {
+				return .known(true)
+			}
+			// Missing custom flags are unknown, not false. The scanner can be
+			// invoked outside the compiler command that ultimately defines `-D`
+			// flags, so silently treating an absent flag as inactive would hide
+			// guarded SafeDI declarations from generation.
+			return .unknown(.init(condition: name, suggestedActiveCondition: name))
+		}
+
+		if let prefixOperator = PrefixOperatorExprSyntax(condition) {
+			guard prefixOperator.operator.text == "!" else {
+				return .unknown(.init(condition: condition.trimmedDescription))
+			}
+			return evaluate(prefixOperator.expression).negated
+		}
+
+		if let sequence = SequenceExprSyntax(condition) {
+			return evaluateSequence(Array(sequence.elements), fallbackDescription: condition.trimmedDescription)
+		}
+
+		if let infixOperator = InfixOperatorExprSyntax(condition),
+		   let binaryOperator = BinaryOperatorExprSyntax(infixOperator.operator)
+		{
+			let left = evaluate(infixOperator.leftOperand)
+			let right = evaluate(infixOperator.rightOperand)
+			switch binaryOperator.operator.text {
+			case "&&":
+				return left.and(right)
+			case "||":
+				return left.or(right)
+			default:
+				return .unknown(.init(condition: condition.trimmedDescription))
+			}
+		}
+
+		if let tuple = TupleExprSyntax(condition),
+		   tuple.elements.count == 1,
+		   let element = tuple.elements.first
+		{
+			return evaluate(element.expression)
+		}
+
+		return .unknown(.init(condition: condition.trimmedDescription))
+	}
+
+	private func evaluateSequence(
+		_ elements: [ExprSyntax],
+		fallbackDescription: String,
+	) -> ConditionalCompilationEvaluation {
+		var index = 0
+
+		func parseOr() -> ConditionalCompilationEvaluation {
+			var result = parseAnd()
+			while consumeOperator("||", elements: elements, index: &index) {
+				result = result.or(parseAnd())
+			}
+			return result
+		}
+
+		func parseAnd() -> ConditionalCompilationEvaluation {
+			var result = parsePrimary()
+			while consumeOperator("&&", elements: elements, index: &index) {
+				result = result.and(parsePrimary())
+			}
+			return result
+		}
+
+		func parsePrimary() -> ConditionalCompilationEvaluation {
+			guard index < elements.count else {
+				return .unknown(.init(condition: fallbackDescription))
+			}
+			let expression = elements[index]
+			index += 1
+			if BinaryOperatorExprSyntax(expression) != nil {
+				return .unknown(.init(condition: fallbackDescription))
+			}
+			return evaluate(expression)
+		}
+
+		let result = parseOr()
+		if index == elements.count {
+			return result
+		} else {
+			return .unknown(.init(condition: fallbackDescription))
+		}
+	}
+
+	private func consumeOperator(
+		_ expectedOperator: String,
+		elements: [ExprSyntax],
+		index: inout Int,
+	) -> Bool {
+		guard index < elements.count,
+		      let binaryOperator = BinaryOperatorExprSyntax(elements[index]),
+		      binaryOperator.operator.text == expectedOperator
+		else {
+			return false
+		}
+		index += 1
+		return true
+	}
+}
+
+enum ConditionalCompilationClauseSelection {
+	case active(IfConfigClauseSyntax?)
+	case unevaluable(UnevaluableConditionalCompilationConditionError)
+}
+
+enum ConditionalCompilationEvaluation {
+	case known(Bool)
+	case unknown(UnevaluableConditionalCompilationConditionError)
+
+	var negated: Self {
+		switch self {
+		case let .known(value):
+			.known(!value)
+		case .unknown:
+			self
+		}
+	}
+
+	func and(_ other: Self) -> Self {
+		switch (self, other) {
+		case (.known(false), _), (_, .known(false)):
+			.known(false)
+		case (.known(true), let other):
+			other
+		case (let selfEvaluation, .known(true)):
+			selfEvaluation
+		case (.unknown, _):
+			self
+		}
+	}
+
+	func or(_ other: Self) -> Self {
+		switch (self, other) {
+		case (.known(true), _), (_, .known(true)):
+			.known(true)
+		case (.known(false), let other):
+			other
+		case (let selfEvaluation, .known(false)):
+			selfEvaluation
+		case (.unknown, _):
+			self
+		}
+	}
+}
+
+extension SyntaxVisitor {
+	func walkIfConfigElements(_ elements: IfConfigClauseSyntax.Elements) {
+		switch elements {
+		case let .statements(statements):
+			walk(statements)
+		case let .switchCases(switchCases):
+			walk(switchCases)
+		case let .decls(decls):
+			walk(decls)
+		case let .postfixExpression(expression):
+			walk(expression)
+		case let .attributes(attributes):
+			walk(attributes)
+		}
+	}
+}
+
+extension IfConfigDeclSyntax {
+	var containsSafeDIDeclaration: Bool {
+		let visitor = SafeDIDeclarationDetector()
+		visitor.walk(self)
+		return visitor.containsSafeDIDeclaration
+	}
+
+	func containsInstantiableBodySyntax(customMockName: String?) -> Bool {
+		let visitor = InstantiableBodySyntaxDetector(customMockName: customMockName)
+		visitor.walk(self)
+		return visitor.containsInstantiableBodySyntax
+	}
+}
+
+private final class SafeDIDeclarationDetector: SyntaxVisitor {
+	init() {
+		super.init(viewMode: .sourceAccurate)
+	}
+
+	var containsSafeDIDeclaration = false
+
+	override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+		visitDecl(node)
+	}
+
+	override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+		visitDecl(node)
+	}
+
+	override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+		visitDecl(node)
+	}
+
+	override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+		if node.attributes.instantiableMacro != nil {
+			containsSafeDIDeclaration = true
+			return .skipChildren
+		}
+		return containsSafeDIDeclaration ? .skipChildren : .visitChildren
+	}
+
+	override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+		if !node.attributes.dependencySources.isEmpty {
+			containsSafeDIDeclaration = true
+		}
+		return .skipChildren
+	}
+
+	override func visit(_ node: MacroExpansionDeclSyntax) -> SyntaxVisitorContinueKind {
+		if node.macroName.text == SafeDIConfigurationVisitor.macroName {
+			containsSafeDIDeclaration = true
+		}
+		return .skipChildren
+	}
+
+	override func visit(_ node: MacroExpansionExprSyntax) -> SyntaxVisitorContinueKind {
+		if node.macroName.text == SafeDIConfigurationVisitor.macroName {
+			containsSafeDIDeclaration = true
+		}
+		return .skipChildren
+	}
+
+	private func visitDecl(_ node: some ConcreteDeclSyntaxProtocol) -> SyntaxVisitorContinueKind {
+		if node.attributes.instantiableMacro != nil {
+			containsSafeDIDeclaration = true
+			return .skipChildren
+		}
+		return containsSafeDIDeclaration ? .skipChildren : .visitChildren
+	}
+}
+
+private final class InstantiableBodySyntaxDetector: SyntaxVisitor {
+	init(customMockName: String?) {
+		self.customMockName = customMockName
+		super.init(viewMode: .sourceAccurate)
+	}
+
+	var containsInstantiableBodySyntax = false
+
+	private let customMockName: String?
+
+	override func visit(_: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+		containsInstantiableBodySyntax = true
+		return .skipChildren
+	}
+
+	override func visit(_: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+		containsInstantiableBodySyntax = true
+		return .skipChildren
+	}
+
+	override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+		if node.name.text == InstantiableVisitor.instantiateMethodName
+			|| node.name.text == InstantiableVisitor.mockMethodName
+			|| node.name.text == customMockName
+		{
+			containsInstantiableBodySyntax = true
+		}
+		return .skipChildren
+	}
+
+	override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+		visitDecl(node)
+	}
+
+	override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+		visitDecl(node)
+	}
+
+	override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+		visitDecl(node)
+	}
+
+	override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+		if node.attributes.instantiableMacro != nil {
+			containsInstantiableBodySyntax = true
+			return .skipChildren
+		}
+		return containsInstantiableBodySyntax ? .skipChildren : .visitChildren
+	}
+
+	private func visitDecl(_ node: some ConcreteDeclSyntaxProtocol) -> SyntaxVisitorContinueKind {
+		if node.attributes.instantiableMacro != nil {
+			containsInstantiableBodySyntax = true
+			return .skipChildren
+		}
+		return containsInstantiableBodySyntax ? .skipChildren : .visitChildren
+	}
+}

--- a/Sources/SafeDICore/Visitors/FileVisitor.swift
+++ b/Sources/SafeDICore/Visitors/FileVisitor.swift
@@ -24,7 +24,10 @@ import SwiftSyntax
 public final class FileVisitor: SyntaxVisitor {
 	// MARK: Initialization
 
-	public init() {
+	public init(activeCompilationConditions: Set<String> = []) {
+		conditionalCompilationEvaluator = ConditionalCompilationEvaluator(
+			activeCompilationConditions: activeCompilationConditions,
+		)
 		super.init(viewMode: .sourceAccurate)
 	}
 
@@ -53,6 +56,20 @@ public final class FileVisitor: SyntaxVisitor {
 
 	public override func visit(_: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
 		.skipChildren
+	}
+
+	public override func visit(_ node: IfConfigDeclSyntax) -> SyntaxVisitorContinueKind {
+		switch conditionalCompilationEvaluator.activeClause(in: node) {
+		case let .active(activeClause):
+			if let elements = activeClause?.elements {
+				walkIfConfigElements(elements)
+			}
+		case let .unevaluable(error):
+			if node.containsSafeDIDeclaration {
+				appendUnevaluableConditionalCompilationCondition(error)
+			}
+		}
+		return .skipChildren
 	}
 
 	public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -101,8 +118,13 @@ public final class FileVisitor: SyntaxVisitor {
 		let instantiableVisitor = InstantiableVisitor(
 			declarationType: .extensionDecl,
 			parentType: nil,
+			activeCompilationConditions: conditionalCompilationEvaluator.activeCompilationConditions,
+			failClosedOnUnevaluableConditionalCompilation: true,
 		)
 		instantiableVisitor.walk(node)
+		for error in instantiableVisitor.unevaluableConditionalCompilationConditions {
+			appendUnevaluableConditionalCompilationCondition(error)
+		}
 		for instantiable in instantiableVisitor.instantiables {
 			instantiables.append(instantiable)
 		}
@@ -134,17 +156,31 @@ public final class FileVisitor: SyntaxVisitor {
 	public private(set) var instantiables = [Instantiable]()
 	public private(set) var configurations = [SafeDIConfiguration]()
 	public private(set) var encounteredUnexpectedNodesSyntax = false
+	public private(set) var unevaluableConditionalCompilationConditions = [UnevaluableConditionalCompilationConditionError]()
 
 	// MARK: Private
 
+	private let conditionalCompilationEvaluator: ConditionalCompilationEvaluator
 	private var parentType: TypeDescription?
+
+	private func appendUnevaluableConditionalCompilationCondition(_ error: UnevaluableConditionalCompilationConditionError) {
+		guard !unevaluableConditionalCompilationConditions.contains(error) else {
+			return
+		}
+		unevaluableConditionalCompilationConditions.append(error)
+	}
 
 	private func visitDecl(_ node: some ConcreteDeclSyntaxProtocol) -> SyntaxVisitorContinueKind {
 		let instantiableVisitor = InstantiableVisitor(
 			declarationType: .concreteDecl,
 			parentType: parentType,
+			activeCompilationConditions: conditionalCompilationEvaluator.activeCompilationConditions,
+			failClosedOnUnevaluableConditionalCompilation: true,
 		)
 		instantiableVisitor.walk(node)
+		for error in instantiableVisitor.unevaluableConditionalCompilationConditions {
+			appendUnevaluableConditionalCompilationCondition(error)
+		}
 		for instantiable in instantiableVisitor.instantiables {
 			instantiables.append(instantiable)
 		}

--- a/Sources/SafeDICore/Visitors/InstantiableVisitor.swift
+++ b/Sources/SafeDICore/Visitors/InstantiableVisitor.swift
@@ -27,9 +27,15 @@ public final class InstantiableVisitor: SyntaxVisitor {
 	public init(
 		declarationType: DeclarationType,
 		parentType: TypeDescription? = nil,
+		activeCompilationConditions: Set<String> = [],
+		failClosedOnUnevaluableConditionalCompilation: Bool = false,
 	) {
 		self.declarationType = declarationType
 		self.parentType = parentType
+		self.failClosedOnUnevaluableConditionalCompilation = failClosedOnUnevaluableConditionalCompilation
+		conditionalCompilationEvaluator = ConditionalCompilationEvaluator(
+			activeCompilationConditions: activeCompilationConditions,
+		)
 		super.init(viewMode: .sourceAccurate)
 	}
 
@@ -134,6 +140,23 @@ public final class InstantiableVisitor: SyntaxVisitor {
 
 	public override func visit(_: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
 		.skipChildren
+	}
+
+	public override func visit(_ node: IfConfigDeclSyntax) -> SyntaxVisitorContinueKind {
+		guard failClosedOnUnevaluableConditionalCompilation else {
+			return .visitChildren
+		}
+		switch conditionalCompilationEvaluator.activeClause(in: node) {
+		case let .active(activeClause):
+			if let elements = activeClause?.elements {
+				walkIfConfigElements(elements)
+			}
+		case let .unevaluable(error):
+			if shouldFailClosed(on: node) {
+				appendUnevaluableConditionalCompilationCondition(error)
+			}
+		}
+		return .skipChildren
 	}
 
 	public override func visit(_: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -447,6 +470,10 @@ public final class InstantiableVisitor: SyntaxVisitor {
 
 	private let declarationType: DeclarationType
 	private let parentType: TypeDescription?
+	private let conditionalCompilationEvaluator: ConditionalCompilationEvaluator
+	private let failClosedOnUnevaluableConditionalCompilation: Bool
+
+	public private(set) var unevaluableConditionalCompilationConditions = [UnevaluableConditionalCompilationConditionError]()
 
 	private func visitDecl(_ node: some ConcreteDeclSyntaxProtocol) -> SyntaxVisitorContinueKind {
 		let nodeDeclarationType: TypeDescription = if let parentType {
@@ -475,6 +502,18 @@ public final class InstantiableVisitor: SyntaxVisitor {
 		processModifiers(node.modifiers, on: node)
 
 		return .visitChildren
+	}
+
+	private func shouldFailClosed(on node: IfConfigDeclSyntax) -> Bool {
+		node.containsSafeDIDeclaration
+			|| node.containsInstantiableBodySyntax(customMockName: customMockName)
+	}
+
+	private func appendUnevaluableConditionalCompilationCondition(_ error: UnevaluableConditionalCompilationConditionError) {
+		guard !unevaluableConditionalCompilationConditions.contains(error) else {
+			return
+		}
+		unevaluableConditionalCompilationConditions.append(error)
 	}
 
 	private func processAttributes(_: AttributeListSyntax, on macro: AttributeSyntax) {

--- a/Sources/SafeDITool/GenerateCommand.swift
+++ b/Sources/SafeDITool/GenerateCommand.swift
@@ -46,6 +46,8 @@ struct Generate: AsyncParsableCommand {
 
 	@Option(parsing: .upToNextOption, help: "Swift file paths scoped to the current target for mock generation. Only used when --output-directory is provided without --swift-manifest.") var mockScopedFiles: [String] = []
 
+	@Option(parsing: .upToNextOption, help: "Active Swift conditional compilation flags to use while scanning SafeDI declarations, matching Swift's -D flags.") var activeCompilationConditions: [String] = []
+
 	@Option(help: "When set, SafeDITool concatenates every generated Swift file (dependency trees + mocks + mock configuration) into this one path — one header, bodies joined in source-file order, deterministic for stable inputs. Intended for build systems that need rule outputs statically declared at analysis time (Bazel, Buck2). Requires 'swift-sources-file-path' or '--include'. Cannot be combined with '--output-directory' or '--swift-manifest' — those are per-file emission modes. May be combined with '--module-info-output'. The combined file is always rewritten on every run, even when content would be unchanged.") var combinedOutput: String?
 
 	@Option(help: "The desired output location of the DOT file expressing the Swift dependency injection tree. Only include this option when running on a project’s root module.") var dotFileOutput: String?
@@ -65,6 +67,8 @@ struct Generate: AsyncParsableCommand {
 			throw ValidationError("--combined-output is mutually exclusive with --output-directory and --swift-manifest. Use --combined-output alone for a single output file, or one of the others for per-file outputs.")
 		}
 
+		let resolvedActiveCompilationConditions = try resolvedActiveCompilationConditions()
+
 		// When --output-directory is provided without --swift-manifest, run an
 		// inline scan to discover roots/mocks and build the manifest automatically.
 		var resolvedSwiftManifest = swiftManifest
@@ -79,13 +83,14 @@ struct Generate: AsyncParsableCommand {
 				outputDirectory: outputDirectory,
 				manifestFile: manifestPath,
 				mockScopedFiles: mockScopedFiles,
+				activeCompilationConditions: resolvedActiveCompilationConditions,
 			)
 			resolvedSwiftManifest = manifestPath
 		}
 
 		let (dependentModuleInfo, parsed) = try await (
 			loadSafeDIModuleInfo(),
-			parsedModule(),
+			parsedModule(activeCompilationConditions: resolvedActiveCompilationConditions),
 		)
 		let initialModule = parsed.module
 		let initialModuleIsFromCache = parsed.isFromCache
@@ -130,7 +135,10 @@ struct Generate: AsyncParsableCommand {
 		   !sourceConfiguration.additionalDirectoriesToInclude.isEmpty
 		{
 			let additionalFiles = try await findSwiftFiles(inDirectories: sourceConfiguration.additionalDirectoriesToInclude)
-			let additionalModule = try await parseSwiftFiles(additionalFiles)
+			let additionalModule = try await parseSwiftFiles(
+				additionalFiles,
+				activeCompilationConditions: resolvedActiveCompilationConditions,
+			)
 			module = ModuleInfo(
 				imports: initialModule.imports + additionalModule.imports,
 				instantiables: initialModule.instantiables + additionalModule.instantiables,
@@ -512,18 +520,42 @@ struct Generate: AsyncParsableCommand {
 	/// cross-version schema drift, etc.) fall through to a fresh parse
 	/// rather than aborting the build — the cache is an optimization
 	/// sidecar, not a correctness requirement.
-	private func parsedModule() async throws -> (module: ModuleInfo, isFromCache: Bool) {
-		if include.isEmpty,
-		   let swiftManifest,
-		   let cached = try await loadCachedModuleInfo(manifestPath: swiftManifest)
-		{
-			(cached, true)
-		} else {
-			try await (parseSwiftFiles(findGenerateSwiftFiles()), false)
+	private func resolvedActiveCompilationConditions() throws -> Set<String> {
+		var conditions = Set(activeCompilationConditions)
+		if let swiftManifest {
+			let manifest = try JSONDecoder().decode(
+				SafeDIToolManifest.self,
+				from: Data(contentsOf: swiftManifest.asFileURL),
+			)
+			conditions.formUnion(manifest.activeCompilationConditions)
 		}
+		return conditions
 	}
 
-	private func loadCachedModuleInfo(manifestPath: String) async throws -> ModuleInfo? {
+	private func parsedModule(activeCompilationConditions: Set<String>) async throws -> (module: ModuleInfo, isFromCache: Bool) {
+		if include.isEmpty, let swiftManifest {
+			let cached = try await loadCachedModuleInfo(
+				manifestPath: swiftManifest,
+				activeCompilationConditions: activeCompilationConditions,
+			)
+			if let cached {
+				return (cached, true)
+			}
+		}
+
+		return try await (
+			parseSwiftFiles(
+				findGenerateSwiftFiles(),
+				activeCompilationConditions: activeCompilationConditions,
+			),
+			false,
+		)
+	}
+
+	private func loadCachedModuleInfo(
+		manifestPath: String,
+		activeCompilationConditions: Set<String>,
+	) async throws -> ModuleInfo? {
 		let cacheURL = scannedModuleInfoURL(forManifestPath: manifestPath)
 		let fileManager = FileManager.default
 		guard let cacheAttributes = try? fileManager.attributesOfItem(atPath: cacheURL.path),
@@ -536,6 +568,10 @@ struct Generate: AsyncParsableCommand {
 		guard let data = try? Data(contentsOf: cacheURL),
 		      let cached = try? JSONDecoder().decode(CachedScannedModuleInfo.self, from: data)
 		else { return nil }
+
+		guard Set(cached.activeCompilationConditions) == activeCompilationConditions else {
+			return nil
+		}
 
 		// Bypass the cache if the current CSV's file set differs from what
 		// scan observed — a custom script could reuse a manifest path with a

--- a/Sources/SafeDITool/ScanCommand.swift
+++ b/Sources/SafeDITool/ScanCommand.swift
@@ -38,6 +38,8 @@ struct Scan: AsyncParsableCommand {
 
 	@Option(parsing: .upToNextOption, help: "Swift file paths scoped to the current target for mock generation. When provided, only these files are scanned for generateMock and #SafeDIConfiguration.") var mockScopedFiles: [String] = []
 
+	@Option(parsing: .upToNextOption, help: "Active Swift conditional compilation flags to use while scanning SafeDI declarations, matching Swift's -D flags.") var activeCompilationConditions: [String] = []
+
 	func run() async throws {
 		try await performScan(
 			inputSourcesFile: inputSourcesFile,
@@ -45,6 +47,7 @@ struct Scan: AsyncParsableCommand {
 			outputDirectory: outputDirectory,
 			manifestFile: manifestFile,
 			mockScopedFiles: mockScopedFiles,
+			activeCompilationConditions: Set(activeCompilationConditions),
 		)
 	}
 }
@@ -59,6 +62,7 @@ func performScan(
 	outputDirectory: String,
 	manifestFile: String,
 	mockScopedFiles: [String] = [],
+	activeCompilationConditions: Set<String> = [],
 ) async throws {
 	let projectRootURL = projectRoot.asFileURL
 	let outputDirectoryURL = outputDirectory.asFileURL
@@ -75,7 +79,10 @@ func performScan(
 
 	// Parse all files once to find roots, mocks, and configurations.
 	let allFilePaths = Set(allSwiftFiles.map(\.relativePath))
-	let allModuleInfo = try await parseSwiftFiles(allFilePaths)
+	let allModuleInfo = try await parseSwiftFiles(
+		allFilePaths,
+		activeCompilationConditions: activeCompilationConditions,
+	)
 
 	// Determine which files are scoped for mock scanning.
 	let mockScopedFilePaths: Set<String> = if mockScopedFiles.isEmpty {
@@ -116,7 +123,10 @@ func performScan(
 		// and trip "multiple types fulfilling" validation downstream.
 		let unparsedAdditionalFiles = additionalFiles.subtracting(allFilePaths)
 		if !unparsedAdditionalFiles.isEmpty {
-			let additionalModuleInfo = try await parseSwiftFiles(unparsedAdditionalFiles)
+			let additionalModuleInfo = try await parseSwiftFiles(
+				unparsedAdditionalFiles,
+				activeCompilationConditions: activeCompilationConditions,
+			)
 			// Merge additional roots/mocks into the combined results.
 			combinedModuleInfo = ModuleInfo(
 				imports: allModuleInfo.imports + additionalModuleInfo.imports,
@@ -210,6 +220,7 @@ func performScan(
 		mockConfigurationOutputFilePath: mockConfigurationOutputFilePath,
 		additionalMocksToGenerate: additionalMocksToGenerate,
 		additionalInputFiles: additionalInputFiles,
+		activeCompilationConditions: activeCompilationConditions.sorted(),
 	)
 
 	let encoder = JSONEncoder()
@@ -269,6 +280,7 @@ func performScan(
 		csvInputPaths: inputFilePaths.sorted(),
 		additionalInputAbsolutePaths: additionalInputFiles.sorted(),
 		additionalDirectories: additionalDirectories,
+		activeCompilationConditions: activeCompilationConditions.sorted(),
 	)
 	let scannedModuleInfoURL = scannedModuleInfoURL(forManifestPath: manifestFile)
 	// Cache write is best-effort. A full disk or other transient FS
@@ -302,6 +314,8 @@ struct CachedScannedModuleInfo: Codable {
 	/// during freshness checks so files added to those directories
 	/// between scan and generate correctly invalidate the cache.
 	let additionalDirectories: [String]
+	/// Active conditional compilation flags used when this cache was created.
+	let activeCompilationConditions: [String]
 }
 
 /// Path alongside the manifest where `scan` persists the parsed

--- a/Sources/SafeDITool/SwiftFileParsing.swift
+++ b/Sources/SafeDITool/SwiftFileParsing.swift
@@ -75,7 +75,10 @@ func findSwiftFiles(inDirectories directories: [String]) async throws -> Set<Str
 }
 
 @available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
-func parseSwiftFiles(_ filePaths: Set<String>) async throws -> ModuleInfo {
+func parseSwiftFiles(
+	_ filePaths: Set<String>,
+	activeCompilationConditions: Set<String> = [],
+) async throws -> ModuleInfo {
 	try await withThrowingTaskGroup(
 		of: (
 			imports: [ImportStatement],
@@ -95,8 +98,11 @@ func parseSwiftFiles(_ filePaths: Set<String>) async throws -> ModuleInfo {
 				let containsInstantiable = content.contains("@\(InstantiableVisitor.macroName)")
 				let containsConfiguration = content.contains("#\(SafeDIConfigurationVisitor.macroName)")
 				guard containsInstantiable || containsConfiguration else { return nil }
-				let fileVisitor = FileVisitor()
+				let fileVisitor = FileVisitor(activeCompilationConditions: activeCompilationConditions)
 				fileVisitor.walk(Parser.parse(source: content))
+				if let error = fileVisitor.unevaluableConditionalCompilationConditions.first {
+					throw error
+				}
 				guard !fileVisitor.instantiables.isEmpty
 					|| !fileVisitor.configurations.isEmpty
 					|| fileVisitor.encounteredUnexpectedNodesSyntax

--- a/Tests/SafeDICoreTests/FileVisitorTests.swift
+++ b/Tests/SafeDICoreTests/FileVisitorTests.swift
@@ -495,6 +495,182 @@ struct FileVisitorTests {
 	}
 
 	@Test
+	func walk_ignoresInactiveIfConfigBranch_whenConditionIsFalse() {
+		let fileVisitor = FileVisitor()
+		fileVisitor.walk(Parser.parse(source: """
+		#if false
+		@Instantiable
+		public struct InactiveService {
+		    public init() {}
+		}
+		#else
+		@Instantiable
+		public struct ActiveService {
+		    public init() {}
+		}
+		#endif
+		"""))
+		#expect(fileVisitor.instantiables == [
+			Instantiable(
+				instantiableType: .simple(name: "ActiveService"),
+				isRoot: false,
+				initializer: Initializer(arguments: []),
+				additionalInstantiables: nil,
+				dependencies: [],
+				declarationType: .structType,
+			),
+		])
+	}
+
+	@Test
+	func walk_visitsActiveIfConfigBranch_whenConditionIsSupplied() {
+		let fileVisitor = FileVisitor(activeCompilationConditions: ["DEBUG"])
+		fileVisitor.walk(Parser.parse(source: """
+		#if DEBUG
+		@Instantiable
+		public struct DebugService {
+		    public init() {}
+		}
+		#else
+		@Instantiable
+		public struct ReleaseService {
+		    public init() {}
+		}
+		#endif
+		"""))
+		#expect(fileVisitor.unevaluableConditionalCompilationConditions.isEmpty)
+		#expect(fileVisitor.instantiables == [
+			Instantiable(
+				instantiableType: .simple(name: "DebugService"),
+				isRoot: false,
+				initializer: Initializer(arguments: []),
+				additionalInstantiables: nil,
+				dependencies: [],
+				declarationType: .structType,
+			),
+		])
+	}
+
+	@Test
+	func walk_visitsElseifBranch_whenEarlierConditionIsFalse() {
+		let fileVisitor = FileVisitor(activeCompilationConditions: ["STAGING"])
+		fileVisitor.walk(Parser.parse(source: """
+		#if false
+		@Instantiable
+		public struct InactiveService {
+		    public init() {}
+		}
+		#elseif STAGING && !false
+		@Instantiable
+		public struct StagingService {
+		    public init() {}
+		}
+		#else
+		@Instantiable
+		public struct FallbackService {
+		    public init() {}
+		}
+		#endif
+		"""))
+		#expect(fileVisitor.unevaluableConditionalCompilationConditions.isEmpty)
+		#expect(fileVisitor.instantiables.map(\.concreteInstantiable) == [
+			.simple(name: "StagingService"),
+		])
+	}
+
+	@Test
+	func walk_evaluatesKnownBooleanOperators_beforeFailingClosed() {
+		let fileVisitor = FileVisitor()
+		fileVisitor.walk(Parser.parse(source: """
+		#if DEBUG && false
+		@Instantiable
+		public struct InactiveService {
+		    public init() {}
+		}
+		#else
+		@Instantiable
+		public struct ActiveService {
+		    public init() {}
+		}
+		#endif
+		"""))
+		#expect(fileVisitor.unevaluableConditionalCompilationConditions.isEmpty)
+		#expect(fileVisitor.instantiables.map(\.concreteInstantiable) == [
+			.simple(name: "ActiveService"),
+		])
+	}
+
+	@Test
+	func walk_ignoresInactiveIfConfigMember_whenConditionIsFalse() {
+		let fileVisitor = FileVisitor()
+		fileVisitor.walk(Parser.parse(source: """
+		@Instantiable
+		public struct SomeService {
+		    public init() {}
+
+		    #if false
+		    @Received let inactiveDependency: InactiveDependency
+		    #endif
+		}
+		"""))
+		#expect(fileVisitor.instantiables == [
+			Instantiable(
+				instantiableType: .simple(name: "SomeService"),
+				isRoot: false,
+				initializer: Initializer(arguments: []),
+				additionalInstantiables: nil,
+				dependencies: [],
+				declarationType: .structType,
+			),
+		])
+	}
+
+	@Test
+	func walk_recordsUnevaluableIfConfigCondition_whenSafeDIDeclarationIsGuardedByUnknownCondition() {
+		let fileVisitor = FileVisitor()
+		fileVisitor.walk(Parser.parse(source: """
+		#if DEBUG
+		@Instantiable
+		public struct DebugService {
+		    public init() {}
+		}
+		#endif
+		"""))
+		#expect(fileVisitor.instantiables.isEmpty)
+		#expect(fileVisitor.unevaluableConditionalCompilationConditions == [
+			UnevaluableConditionalCompilationConditionError(
+				condition: "DEBUG",
+				suggestedActiveCondition: "DEBUG",
+			),
+		])
+	}
+
+	@Test
+	func walk_recordsUnevaluableIfConfigCondition_whenCustomMockIsGuardedByUnknownCondition() {
+		let fileVisitor = FileVisitor()
+		fileVisitor.walk(Parser.parse(source: """
+		@Instantiable(generateMock: true, customMockName: "customMock")
+		public struct SomeService {
+		    public init() {}
+
+		    #if DEBUG
+		    public static func customMock() -> SomeService {
+		        SomeService()
+		    }
+		    #endif
+		}
+		"""))
+		#expect(fileVisitor.instantiables.count == 1)
+		#expect(fileVisitor.instantiables.first?.mockInitializer == nil)
+		#expect(fileVisitor.unevaluableConditionalCompilationConditions == [
+			UnevaluableConditionalCompilationConditionError(
+				condition: "DEBUG",
+				suggestedActiveCondition: "DEBUG",
+			),
+		])
+	}
+
+	@Test
 	func walk_ignoresSafeDIConfigurationInsideType() {
 		let fileVisitor = FileVisitor()
 		fileVisitor.walk(Parser.parse(source: """

--- a/Tests/SafeDIToolTests/Helpers/SafeDIToolTestExecution.swift
+++ b/Tests/SafeDIToolTests/Helpers/SafeDIToolTestExecution.swift
@@ -41,6 +41,7 @@ func executeSafeDIToolTest(
 	buildCombinedOutput: Bool = false,
 	filesToDelete: inout [URL],
 	includeFolders: [String] = [],
+	activeCompilationConditions: [String] = [],
 	skipCompileVerification: Bool = false,
 ) async throws -> TestOutput {
 	// Create additional directory first so its path can be substituted into target file content.
@@ -127,6 +128,7 @@ func executeSafeDIToolTest(
 				outputDirectory: outputDirectory.path,
 				manifestFile: manifestFile.relativePath,
 				mockScopedFiles: swiftFiles.map(\.relativePath),
+				activeCompilationConditions: Set(activeCompilationConditions),
 			)
 			manifestPath = manifestFile.relativePath
 
@@ -139,6 +141,9 @@ func executeSafeDIToolTest(
 		}
 		for module in additionalImportedModules {
 			generateArguments += ["--additional-imported-modules", module]
+		}
+		for condition in activeCompilationConditions {
+			generateArguments += ["--active-compilation-conditions", condition]
 		}
 		generateArguments += ["--module-info-output", moduleInfoOutput.relativePath]
 		if !dependentModuleInfoPaths.isEmpty {

--- a/Tests/SafeDIToolTests/SafeDIToolCodeGenerationErrorTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolCodeGenerationErrorTests.swift
@@ -40,6 +40,31 @@ struct SafeDIToolCodeGenerationErrorTests: ~Copyable {
 
 	@Test
 	@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+	mutating func run_onCodeWithUnknownConditionalCompilationAroundInstantiable_throwsError() async {
+		await assertThrowsError(
+			"""
+			Unable to evaluate conditional compilation condition `DEBUG` while scanning SafeDI declarations. Pass the active condition to SafeDITool with `--active-compilation-conditions DEBUG`, or remove the SafeDI declaration from the conditional branch.
+			""",
+		) {
+			try await executeSafeDIToolTest(
+				swiftFileContent: [
+					"""
+					#if DEBUG
+					@Instantiable(isRoot: true)
+					public struct Root: Instantiable {
+					    public init() {}
+					}
+					#endif
+					""",
+				],
+				buildSwiftOutputDirectory: true,
+				filesToDelete: &filesToDelete,
+			)
+		}
+	}
+
+	@Test
+	@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 	mutating func run_onCodeWithPropertyWithUnknownFulfilledType_throwsError() async {
 		await assertThrowsError(
 			"""

--- a/Tests/SafeDIToolTests/SafeDIToolCodeGenerationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolCodeGenerationTests.swift
@@ -52,6 +52,29 @@ struct SafeDIToolCodeGenerationTests: ~Copyable {
 
 	@Test
 	@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+	mutating func run_usesActiveCompilationConditionToScanGuardedRoot() async throws {
+		let output = try await executeSafeDIToolTest(
+			swiftFileContent: [
+				"""
+				#if DEBUG
+				@Instantiable(isRoot: true)
+				public struct Root: Instantiable {
+				    public init() {}
+				}
+				#endif
+				""",
+			],
+			buildSwiftOutputDirectory: true,
+			filesToDelete: &filesToDelete,
+			activeCompilationConditions: ["DEBUG"],
+		)
+
+		#expect(output.moduleInfo.instantiables.map(\.concreteInstantiable) == [.simple(name: "Root")])
+		#expect(output.generatedFiles?["Root+SafeDI.swift"] != nil)
+	}
+
+	@Test
+	@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 	mutating func run_doesNotWriteExtensionIfRootAlreadyHasEmptyInitializer() async throws {
 		let output = try await executeSafeDIToolTest(
 			swiftFileContent: [

--- a/Tests/SafeDIToolTests/SafeDIToolMockGenerationTests.swift
+++ b/Tests/SafeDIToolTests/SafeDIToolMockGenerationTests.swift
@@ -11821,6 +11821,7 @@ struct SafeDIToolMockGenerationTests: ~Copyable {
 			],
 			buildSwiftOutputDirectory: true,
 			filesToDelete: &filesToDelete,
+			activeCompilationConditions: ["DEBUG"],
 		)
 
 		#expect(output.mockFiles.count == 3)


### PR DESCRIPTION
SafeDITool walks every branch of a SwiftSyntax conditional-compilation while scanning for SafeDI declarations — potentially leaving inactive declarations and members visible to code generation and allowing unknown target-specific conditions to silently affect the dependency graph.

This PR closes the loophole by adding a conditional-compilation evaluator for the scanner. It selects active #if/#elseif/#else clauses, supports boolean literals plus !, &&, ||, and parentheses, and treats custom flags as active only when supplied through the new active-compilation-conditions input.

If an unevaluable condition guards a SafeDI declaration or relevant instantiable member, parsing fails closed with an actionable error.


Disclosure:
- The implementation was AI assisted.
- I haven't opened an issue to discuss this as a feature rather than a bug fix. I hope that's okay, and am more than happy to discuss if that would be useful.

Thanks!